### PR TITLE
Add CI with GitHub Actions and Xcode Cloud support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           xcodebuild build \
             -workspace Stower.xcworkspace \
             -scheme Stower \
-            -destination "platform=macOS" \
+            -destination "generic/platform=macOS" \
             -skipMacroValidation \
             -skipPackagePluginValidation \
             CODE_SIGN_IDENTITY="-" \
@@ -96,10 +96,8 @@ jobs:
           xcodebuild test \
             -workspace Stower.xcworkspace \
             -scheme Stower \
-            -destination "platform=macOS" \
+            -destination "platform=iOS Simulator,name=iPhone 16" \
             -skipMacroValidation \
             -skipPackagePluginValidation \
-            CODE_SIGN_IDENTITY="-" \
-            CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
             -quiet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
     name: Lint
     runs-on: macos-latest
     timeout-minutes: 20
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -75,7 +74,6 @@ jobs:
     name: Test
     runs-on: macos-latest
     timeout-minutes: 20
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -104,5 +102,4 @@ jobs:
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
-            -quiet \
-            || true
+            -quiet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,11 @@ jobs:
 
       - name: Test
         run: |
-          cd StowerPackage && swift test \
+          xcodebuild test \
+            -workspace Stower.xcworkspace \
+            -scheme StowerFeature \
+            -destination "platform=iOS Simulator,name=iPhone 16" \
             -skipMacroValidation \
-            -skipPackagePluginValidation
+            -skipPackagePluginValidation \
+            CODE_SIGNING_ALLOWED=NO \
+            -quiet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,9 @@ jobs:
         run: |
           xcodebuild test \
             -workspace Stower.xcworkspace \
-            -scheme StowerFeature \
+            -scheme Stower \
             -destination "platform=iOS Simulator,name=iPhone 16" \
+            -skip-testing:StowerUITests \
             -skipMacroValidation \
             -skipPackagePluginValidation \
             CODE_SIGNING_ALLOWED=NO \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,108 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: macos-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Lint
+        run: swiftlint lint --config .swiftlint.yml --strict --quiet
+
+  build:
+    name: Build
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Cache SPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: ${{ runner.os }}-spm-
+
+      - name: Build iOS
+        run: |
+          xcodebuild build \
+            -workspace Stower.xcworkspace \
+            -scheme Stower \
+            -destination "generic/platform=iOS" \
+            -skipMacroValidation \
+            -skipPackagePluginValidation \
+            CODE_SIGNING_ALLOWED=NO \
+            -quiet
+
+      - name: Build macOS
+        run: |
+          xcodebuild build \
+            -workspace Stower.xcworkspace \
+            -scheme Stower \
+            -destination "platform=macOS" \
+            -skipMacroValidation \
+            -skipPackagePluginValidation \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            -quiet
+
+  test:
+    name: Test
+    runs-on: macos-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Cache SPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: ${{ runner.os }}-spm-
+
+      - name: Test
+        run: |
+          xcodebuild test \
+            -workspace Stower.xcworkspace \
+            -scheme Stower \
+            -destination "platform=macOS" \
+            -skipMacroValidation \
+            -skipPackagePluginValidation \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            -quiet \
+            || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,11 +93,6 @@ jobs:
 
       - name: Test
         run: |
-          xcodebuild test \
-            -workspace Stower.xcworkspace \
-            -scheme Stower \
-            -destination "platform=iOS Simulator,name=iPhone 16" \
+          cd StowerPackage && swift test \
             -skipMacroValidation \
-            -skipPackagePluginValidation \
-            CODE_SIGNING_ALLOWED=NO \
-            -quiet
+            -skipPackagePluginValidation

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,311 @@
+# SwiftLint Configuration for Stower
+# Security-focused configuration with modern Swift/SwiftUI patterns
+
+# Files and directories to include/exclude
+included:
+  - Stower
+  - StowerPackage/Sources
+  - StowerPackage/Tests
+  - StowerShare
+
+excluded:
+  - .build
+  - .swiftpm
+  - DerivedData
+  - build
+  - Stower.xcodeproj
+  - Config
+  - "*/Generated"
+  - "*/Resources"
+  - "**/*.generated.swift"
+
+# Analyzer rules (require compilation)
+analyzer_rules:
+  - explicit_self
+  - unused_import
+  - unused_declaration
+
+# Opt-in rules (not enabled by default)
+opt_in_rules:
+  - accessibility_label_for_image
+  - array_init
+  - attributes
+  - closure_end_indentation
+  - closure_spacing
+  - collection_alignment
+  - conditional_returns_on_newline
+  - contains_over_filter_count
+  - contains_over_filter_is_empty
+  - contains_over_first_not_nil
+  - contains_over_range_nil_comparison
+  - convenience_type
+  - discouraged_object_literal
+  - empty_collection_literal
+  - empty_count
+  - empty_string
+  - enum_case_associated_values_count
+  - explicit_enum_raw_value
+  - explicit_init
+  - fallthrough
+  - fatal_error_message
+  - file_header
+  - file_name
+  - file_name_no_space
+  - first_where
+  - flatmap_over_map_reduce
+  - function_default_parameter_at_end
+  - identical_operands
+  - implicit_return
+  - joined_default_parameter
+  - last_where
+  - legacy_multiple
+  - literal_expression_end_indentation
+  - lower_acl_than_parent
+  - modifier_order
+  - multiline_arguments
+  - multiline_function_chains
+  - multiline_literal_brackets
+  - multiline_parameters
+  - multiline_parameters_brackets
+  - nimble_operator
+  - no_extension_access_modifier
+  - no_grouping_extension
+  - number_separator
+  - operator_usage_whitespace
+  - optional_enum_case_matching
+  - overridden_super_call
+  - override_in_extension
+  - pattern_matching_keywords
+  - prefer_self_type_over_type_of_self
+  - prefer_zero_over_explicit_init
+  - prefixed_toplevel_constant
+  - private_action
+  - private_outlet
+  - quick_discouraged_call
+  - quick_discouraged_focused_test
+  - quick_discouraged_pending_test
+  - reduce_into
+  - redundant_nil_coalescing
+  - redundant_type_annotation
+  - required_enum_case
+  - single_test_class
+  - sorted_first_last
+  - sorted_imports
+  - static_operator
+  - strict_fileprivate
+  - switch_case_on_newline
+  - toggle_bool
+  - trailing_closure
+  - type_contents_order
+  - unavailable_function
+  - unneeded_parentheses_in_closure_argument
+  - unowned_variable_capture
+  - untyped_error_in_catch
+  - vertical_parameter_alignment_on_call
+  - vertical_whitespace_closing_braces
+  - vertical_whitespace_opening_braces
+  - weak_delegate
+  - xct_specific_matcher
+  - yoda_condition
+
+# Disabled rules
+disabled_rules:
+  - todo
+  - line_length
+  - type_body_length
+  - file_length
+  - force_try
+  - type_contents_order
+  - no_grouping_extension
+  - file_header
+  - type_name
+  - cyclomatic_complexity
+  - function_body_length
+  - force_cast
+  - identifier_name
+  - shorthand_operator
+  - no_extension_access_modifier
+  - empty_count
+
+# Custom rules for security and project-specific patterns
+custom_rules:
+  no_print_statements:
+    name: "No Print Statements"
+    regex: '\bprint\s*\('
+    message: "Use Logger instead of print statements for security and consistency"
+    severity: warning
+    excluded: ".*Tests.*\\.swift$|.*Preview.*\\.swift$"
+
+  no_sensitive_logging:
+    name: "No Sensitive Data Logging"
+    regex: '\b(?:password|token|secret|apiKey|authKey|privateKey|accessKey)\b'
+    message: "Potential sensitive data in logging - review for security implications"
+    severity: warning
+    excluded: ".*Tests.*\\.swift$"
+
+  safe_error_messages:
+    name: "Safe Error Messages"
+    regex: '(?<!Logger\.shared\.)(?:error|Error|message|Message|alert|Alert|text|Text)\s*[=:]\s*"[^"]*\b(?:SQL|query|database|modelContext|CoreData|SwiftData|internal|private key)\b'
+    message: "Error messages should not expose internal implementation details"
+    severity: warning
+    excluded: ".*Tests.*\\.swift$"
+
+  use_navigation_stack:
+    name: "Use NavigationStack"
+    regex: '\bNavigationView\b'
+    message: "Use NavigationStack instead of deprecated NavigationView (iOS 16+)"
+    severity: error
+
+  use_l10n_enum:
+    name: "Use L10n Enum"
+    regex: '\bNSLocalizedString\b'
+    message: "Use L10n enum system instead of NSLocalizedString for consistency"
+    severity: warning
+
+  no_hardcoded_strings:
+    name: "No Hardcoded UI Strings"
+    regex: '(?:Text|Label|Button|Alert)\s*\(\s*"[A-Z][a-zA-Z\s]{20,}"'
+    message: "UI strings should use localization for internationalization"
+    severity: warning
+    excluded: ".*Tests.*\\.swift$|.*Preview.*\\.swift$"
+
+  no_state_object:
+    name: "Use @Observable instead of @StateObject"
+    regex: '@StateObject|@ObservableObject'
+    message: "Use @Observable instead of @StateObject/@ObservableObject (iOS 17+)"
+    severity: error
+
+  require_input_validation:
+    name: "Input Validation Required"
+    regex: '(?:TextField|SecureField).*(?:password|email|phone|credit|ssn|account)'
+    message: "Sensitive input fields should include validation"
+    severity: warning
+    excluded: ".*Tests.*\\.swift$|.*Preview.*\\.swift$"
+
+  no_expect_false_pattern:
+    name: "No expect(false) Pattern"
+    regex: '#expect\\(\\s*false\\s*[,)]'
+    message: "Use Issue.record() instead of #expect(false) to avoid compiler warnings"
+    severity: error
+
+  no_unused_test_variables:
+    name: "No Unused Test Variables"
+    regex: '(?:let|var)\s+\w+\s*=\s*(?:true|false|\"\w+\")\s*\n(?:[^=\n]*\n)*\s*(?:let|var|\#expect|\})'
+    message: "Unused variable detected - remove or use with '_ = variableName' if intentionally unused"
+    severity: warning
+    included: ".*Tests.*\\.swift$"
+
+  prefer_let_over_var:
+    name: "Prefer let over var when not mutated"
+    regex: 'var\s+(\w+)\s*:\s*\[.*?\]\s*=\s*\[(?:[^\]]*\n)*[^\]]*\](?!\s*\.\w+\s*=)(?!\s*\[)'
+    message: "Use 'let' instead of 'var' for immutable collections"
+    severity: warning
+
+# Rule configurations
+accessibility_label_for_image:
+  severity: warning
+
+array_init:
+  severity: warning
+
+attributes:
+  always_on_same_line:
+    - "@IBAction"
+    - "@NSManaged"
+    - "@objc"
+
+closure_end_indentation:
+  severity: warning
+
+closure_spacing:
+  severity: warning
+
+collection_alignment:
+  align_colons: true
+
+conditional_returns_on_newline:
+  if_only: true
+
+contains_over_filter_count:
+  severity: error
+
+contains_over_filter_is_empty:
+  severity: error
+
+empty_string:
+  severity: warning
+
+enum_case_associated_values_count:
+  warning: 6
+  error: 8
+
+explicit_enum_raw_value:
+  severity: warning
+
+file_name:
+  severity: warning
+  excluded:
+    - "Generated"
+
+file_name_no_space:
+  severity: error
+
+function_parameter_count:
+  warning: 6
+  error: 8
+
+large_tuple:
+  warning: 3
+  error: 4
+
+modifier_order:
+  preferred_modifier_order:
+    - "override"
+    - "acl"
+    - "setterACL"
+    - "dynamic"
+    - "mutating"
+    - "lazy"
+    - "final"
+    - "required"
+    - "convenience"
+
+multiline_arguments:
+  first_argument_location: next_line
+  only_enforce_after_first_closure_on_first_line: true
+
+multiline_parameters:
+  allows_single_line: true
+
+nesting:
+  type_level:
+    warning: 2
+    error: 3
+
+number_separator:
+  minimum_length: 5
+  minimum_fraction_length: 5
+
+private_outlet:
+  allow_private_set: true
+
+reduce_into:
+  severity: error
+
+redundant_nil_coalescing:
+  severity: error
+
+sorted_imports:
+  severity: warning
+
+trailing_comma:
+  mandatory_comma: true
+
+trailing_whitespace:
+  ignores_empty_lines: false
+  ignores_comments: true
+
+vertical_whitespace:
+  max_empty_lines: 2
+
+warning_threshold: 2500

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -49,7 +49,6 @@ opt_in_rules:
   - fallthrough
   - fatal_error_message
   - file_header
-  - file_name
   - file_name_no_space
   - first_where
   - flatmap_over_map_reduce
@@ -126,6 +125,8 @@ disabled_rules:
   - shorthand_operator
   - no_extension_access_modifier
   - empty_count
+  - redundant_string_enum_value
+  - file_name
 
 # Custom rules for security and project-specific patterns
 custom_rules:
@@ -242,11 +243,6 @@ enum_case_associated_values_count:
 explicit_enum_raw_value:
   severity: warning
 
-file_name:
-  severity: warning
-  excluded:
-    - "Generated"
-
 file_name_no_space:
   severity: error
 
@@ -257,18 +253,6 @@ function_parameter_count:
 large_tuple:
   warning: 3
   error: 4
-
-modifier_order:
-  preferred_modifier_order:
-    - "override"
-    - "acl"
-    - "setterACL"
-    - "dynamic"
-    - "mutating"
-    - "lazy"
-    - "final"
-    - "required"
-    - "convenience"
 
 multiline_arguments:
   first_argument_location: next_line

--- a/Config/Tests.xcconfig
+++ b/Config/Tests.xcconfig
@@ -13,8 +13,8 @@ MACOSX_DEPLOYMENT_TARGET = 26.0
 // ==========================================
 // Test Target Identity
 // ==========================================
+PRODUCT_NAME = StowerUITests
 PRODUCT_BUNDLE_IDENTIFIER = com.ryanleewilliams.stower.uitests
-PRODUCT_MODULE_NAME = $(PRODUCT_NAME)UITests
 
 // ==========================================
 // Code Coverage

--- a/Stower.xcodeproj/project.pbxproj
+++ b/Stower.xcodeproj/project.pbxproj
@@ -561,8 +561,8 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown portrait";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown landscape-left landscape-right portrait portrait-upside-down";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -612,8 +612,8 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown portrait";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown landscape-left landscape-right portrait portrait-upside-down";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Stower.xcodeproj/xcshareddata/xcschemes/Stower.xcscheme
+++ b/Stower.xcodeproj/xcshareddata/xcschemes/Stower.xcscheme
@@ -43,7 +43,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8B41F65B2DEDD0D6001A66F9"
-               BuildableName = "Stower.xctest"
+               BuildableName = "StowerUITests.xctest"
                BlueprintName = "StowerUITests"
                ReferencedContainer = "container:Stower.xcodeproj">
             </BuildableReference>

--- a/Stower/StowerApp.swift
+++ b/Stower/StowerApp.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import StowerFeature
+import SwiftUI
 
 @main
 struct StowerApp: App {

--- a/StowerPackage/Sources/StowerData/Data/Bootstrap+CloudSync.swift
+++ b/StowerPackage/Sources/StowerData/Data/Bootstrap+CloudSync.swift
@@ -5,6 +5,7 @@ import SQLiteData
 import CloudKit
 #endif
 
+// swiftlint:disable:next prefixed_toplevel_constant
 private let cloudSyncLogger = Logger(subsystem: "com.ryanleewilliams.stower", category: "CloudSync")
 
 extension StowerDatabase {
@@ -19,7 +20,7 @@ extension StowerDatabase {
         continuation.yield(.starting)
 
         do {
-            let delegate = syncEngineDelegate ?? StowerSyncEngineDelegate(emit: { continuation.yield($0) })
+            let delegate = syncEngineDelegate ?? StowerSyncEngineDelegate { continuation.yield($0) }
             let syncEngine: SyncEngine = try SyncEngine(
                 for: database,
                 tables: SavedItemSyncTable.self,

--- a/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
+++ b/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
@@ -1,5 +1,5 @@
-import Foundation
 import Dependencies
+import Foundation
 import SQLiteData
 
 // MARK: - Diagnostics Types
@@ -8,7 +8,7 @@ public struct SyncDiagnostics: Equatable, Sendable {
     public var syncedItemsCount: Int
     public var pendingChangesCount: Int
     public var metadataCount: Int
-    public var sampleItems: [SyncItemSummary]
+    public let sampleItems: [SyncItemSummary]
 
     public init(
         syncedItemsCount: Int,
@@ -42,9 +42,9 @@ public struct SyncDiagnosticsClient: Sendable {
         self.load = load
     }
 
-    public static let noop = Self(load: {
+    public static let noop = Self {
         .init(syncedItemsCount: 0, pendingChangesCount: 0, metadataCount: 0, sampleItems: [])
-    })
+    }
 }
 
 // MARK: - CloudSync Client Type
@@ -114,13 +114,16 @@ public enum StowerDatabase {
                 try db.attachMetadatabase(containerIdentifier: cloudKitContainerID)
             } catch {
                 #if DEBUG
+                // swiftlint:disable:next no_print_statements
                 print("⚠️ SQLiteData metadatabase unavailable: \(error)")
                 #endif
             }
         }
 
         #if DEBUG
+        // swiftlint:disable:next no_print_statements
         print("🔧 Bootstrap: appGroupID = \(appGroupID)")
+        // swiftlint:disable:next no_print_statements
         print("🔧 Bootstrap: cloudKitContainerID = \(cloudKitContainerID)")
         #endif
 
@@ -128,7 +131,8 @@ public enum StowerDatabase {
         // extension and the main app can both read and write the same file.
         // In .preview / .test, SQLiteData ignores `path` and uses a tempfile.
         let resolvedPath: String?
-        @Dependency(\.context) var context
+        @Dependency(\.context)
+        var context
         if context == .live {
             let url = try resolveAppGroupDatabaseURL()
             try migrateLegacySandboxDatabaseIfNeeded(to: url)
@@ -182,6 +186,7 @@ public enum StowerDatabase {
         }
 
         #if DEBUG
+        // swiftlint:disable:next no_print_statements
         print("ℹ️ Migrated legacy Stower database from \(legacyURL.path) to \(destination.path)")
         #endif
     }
@@ -201,15 +206,33 @@ public enum StowerDatabase {
     private static func migrate(database: any DatabaseWriter) throws {
         var migrator = DatabaseMigrator()
         migrator.eraseDatabaseOnSchemaChange = false
-        migrator.registerMigration("create-stower-v2-reader") { db in try migration_v1(db) }
-        migrator.registerMigration("cloudkit-split-sync-v1") { db in try migration_v2(db) }
-        migrator.registerMigration("add-source-html-to-content") { db in try migration_v3(db) }
-        migrator.registerMigration("add-last-read-block-index") { db in try migration_v4(db) }
-        migrator.registerMigration("add-isread-isstarred-softdelete-and-tags") { db in try migration_v5(db) }
-        migrator.registerMigration("drop-unique-indexes-from-sync-tables") { db in try migration_v6(db) }
-        migrator.registerMigration("add-ai-summary-columns") { db in try migration_v7(db) }
-        migrator.registerMigration("add-pdf-support") { db in try migration_v8(db) }
-        migrator.registerMigration("flexoki-background-accents") { db in try migration_v9(db) }
+        migrator.registerMigration("create-stower-v2-reader") { db in
+            try migration_v1(db)
+        }
+        migrator.registerMigration("cloudkit-split-sync-v1") { db in
+            try migration_v2(db)
+        }
+        migrator.registerMigration("add-source-html-to-content") { db in
+            try migration_v3(db)
+        }
+        migrator.registerMigration("add-last-read-block-index") { db in
+            try migration_v4(db)
+        }
+        migrator.registerMigration("add-isread-isstarred-softdelete-and-tags") { db in
+            try migration_v5(db)
+        }
+        migrator.registerMigration("drop-unique-indexes-from-sync-tables") { db in
+            try migration_v6(db)
+        }
+        migrator.registerMigration("add-ai-summary-columns") { db in
+            try migration_v7(db)
+        }
+        migrator.registerMigration("add-pdf-support") { db in
+            try migration_v8(db)
+        }
+        migrator.registerMigration("flexoki-background-accents") { db in
+            try migration_v9(db)
+        }
         try migrator.migrate(database)
     }
 

--- a/StowerPackage/Sources/StowerData/Data/ReaderDocumentCache.swift
+++ b/StowerPackage/Sources/StowerData/Data/ReaderDocumentCache.swift
@@ -8,8 +8,8 @@ import Foundation
 /// usage stays predictable for users who read many articles in one session.
 final class ReaderDocumentCache: @unchecked Sendable {
     private let lock = NSLock()
-    private var storage: [UUID: ReaderDocument] = [:]
-    private var accessOrder: [UUID] = []
+    private var storage: [UUID: ReaderDocument] = [:] // swiftlint:disable:this prefer_let_over_var
+    private var accessOrder: [UUID] = [] // swiftlint:disable:this prefer_let_over_var
     private let capacity: Int
 
     init(capacity: Int = 16) {

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Documents.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Documents.swift
@@ -3,84 +3,94 @@ import SQLiteData
 
 extension StowerRepository {
     static func _saveReaderDocument(database: any DatabaseWriter) -> @Sendable (UUID, ReaderDocument, String) async throws -> Void {
-        { (id: UUID, document: ReaderDocument, plainText: String) async throws -> Void in
-            let now: Date = Date.now
-            let json: String = try String(decoding: JSONEncoder().encode(document), as: UTF8.self)
-            let hash: String = sha256Hex(plainText)
-            try await database.write { db -> Void in
+        { (id: UUID, document: ReaderDocument, plainText: String) async throws in
+            let now = Date.now
+            let json = try String(bytes: JSONEncoder().encode(document), encoding: .utf8) ?? ""
+            let hash = sha256Hex(plainText)
+            try await database.write { db in
                 guard try SavedItemSyncTable.find(id).fetchOne(db) != nil else { return }
                 if try SavedItemContentLocalTable.find(id).fetchOne(db) != nil {
-                    try SavedItemContentLocalTable.find(id).update {
-                        $0.documentJSON = json
-                        $0.plainText = plainText
-                        $0.sourceHTMLHash = hash
-                        $0.localStatus = "available"
-                        $0.localError = #bind(nil as String?)
-                        $0.updatedAt = now
-                    }.execute(db)
+                    try SavedItemContentLocalTable
+                        .find(id)
+                        .update {
+                            $0.documentJSON = json
+                            $0.plainText = plainText
+                            $0.sourceHTMLHash = hash
+                            $0.localStatus = "available"
+                            $0.localError = #bind(nil as String?)
+                            $0.updatedAt = now
+                        }
+                        .execute(db)
                 } else {
-                    try SavedItemContentLocalTable.insert {
-                        SavedItemContentLocalTable.Draft(
-                            itemID: id,
-                            renderFormat: document.sourceURL == nil ? "plainText" : "structuredV1",
-                            documentVersion: document.version,
-                            plainText: plainText,
-                            documentJSON: json,
-                            sourceHTMLHash: hash,
-                            sourceHTML: "",
-                            localStatus: "available",
-                            localError: nil,
-                            createdAt: now,
-                            updatedAt: now
-                        )
-                    }.execute(db)
+                    try SavedItemContentLocalTable
+                        .insert {
+                            SavedItemContentLocalTable.Draft(
+                                itemID: id,
+                                renderFormat: document.sourceURL == nil ? "plainText" : "structuredV1",
+                                documentVersion: document.version,
+                                plainText: plainText,
+                                documentJSON: json,
+                                sourceHTMLHash: hash,
+                                sourceHTML: "",
+                                localStatus: "available",
+                                localError: nil,
+                                createdAt: now,
+                                updatedAt: now
+                            )
+                        }
+                        .execute(db)
                 }
             }
         }
     }
 
     static func _saveSummary(database: any DatabaseWriter) -> @Sendable (UUID, String) async throws -> Void {
-        { (id: UUID, text: String) async throws -> Void in
-            let now: Date = Date.now
-            try await database.write { db -> Void in
+        { (id: UUID, text: String) async throws in
+            let now = Date.now
+            try await database.write { db in
                 // The content row is created during ingestion; if it's missing
                 // we silently drop the write rather than synthesizing a half-
                 // populated row. A missing row means the item itself isn't
                 // persisted, which is an upstream bug the summary cache can't fix.
                 guard try SavedItemContentLocalTable.find(id).fetchOne(db) != nil else { return }
-                try SavedItemContentLocalTable.find(id).update {
-                    $0.summary = #bind(text)
-                    $0.summaryGeneratedAt = #bind(now)
-                    $0.updatedAt = now
-                }.execute(db)
+                try SavedItemContentLocalTable
+                    .find(id)
+                    .update {
+                        $0.summary = #bind(text)
+                        $0.summaryGeneratedAt = #bind(now)
+                        $0.updatedAt = now
+                    }
+                    .execute(db)
             }
         }
     }
 
     static func _upsertMedia(database: any DatabaseWriter) -> @Sendable ([MediaDescriptor], UUID) async throws -> Void {
-        { (media: [MediaDescriptor], itemID: UUID) async throws -> Void in
-            let now: Date = Date.now
-            try await database.write { db -> Void in
+        { (media: [MediaDescriptor], itemID: UUID) async throws in
+            let now = Date.now
+            try await database.write { db in
                 try SavedMediaLocalTable.where { $0.itemID.eq(itemID) }.delete().execute(db)
                 for descriptor in media {
-                    try SavedMediaLocalTable.insert {
-                        SavedMediaLocalTable.Draft(
-                            id: UUID(),
-                            itemID: itemID,
-                            kind: descriptor.kind.rawValue,
-                            sourceURL: descriptor.sourceURL,
-                            localURL: descriptor.localURL,
-                            mimeType: descriptor.mimeType,
-                            width: descriptor.width,
-                            height: descriptor.height,
-                            durationSeconds: descriptor.durationSeconds,
-                            posterURL: descriptor.posterURL,
-                            caption: descriptor.caption,
-                            status: "ready",
-                            createdAt: now,
-                            updatedAt: now
-                        )
-                    }.execute(db)
+                    try SavedMediaLocalTable
+                        .insert {
+                            SavedMediaLocalTable.Draft(
+                                id: UUID(),
+                                itemID: itemID,
+                                kind: descriptor.kind.rawValue,
+                                sourceURL: descriptor.sourceURL,
+                                localURL: descriptor.localURL,
+                                mimeType: descriptor.mimeType,
+                                width: descriptor.width,
+                                height: descriptor.height,
+                                durationSeconds: descriptor.durationSeconds,
+                                posterURL: descriptor.posterURL,
+                                caption: descriptor.caption,
+                                status: "ready",
+                                createdAt: now,
+                                updatedAt: now
+                            )
+                        }
+                        .execute(db)
                 }
             }
         }

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Filters.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Filters.swift
@@ -4,7 +4,6 @@ import SQLiteData
 // MARK: - Filter-aware reads + list-bucket mutations
 
 extension StowerRepository {
-
     // MARK: Filtered fetch
 
     static func _fetchLibraryFiltered(
@@ -83,7 +82,7 @@ extension StowerRepository {
                 let junctions: [ItemTagSyncTable] = ids.isEmpty
                     ? []
                     : try ItemTagSyncTable.where { $0.itemID.in(ids) }.fetchAll(db)
-                var tagIDsByItem: [UUID: [UUID]] = [:]
+                var tagIDsByItem: [UUID: [UUID]] = [:] // swiftlint:disable:this prefer_let_over_var
                 for row in junctions {
                     tagIDsByItem[row.itemID, default: []].append(row.tagID)
                 }
@@ -91,7 +90,9 @@ extension StowerRepository {
                 var seen = Set<String>()
                 return synced.compactMap { row -> SavedItem? in
                     if let key = normalizedURLKey(row.canonicalURL ?? row.sourceURL) {
-                        if seen.contains(key) { return nil }
+                        if seen.contains(key) {
+                            return nil
+                        }
                         seen.insert(key)
                     }
                     return toDomain(
@@ -110,13 +111,16 @@ extension StowerRepository {
         database: any DatabaseWriter,
         scheduleSync: @escaping @Sendable () -> Void
     ) -> @Sendable (UUID, Bool) async throws -> Void {
-        { (id: UUID, isRead: Bool) async throws -> Void in
+        { (id: UUID, isRead: Bool) async throws in
             let now = Date.now
-            try await database.write { db -> Void in
-                try SavedItemSyncTable.find(id).update {
-                    $0.isRead = #bind(isRead)
-                    $0.updatedAt = #bind(now)
-                }.execute(db)
+            try await database.write { db in
+                try SavedItemSyncTable
+                    .find(id)
+                    .update {
+                        $0.isRead = #bind(isRead)
+                        $0.updatedAt = #bind(now)
+                    }
+                    .execute(db)
             }
             scheduleSync()
         }
@@ -126,13 +130,16 @@ extension StowerRepository {
         database: any DatabaseWriter,
         scheduleSync: @escaping @Sendable () -> Void
     ) -> @Sendable (UUID, Bool) async throws -> Void {
-        { (id: UUID, isStarred: Bool) async throws -> Void in
+        { (id: UUID, isStarred: Bool) async throws in
             let now = Date.now
-            try await database.write { db -> Void in
-                try SavedItemSyncTable.find(id).update {
-                    $0.isStarred = #bind(isStarred)
-                    $0.updatedAt = #bind(now)
-                }.execute(db)
+            try await database.write { db in
+                try SavedItemSyncTable
+                    .find(id)
+                    .update {
+                        $0.isStarred = #bind(isStarred)
+                        $0.updatedAt = #bind(now)
+                    }
+                    .execute(db)
             }
             scheduleSync()
         }
@@ -142,13 +149,16 @@ extension StowerRepository {
         database: any DatabaseWriter,
         scheduleSync: @escaping @Sendable () -> Void
     ) -> @Sendable (UUID) async throws -> Void {
-        { (id: UUID) async throws -> Void in
+        { (id: UUID) async throws in
             let now = Date.now
-            try await database.write { db -> Void in
-                try SavedItemSyncTable.find(id).update {
-                    $0.deletedAt = #bind(Date?.some(now))
-                    $0.updatedAt = #bind(now)
-                }.execute(db)
+            try await database.write { db in
+                try SavedItemSyncTable
+                    .find(id)
+                    .update {
+                        $0.deletedAt = #bind(Date?.some(now))
+                        $0.updatedAt = #bind(now)
+                    }
+                    .execute(db)
             }
             scheduleSync()
         }
@@ -158,13 +168,16 @@ extension StowerRepository {
         database: any DatabaseWriter,
         scheduleSync: @escaping @Sendable () -> Void
     ) -> @Sendable (UUID) async throws -> Void {
-        { (id: UUID) async throws -> Void in
+        { (id: UUID) async throws in
             let now = Date.now
-            try await database.write { db -> Void in
-                try SavedItemSyncTable.find(id).update {
-                    $0.deletedAt = #bind(nil)
-                    $0.updatedAt = #bind(now)
-                }.execute(db)
+            try await database.write { db in
+                try SavedItemSyncTable
+                    .find(id)
+                    .update {
+                        $0.deletedAt = #bind(nil)
+                        $0.updatedAt = #bind(now)
+                    }
+                    .execute(db)
             }
             scheduleSync()
         }
@@ -174,8 +187,8 @@ extension StowerRepository {
         database: any DatabaseWriter,
         scheduleSync: @escaping @Sendable () -> Void
     ) -> @Sendable (UUID) async throws -> Void {
-        { (id: UUID) async throws -> Void in
-            try await database.write { db -> Void in
+        { (id: UUID) async throws in
+            try await database.write { db in
                 try ItemTagSyncTable.where { $0.itemID.eq(id) }.delete().execute(db)
                 try SavedItemSyncTable.find(id).delete().execute(db)
             }
@@ -249,7 +262,7 @@ extension StowerRepository {
                     .fetchAll(db)
                     .map(\.id)
                 let liveIDSet = Set(liveIDs)
-                var byTag: [UUID: Int] = [:]
+                var byTag: [UUID: Int] = [:] // swiftlint:disable:this prefer_let_over_var
                 for row in taggedRows where liveIDSet.contains(row.itemID) {
                     byTag[row.tagID, default: 0] += 1
                 }

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Helpers.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Helpers.swift
@@ -76,10 +76,14 @@ extension StowerRepository {
 
     static func processingState(from local: SavedItemContentLocalTable?) -> ProcessingState {
         switch local?.localStatus {
-        case "available": return .ready
-        case "downloading": return .extracting
-        case "failed": return .failed
-        default: return .queued
+        case "available":
+            return .ready
+        case "downloading":
+            return .extracting
+        case "failed":
+            return .failed
+        default:
+            return .queued
         }
     }
 
@@ -109,56 +113,63 @@ extension StowerRepository {
         now: Date,
         updateLocalStatus: String
     ) throws {
-        let documentJSON: String = try String(decoding: JSONEncoder().encode(result.document), as: UTF8.self)
-        let hash: String = sha256Hex(result.plainText)
+        let documentJSON = try String(bytes: JSONEncoder().encode(result.document), encoding: .utf8) ?? ""
+        let hash = sha256Hex(result.plainText)
 
         if try SavedItemContentLocalTable.find(itemID).fetchOne(db) != nil {
-            try SavedItemContentLocalTable.find(itemID).update {
-                $0.renderFormat = result.renderFormat.rawValue
-                $0.documentVersion = result.document.version
-                $0.plainText = result.plainText
-                $0.documentJSON = documentJSON
-                $0.sourceHTMLHash = hash
-                $0.sourceHTML = result.sourceHTML
-                $0.localStatus = updateLocalStatus
-                $0.localError = #bind(result.processingError)
-                $0.updatedAt = now
-                if let pdfHash = result.pdfSHA256 {
-                    $0.pdfSHA256 = #bind(pdfHash)
+            try SavedItemContentLocalTable
+                .find(itemID)
+                .update {
+                    $0.renderFormat = result.renderFormat.rawValue
+                    $0.documentVersion = result.document.version
+                    $0.plainText = result.plainText
+                    $0.documentJSON = documentJSON
+                    $0.sourceHTMLHash = hash
+                    $0.sourceHTML = result.sourceHTML
+                    $0.localStatus = updateLocalStatus
+                    $0.localError = #bind(result.processingError)
+                    $0.updatedAt = now
+                    if let pdfHash = result.pdfSHA256 {
+                        $0.pdfSHA256 = #bind(pdfHash)
+                    }
                 }
-            }.execute(db)
+                .execute(db)
         } else {
-            try SavedItemContentLocalTable.insert {
-                SavedItemContentLocalTable.Draft(
-                    itemID: itemID,
-                    renderFormat: result.renderFormat.rawValue,
-                    documentVersion: result.document.version,
-                    plainText: result.plainText,
-                    documentJSON: documentJSON,
-                    sourceHTMLHash: hash,
-                    sourceHTML: result.sourceHTML,
-                    localStatus: updateLocalStatus,
-                    localError: result.processingError,
-                    createdAt: now,
-                    updatedAt: now,
-                    pdfSHA256: result.pdfSHA256
-                )
-            }.execute(db)
+            try SavedItemContentLocalTable
+                .insert {
+                    SavedItemContentLocalTable.Draft(
+                        itemID: itemID,
+                        renderFormat: result.renderFormat.rawValue,
+                        documentVersion: result.document.version,
+                        plainText: result.plainText,
+                        documentJSON: documentJSON,
+                        sourceHTMLHash: hash,
+                        sourceHTML: result.sourceHTML,
+                        localStatus: updateLocalStatus,
+                        localError: result.processingError,
+                        createdAt: now,
+                        updatedAt: now,
+                        pdfSHA256: result.pdfSHA256
+                    )
+                }
+                .execute(db)
         }
 
         // For PDF items, also mirror the extracted document into the
         // CloudKit-synced table so the second device can render the structured
         // text view without having the PDF bytes (which never sync).
         if result.renderFormat == .pdf {
-            try SavedPDFContentSyncTable.upsert {
-                SavedPDFContentSyncTable.Draft(
-                    id: itemID,
-                    documentJSON: documentJSON,
-                    plainText: result.plainText,
-                    createdAt: now,
-                    updatedAt: now
-                )
-            }.execute(db)
+            try SavedPDFContentSyncTable
+                .upsert {
+                    SavedPDFContentSyncTable.Draft(
+                        id: itemID,
+                        documentJSON: documentJSON,
+                        plainText: result.plainText,
+                        createdAt: now,
+                        updatedAt: now
+                    )
+                }
+                .execute(db)
         }
 
         // Media and embed rows have a UNIQUE constraint on (itemID, sourceURL)
@@ -170,39 +181,43 @@ extension StowerRepository {
         try SavedEmbedLocalTable.where { $0.itemID.eq(itemID) }.delete().execute(db)
 
         for descriptor in result.media {
-            try SavedMediaLocalTable.insert {
-                SavedMediaLocalTable.Draft(
-                    id: UUID(),
-                    itemID: itemID,
-                    kind: descriptor.kind.rawValue,
-                    sourceURL: descriptor.sourceURL,
-                    localURL: descriptor.localURL,
-                    mimeType: descriptor.mimeType,
-                    width: descriptor.width,
-                    height: descriptor.height,
-                    durationSeconds: descriptor.durationSeconds,
-                    posterURL: descriptor.posterURL,
-                    caption: descriptor.caption,
-                    status: "ready",
-                    createdAt: now,
-                    updatedAt: now
-                )
-            }.execute(db)
+            try SavedMediaLocalTable
+                .insert {
+                    SavedMediaLocalTable.Draft(
+                        id: UUID(),
+                        itemID: itemID,
+                        kind: descriptor.kind.rawValue,
+                        sourceURL: descriptor.sourceURL,
+                        localURL: descriptor.localURL,
+                        mimeType: descriptor.mimeType,
+                        width: descriptor.width,
+                        height: descriptor.height,
+                        durationSeconds: descriptor.durationSeconds,
+                        posterURL: descriptor.posterURL,
+                        caption: descriptor.caption,
+                        status: "ready",
+                        createdAt: now,
+                        updatedAt: now
+                    )
+                }
+                .execute(db)
         }
 
         for embed in result.embeds {
-            try SavedEmbedLocalTable.insert {
-                SavedEmbedLocalTable.Draft(
-                    id: UUID(),
-                    itemID: itemID,
-                    provider: embed.provider,
-                    embedURL: embed.embedURL,
-                    htmlSnippet: embed.htmlSnippet,
-                    status: "ready",
-                    createdAt: now,
-                    updatedAt: now
-                )
-            }.execute(db)
+            try SavedEmbedLocalTable
+                .insert {
+                    SavedEmbedLocalTable.Draft(
+                        id: UUID(),
+                        itemID: itemID,
+                        provider: embed.provider,
+                        embedURL: embed.embedURL,
+                        htmlSnippet: embed.htmlSnippet,
+                        status: "ready",
+                        createdAt: now,
+                        updatedAt: now
+                    )
+                }
+                .execute(db)
         }
     }
 }
@@ -224,7 +239,7 @@ extension StowerRepository {
         guard let key = normalizedURLKey(urlString) else { return UUID() }
         let digest = SHA256.hash(data: Data(key.utf8))
         let bytes = Array(digest)
-        var b = bytes[0..<16].map { $0 }
+        var b = Array(bytes[0..<16])
         b[6] = (b[6] & 0x0F) | 0x50
         b[8] = (b[8] & 0x3F) | 0x80
         var uuidBytes: uuid_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Ingestion.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Ingestion.swift
@@ -10,10 +10,14 @@ extension StowerRepository {
     /// the reader on a blank screen for anything that couldn't be extracted.
     private static func localStatus(for state: ProcessingState) -> String {
         switch state {
-        case .ready, .partial: return "available"
-        case .failed: return "failed"
-        case .extracting: return "downloading"
-        case .queued: return "notDownloaded"
+        case .ready, .partial:
+            return "available"
+        case .failed:
+            return "failed"
+        case .extracting:
+            return "downloading"
+        case .queued:
+            return "notDownloaded"
         }
     }
 
@@ -23,9 +27,9 @@ extension StowerRepository {
     ) -> @Sendable (IngestionResult) async throws -> SavedItem {
         { (result: IngestionResult) async throws -> SavedItem in
             let item: SavedItem = try await database.write { db -> SavedItem in
-                let now: Date = Date.now
-                let itemID: UUID = stableItemID(from: result.canonicalURL ?? result.sourceURL)
-                let syncDraft: SavedItemSyncTable.Draft = makeSyncDraft(id: itemID, result: result, now: now)
+                let now = Date.now
+                let itemID = stableItemID(from: result.canonicalURL ?? result.sourceURL)
+                let syncDraft = makeSyncDraft(id: itemID, result: result, now: now)
                 try SavedItemSyncTable.upsert { syncDraft }.execute(db)
                 try persistLocalContentAndCaches(db: db, itemID: itemID, result: result, now: now, updateLocalStatus: localStatus(for: result.processingState))
                 // Read back the just-written local row so the returned
@@ -46,8 +50,8 @@ extension StowerRepository {
         scheduleSync: @escaping @Sendable () -> Void
     ) -> @Sendable (UUID, IngestionResult) async throws -> SavedItem? {
         { (id: UUID, result: IngestionResult) async throws -> SavedItem? in
-            let now: Date = Date.now
-            try await database.write { db -> Void in
+            let now = Date.now
+            try await database.write { db in
                 guard try SavedItemSyncTable.find(id).fetchOne(db) != nil else { return }
                 try db.execute(
                     sql: """
@@ -61,7 +65,7 @@ extension StowerRepository {
                         result.title, result.sourceURL, result.canonicalURL, result.excerpt,
                         result.heroImageURL, result.author, result.publishedAt?.timeIntervalSince1970,
                         result.siteName, result.readingTimeMinutes, result.hasRichMedia ? 1 : 0,
-                        now.timeIntervalSince1970, id.uuidString
+                        now.timeIntervalSince1970, id.uuidString,
                     ]
                 )
                 try persistLocalContentAndCaches(db: db, itemID: id, result: result, now: now, updateLocalStatus: localStatus(for: result.processingState))
@@ -76,9 +80,9 @@ extension StowerRepository {
     }
 
     static func _hydrateItemContent(database: any DatabaseWriter) -> @Sendable (UUID, IngestionResult) async throws -> Void {
-        { (id: UUID, result: IngestionResult) async throws -> Void in
-            let now: Date = Date.now
-            try await database.write { db -> Void in
+        { (id: UUID, result: IngestionResult) async throws in
+            let now = Date.now
+            try await database.write { db in
                 guard try SavedItemSyncTable.find(id).fetchOne(db) != nil else { return }
                 try persistLocalContentAndCaches(db: db, itemID: id, result: result, now: now, updateLocalStatus: localStatus(for: result.processingState))
             }
@@ -86,15 +90,18 @@ extension StowerRepository {
     }
 
     static func _updateLocalContentStatus(database: any DatabaseWriter) -> @Sendable (UUID, String, String?) async throws -> Void {
-        { (id: UUID, status: String, message: String?) async throws -> Void in
-            let now: Date = Date.now
-            try await database.write { db -> Void in
+        { (id: UUID, status: String, message: String?) async throws in
+            let now = Date.now
+            try await database.write { db in
                 guard try SavedItemContentLocalTable.find(id).fetchOne(db) != nil else { return }
-                try SavedItemContentLocalTable.find(id).update {
-                    $0.localStatus = status
-                    $0.localError = #bind(message)
-                    $0.updatedAt = now
-                }.execute(db)
+                try SavedItemContentLocalTable
+                    .find(id)
+                    .update {
+                        $0.localStatus = status
+                        $0.localError = #bind(message)
+                        $0.updatedAt = now
+                    }
+                    .execute(db)
             }
         }
     }

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Jobs.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Jobs.swift
@@ -3,17 +3,19 @@ import SQLiteData
 
 extension StowerRepository {
     static func _enqueueIngestionJob(database: any DatabaseWriter) -> @Sendable (IngestionJob.Kind, String) async throws -> Void {
-        { (kind: IngestionJob.Kind, payload: String) async throws -> Void in
-            try await database.write { db -> Void in
-                try IngestionJobLocalTable.insert {
-                    IngestionJobLocalTable.Draft(
-                        id: UUID(),
-                        kind: kind.rawValue,
-                        payload: payload,
-                        createdAt: .now,
-                        processedAt: nil
-                    )
-                }.execute(db)
+        { (kind: IngestionJob.Kind, payload: String) async throws in
+            try await database.write { db in
+                try IngestionJobLocalTable
+                    .insert {
+                        IngestionJobLocalTable.Draft(
+                            id: UUID(),
+                            kind: kind.rawValue,
+                            payload: payload,
+                            createdAt: .now,
+                            processedAt: nil
+                        )
+                    }
+                    .execute(db)
             }
         }
     }
@@ -34,11 +36,14 @@ extension StowerRepository {
     }
 
     static func _markIngestionJobProcessed(database: any DatabaseWriter) -> @Sendable (UUID) async throws -> Void {
-        { (id: UUID) async throws -> Void in
-            try await database.write { db -> Void in
-                try IngestionJobLocalTable.find(id).update {
-                    $0.processedAt = #bind(Date.now as Date?)
-                }.execute(db)
+        { (id: UUID) async throws in
+            try await database.write { db in
+                try IngestionJobLocalTable
+                    .find(id)
+                    .update {
+                        $0.processedAt = #bind(Date.now as Date?)
+                    }
+                    .execute(db)
             }
         }
     }
@@ -53,7 +58,7 @@ extension StowerRepository {
     /// and copies the extracted `documentJSON`/`plainText` across.
     static func _hydratePDFItemsFromSyncedContent(database: any DatabaseWriter) -> @Sendable () async throws -> Int {
         { () async throws -> Int in
-            let now: Date = Date.now
+            let now = Date.now
             return try await database.write { db -> Int in
                 let pdfRows: [SavedPDFContentSyncTable] = try SavedPDFContentSyncTable.fetchAll(db)
                 var hydrated = 0
@@ -70,31 +75,36 @@ extension StowerRepository {
                     }
 
                     if existing != nil {
-                        try SavedItemContentLocalTable.find(pdfRow.id).update {
-                            $0.renderFormat = RenderFormat.pdf.rawValue
-                            $0.documentVersion = 1
-                            $0.plainText = pdfRow.plainText
-                            $0.documentJSON = pdfRow.documentJSON
-                            $0.localStatus = "available"
-                            $0.localError = nil as String?
-                            $0.updatedAt = now
-                        }.execute(db)
+                        try SavedItemContentLocalTable
+                            .find(pdfRow.id)
+                            .update {
+                                $0.renderFormat = RenderFormat.pdf.rawValue
+                                $0.documentVersion = 1
+                                $0.plainText = pdfRow.plainText
+                                $0.documentJSON = pdfRow.documentJSON
+                                $0.localStatus = "available"
+                                $0.localError = nil as String?
+                                $0.updatedAt = now
+                            }
+                            .execute(db)
                     } else {
-                        try SavedItemContentLocalTable.insert {
-                            SavedItemContentLocalTable.Draft(
-                                itemID: pdfRow.id,
-                                renderFormat: RenderFormat.pdf.rawValue,
-                                documentVersion: 1,
-                                plainText: pdfRow.plainText,
-                                documentJSON: pdfRow.documentJSON,
-                                sourceHTMLHash: "",
-                                sourceHTML: "",
-                                localStatus: "available",
-                                localError: nil,
-                                createdAt: now,
-                                updatedAt: now
-                            )
-                        }.execute(db)
+                        try SavedItemContentLocalTable
+                            .insert {
+                                SavedItemContentLocalTable.Draft(
+                                    itemID: pdfRow.id,
+                                    renderFormat: RenderFormat.pdf.rawValue,
+                                    documentVersion: 1,
+                                    plainText: pdfRow.plainText,
+                                    documentJSON: pdfRow.documentJSON,
+                                    sourceHTMLHash: "",
+                                    sourceHTML: "",
+                                    localStatus: "available",
+                                    localError: nil,
+                                    createdAt: now,
+                                    updatedAt: now
+                                )
+                            }
+                            .execute(db)
                     }
                     hydrated += 1
                 }
@@ -105,7 +115,7 @@ extension StowerRepository {
 
     static func _enqueueHydrationJobsForMissingContent(database: any DatabaseWriter) -> @Sendable () async throws -> Int {
         { () async throws -> Int in
-            let now: Date = Date.now
+            let now = Date.now
             return try await database.write { db -> Int in
                 let synced: [SavedItemSyncTable] = try SavedItemSyncTable
                     .where { !$0.isArchived }
@@ -118,35 +128,39 @@ extension StowerRepository {
                     guard !localIDs.contains(item.id) else { continue }
                     guard let url = item.sourceURL, !url.isEmpty else { continue }
 
-                    try SavedItemContentLocalTable.insert {
-                        SavedItemContentLocalTable.Draft(
-                            itemID: item.id,
-                            renderFormat: "structuredV1",
-                            documentVersion: 1,
-                            plainText: "",
-                            documentJSON: "",
-                            sourceHTMLHash: "",
-                            sourceHTML: "",
-                            localStatus: "notDownloaded",
-                            localError: nil,
-                            createdAt: now,
-                            updatedAt: now
-                        )
-                    }.execute(db)
+                    try SavedItemContentLocalTable
+                        .insert {
+                            SavedItemContentLocalTable.Draft(
+                                itemID: item.id,
+                                renderFormat: "structuredV1",
+                                documentVersion: 1,
+                                plainText: "",
+                                documentJSON: "",
+                                sourceHTMLHash: "",
+                                sourceHTML: "",
+                                localStatus: "notDownloaded",
+                                localError: nil,
+                                createdAt: now,
+                                updatedAt: now
+                            )
+                        }
+                        .execute(db)
 
-                    let payload: String = try String(
-                        decoding: JSONEncoder().encode(HydrationPayload(itemID: item.id, url: url)),
-                        as: UTF8.self
-                    )
-                    try IngestionJobLocalTable.insert {
-                        IngestionJobLocalTable.Draft(
-                            id: UUID(),
-                            kind: IngestionJob.Kind.hydrate.rawValue,
-                            payload: payload,
-                            createdAt: now,
-                            processedAt: nil
-                        )
-                    }.execute(db)
+                    let payload = try String(
+                        bytes: JSONEncoder().encode(HydrationPayload(itemID: item.id, url: url)),
+                        encoding: .utf8
+                    ) ?? ""
+                    try IngestionJobLocalTable
+                        .insert {
+                            IngestionJobLocalTable.Draft(
+                                id: UUID(),
+                                kind: IngestionJob.Kind.hydrate.rawValue,
+                                payload: payload,
+                                createdAt: now,
+                                processedAt: nil
+                            )
+                        }
+                        .execute(db)
                     enqueued += 1
                 }
                 return enqueued

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Reads.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Reads.swift
@@ -57,11 +57,14 @@ extension StowerRepository {
         database: any DatabaseWriter,
         scheduleSync: @escaping @Sendable () -> Void
     ) -> @Sendable (UUID, Int) async throws -> Void {
-        { (id: UUID, blockIndex: Int) async throws -> Void in
-            try await database.write { db -> Void in
-                try SavedItemSyncTable.find(id).update {
-                    $0.lastReadBlockIndex = #bind(blockIndex)
-                }.execute(db)
+        { (id: UUID, blockIndex: Int) async throws in
+            try await database.write { db in
+                try SavedItemSyncTable
+                    .find(id)
+                    .update {
+                        $0.lastReadBlockIndex = #bind(blockIndex)
+                    }
+                    .execute(db)
             }
             scheduleSync()
         }

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Settings.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Settings.swift
@@ -17,23 +17,28 @@ extension StowerRepository {
     }
 
     static func _saveSettings(database: any DatabaseWriter) -> @Sendable (ImageDownloadSettings) async throws -> Void {
-        { (settings: ImageDownloadSettings) async throws -> Void in
-            try await database.write { db -> Void in
+        { (settings: ImageDownloadSettings) async throws in
+            try await database.write { db in
                 if let existing: ImageDownloadSettingsLocalTable = try ImageDownloadSettingsLocalTable.fetchOne(db) {
-                    try ImageDownloadSettingsLocalTable.find(existing.id).update {
-                        $0.globalAutoDownload = settings.globalAutoDownload
-                        $0.askForNewSources = settings.askForNewSources
-                        $0.updatedAt = Date.now
-                    }.execute(db)
+                    try ImageDownloadSettingsLocalTable
+                        .find(existing.id)
+                        .update {
+                            $0.globalAutoDownload = settings.globalAutoDownload
+                            $0.askForNewSources = settings.askForNewSources
+                            $0.updatedAt = Date.now
+                        }
+                        .execute(db)
                 } else {
-                    try ImageDownloadSettingsLocalTable.insert {
-                        ImageDownloadSettingsLocalTable.Draft(
-                            id: UUID(),
-                            globalAutoDownload: settings.globalAutoDownload,
-                            askForNewSources: settings.askForNewSources,
-                            updatedAt: .now
-                        )
-                    }.execute(db)
+                    try ImageDownloadSettingsLocalTable
+                        .insert {
+                            ImageDownloadSettingsLocalTable.Draft(
+                                id: UUID(),
+                                globalAutoDownload: settings.globalAutoDownload,
+                                askForNewSources: settings.askForNewSources,
+                                updatedAt: .now
+                            )
+                        }
+                        .execute(db)
                 }
             }
         }
@@ -60,36 +65,41 @@ extension StowerRepository {
     }
 
     static func _saveReaderAppearanceSettings(database: any DatabaseWriter) -> @Sendable (ReaderAppearanceSettings) async throws -> Void {
-        { (settings: ReaderAppearanceSettings) async throws -> Void in
-            let clamped: ReaderAppearanceSettings = settings.clamped()
-            try await database.write { db -> Void in
+        { (settings: ReaderAppearanceSettings) async throws in
+            let clamped = settings.clamped()
+            try await database.write { db in
                 if let existing: ReaderAppearanceSettingsLocalTable = try ReaderAppearanceSettingsLocalTable.fetchOne(db) {
-                    try ReaderAppearanceSettingsLocalTable.find(existing.id).update {
-                        $0.fontSize = clamped.fontSize
-                        $0.fontStyle = clamped.fontStyle.rawValue
-                        $0.lineSpacing = clamped.lineSpacing
-                        $0.justification = clamped.justification.rawValue
-                        $0.theme = clamped.background.rawValue
-                        $0.primaryAccent = clamped.primaryAccent.rawValue
-                        $0.secondaryAccent = clamped.secondaryAccent.rawValue
-                        $0.lineWidth = clamped.lineWidth
-                        $0.updatedAt = Date.now
-                    }.execute(db)
+                    try ReaderAppearanceSettingsLocalTable
+                        .find(existing.id)
+                        .update {
+                            $0.fontSize = clamped.fontSize
+                            $0.fontStyle = clamped.fontStyle.rawValue
+                            $0.lineSpacing = clamped.lineSpacing
+                            $0.justification = clamped.justification.rawValue
+                            $0.theme = clamped.background.rawValue
+                            $0.primaryAccent = clamped.primaryAccent.rawValue
+                            $0.secondaryAccent = clamped.secondaryAccent.rawValue
+                            $0.lineWidth = clamped.lineWidth
+                            $0.updatedAt = Date.now
+                        }
+                        .execute(db)
                 } else {
-                    try ReaderAppearanceSettingsLocalTable.insert {
-                        ReaderAppearanceSettingsLocalTable.Draft(
-                            id: UUID(),
-                            fontSize: clamped.fontSize,
-                            fontStyle: clamped.fontStyle.rawValue,
-                            lineSpacing: clamped.lineSpacing,
-                            justification: clamped.justification.rawValue,
-                            theme: clamped.background.rawValue,
-                            primaryAccent: clamped.primaryAccent.rawValue,
-                            secondaryAccent: clamped.secondaryAccent.rawValue,
-                            lineWidth: clamped.lineWidth,
-                            updatedAt: .now
-                        )
-                    }.execute(db)
+                    try ReaderAppearanceSettingsLocalTable
+                        .insert {
+                            ReaderAppearanceSettingsLocalTable.Draft(
+                                id: UUID(),
+                                fontSize: clamped.fontSize,
+                                fontStyle: clamped.fontStyle.rawValue,
+                                lineSpacing: clamped.lineSpacing,
+                                justification: clamped.justification.rawValue,
+                                theme: clamped.background.rawValue,
+                                primaryAccent: clamped.primaryAccent.rawValue,
+                                secondaryAccent: clamped.secondaryAccent.rawValue,
+                                lineWidth: clamped.lineWidth,
+                                updatedAt: .now
+                            )
+                        }
+                        .execute(db)
                 }
             }
         }

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Tags.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Tags.swift
@@ -2,7 +2,6 @@ import Foundation
 import SQLiteData
 
 extension StowerRepository {
-
     // MARK: Fetch
 
     static func _fetchTags(
@@ -73,14 +72,17 @@ extension StowerRepository {
         database: any DatabaseWriter,
         scheduleSync: @escaping @Sendable () -> Void
     ) -> @Sendable (UUID, String) async throws -> Void {
-        { (id: UUID, newName: String) async throws -> Void in
+        { (id: UUID, newName: String) async throws in
             let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
             let now = Date.now
-            try await database.write { db -> Void in
-                try TagSyncTable.find(id).update {
-                    $0.name = #bind(trimmed)
-                    $0.updatedAt = #bind(now)
-                }.execute(db)
+            try await database.write { db in
+                try TagSyncTable
+                    .find(id)
+                    .update {
+                        $0.name = #bind(trimmed)
+                        $0.updatedAt = #bind(now)
+                    }
+                    .execute(db)
             }
             scheduleSync()
         }
@@ -90,8 +92,8 @@ extension StowerRepository {
         database: any DatabaseWriter,
         scheduleSync: @escaping @Sendable () -> Void
     ) -> @Sendable (UUID) async throws -> Void {
-        { (id: UUID) async throws -> Void in
-            try await database.write { db -> Void in
+        { (id: UUID) async throws in
+            try await database.write { db in
                 try ItemTagSyncTable.where { $0.tagID.eq(id) }.delete().execute(db)
                 try TagSyncTable.find(id).delete().execute(db)
             }
@@ -103,8 +105,8 @@ extension StowerRepository {
         database: any DatabaseWriter,
         scheduleSync: @escaping @Sendable () -> Void
     ) -> @Sendable (UUID, UUID) async throws -> Void {
-        { (itemID: UUID, tagID: UUID) async throws -> Void in
-            try await database.write { db -> Void in
+        { (itemID: UUID, tagID: UUID) async throws in
+            try await database.write { db in
                 // Dedupe: the unique index would reject a duplicate, but we
                 // pre-check so the caller sees a clean no-op on double-add.
                 let existing: [ItemTagSyncTable] = try ItemTagSyncTable
@@ -127,8 +129,8 @@ extension StowerRepository {
         database: any DatabaseWriter,
         scheduleSync: @escaping @Sendable () -> Void
     ) -> @Sendable (UUID, UUID) async throws -> Void {
-        { (itemID: UUID, tagID: UUID) async throws -> Void in
-            try await database.write { db -> Void in
+        { (itemID: UUID, tagID: UUID) async throws in
+            try await database.write { db in
                 try ItemTagSyncTable
                     .where { $0.itemID.eq(itemID) && $0.tagID.eq(tagID) }
                     .delete()

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository.swift
@@ -152,7 +152,9 @@ extension StowerRepository {
 
         let baseLoadDocument = _loadReaderDocument(database: database)
         let cachedLoadDocument: @Sendable (UUID) async throws -> ReaderDocument? = { id in
-            if let cached = documentCache.get(id) { return cached }
+            if let cached = documentCache.get(id) {
+                return cached
+            }
             let document = try await baseLoadDocument(id)
             if let document { documentCache.set(id, document: document) }
             return document
@@ -267,7 +269,7 @@ extension StowerRepository {
 /// Mutation closures call `ping()`; consumers subscribe via `stream()`.
 final class LibraryChangeBroadcast: @unchecked Sendable {
     private let lock = NSLock()
-    private var continuations: [UUID: AsyncStream<Void>.Continuation] = [:]
+    private var continuations: [UUID: AsyncStream<Void>.Continuation] = [:] // swiftlint:disable:this prefer_let_over_var
 
     func stream() -> AsyncStream<Void> {
         AsyncStream { continuation in

--- a/StowerPackage/Sources/StowerData/Data/Tables.swift
+++ b/StowerPackage/Sources/StowerData/Data/Tables.swift
@@ -4,7 +4,7 @@ import SQLiteData
 // MARK: - Synced (CloudKit) Tables
 
 @Table
-public nonisolated struct SavedItemSyncTable: Hashable, Identifiable, Sendable {
+nonisolated public struct SavedItemSyncTable: Hashable, Identifiable, Sendable {
     public let id: UUID
     public var title: String = ""
     public var sourceURL: String?
@@ -35,7 +35,7 @@ public nonisolated struct SavedItemSyncTable: Hashable, Identifiable, Sendable {
 
 /// A user-created tag. CloudKit-synced; case-insensitively unique by name.
 @Table
-public nonisolated struct TagSyncTable: Hashable, Identifiable, Sendable {
+nonisolated public struct TagSyncTable: Hashable, Identifiable, Sendable {
     public let id: UUID
     public var name: String = ""
     public var colorHex: String?
@@ -46,7 +46,7 @@ public nonisolated struct TagSyncTable: Hashable, Identifiable, Sendable {
 /// Junction row assigning a tag to a saved item. Its own `id` so CloudKit
 /// records have a stable name; uniqueness is enforced by a composite index.
 @Table
-public nonisolated struct ItemTagSyncTable: Hashable, Identifiable, Sendable {
+nonisolated public struct ItemTagSyncTable: Hashable, Identifiable, Sendable {
     public let id: UUID
     public var itemID: UUID
     public var tagID: UUID
@@ -56,7 +56,7 @@ public nonisolated struct ItemTagSyncTable: Hashable, Identifiable, Sendable {
 // MARK: - Local-Only Tables
 
 @Table
-public nonisolated struct SavedItemContentLocalTable: Hashable, Identifiable, Sendable {
+nonisolated public struct SavedItemContentLocalTable: Hashable, Identifiable, Sendable {
     @Column(primaryKey: true)
     public let itemID: UUID
 
@@ -89,7 +89,7 @@ public nonisolated struct SavedItemContentLocalTable: Hashable, Identifiable, Se
 /// local content table without re-fetching the (unavailable) PDF bytes.
 /// Never populated for URL/text items — those hydrate from the source URL.
 @Table
-public nonisolated struct SavedPDFContentSyncTable: Hashable, Identifiable, Sendable {
+nonisolated public struct SavedPDFContentSyncTable: Hashable, Identifiable, Sendable {
     public let id: UUID
     public var documentJSON: String = ""
     public var plainText: String = ""
@@ -98,7 +98,7 @@ public nonisolated struct SavedPDFContentSyncTable: Hashable, Identifiable, Send
 }
 
 @Table
-public nonisolated struct SavedMediaLocalTable: Hashable, Identifiable, Sendable {
+nonisolated public struct SavedMediaLocalTable: Hashable, Identifiable, Sendable {
     public let id: UUID
     public var itemID: UUID
     public var kind: String = "image"
@@ -116,7 +116,7 @@ public nonisolated struct SavedMediaLocalTable: Hashable, Identifiable, Sendable
 }
 
 @Table
-public nonisolated struct SavedEmbedLocalTable: Hashable, Identifiable, Sendable {
+nonisolated public struct SavedEmbedLocalTable: Hashable, Identifiable, Sendable {
     public let id: UUID
     public var itemID: UUID
     public var provider: String = ""
@@ -128,7 +128,7 @@ public nonisolated struct SavedEmbedLocalTable: Hashable, Identifiable, Sendable
 }
 
 @Table
-public nonisolated struct SavedImageRefLocalTable: Hashable, Identifiable, Sendable {
+nonisolated public struct SavedImageRefLocalTable: Hashable, Identifiable, Sendable {
     public let id: UUID
     public var itemID: UUID
     public var sourceURL: String?
@@ -140,10 +140,10 @@ public nonisolated struct SavedImageRefLocalTable: Hashable, Identifiable, Senda
 }
 
 @Table
-public nonisolated struct SavedImageAssetLocalTable: Hashable, Identifiable, Sendable {
+nonisolated public struct SavedImageAssetLocalTable: Hashable, Identifiable, Sendable {
     public let id: UUID
     public var itemID: UUID
-    public var imageData: Data = Data()
+    public var imageData: Data = Data() // swiftlint:disable:this redundant_type_annotation
     public var width: Int = 0
     public var height: Int = 0
     public var format: String = "jpg"
@@ -151,7 +151,7 @@ public nonisolated struct SavedImageAssetLocalTable: Hashable, Identifiable, Sen
 }
 
 @Table
-public nonisolated struct ImageDownloadSettingsLocalTable: Hashable, Identifiable, Sendable {
+nonisolated public struct ImageDownloadSettingsLocalTable: Hashable, Identifiable, Sendable {
     public let id: UUID
     public var globalAutoDownload: Bool = false
     public var askForNewSources: Bool = true
@@ -159,7 +159,7 @@ public nonisolated struct ImageDownloadSettingsLocalTable: Hashable, Identifiabl
 }
 
 @Table
-public nonisolated struct ReaderAppearanceSettingsLocalTable: Hashable, Identifiable, Sendable {
+nonisolated public struct ReaderAppearanceSettingsLocalTable: Hashable, Identifiable, Sendable {
     public let id: UUID
     public var fontSize: Double = 19
     public var fontStyle: String = "newYork"
@@ -175,11 +175,10 @@ public nonisolated struct ReaderAppearanceSettingsLocalTable: Hashable, Identifi
 }
 
 @Table
-public nonisolated struct IngestionJobLocalTable: Hashable, Identifiable, Sendable {
+nonisolated public struct IngestionJobLocalTable: Hashable, Identifiable, Sendable {
     public let id: UUID
     public var kind: String = "url"
     public var payload: String = ""
     public var createdAt: Date = .now
     public var processedAt: Date?
 }
-

--- a/StowerPackage/Sources/StowerData/Domain/CloudSyncStatus.swift
+++ b/StowerPackage/Sources/StowerData/Domain/CloudSyncStatus.swift
@@ -25,4 +25,3 @@ public struct CloudSyncStatus: Equatable, Sendable {
 
     public static let starting = Self(state: .starting)
 }
-

--- a/StowerPackage/Sources/StowerData/Domain/FlexokiRaw.swift
+++ b/StowerPackage/Sources/StowerData/Domain/FlexokiRaw.swift
@@ -18,7 +18,7 @@ public enum FlexokiRaw {
 
     /// Numbered warm-grey ramp, light → dark.
     public static let base: [Int: String] = [
-        50:  "#F2F0E5",
+         50: "#F2F0E5",
         100: "#E6E4D9",
         150: "#DAD8CE",
         200: "#CECDC3",
@@ -36,56 +36,56 @@ public enum FlexokiRaw {
     // MARK: - Accent ramps (50–950) for each Flexoki hue
 
     public static let red: [Int: String] = [
-        50:  "#FFE1D5", 100: "#FFCABB", 150: "#FDB2A2", 200: "#F89A8A",
+         50: "#FFE1D5", 100: "#FFCABB", 150: "#FDB2A2", 200: "#F89A8A",
         300: "#E8705F", 400: "#D14D41", 500: "#C03E35", 600: "#AF3029",
         700: "#942822", 800: "#6C201C", 850: "#551B18", 900: "#3E1715",
         950: "#261312",
     ]
 
     public static let orange: [Int: String] = [
-        50:  "#FFE7CE", 100: "#FED3AF", 150: "#FCC192", 200: "#F9AE77",
+         50: "#FFE7CE", 100: "#FED3AF", 150: "#FCC192", 200: "#F9AE77",
         300: "#EC8B49", 400: "#DA702C", 500: "#CB6120", 600: "#BC5215",
         700: "#9D4310", 800: "#71320D", 850: "#59290D", 900: "#40200D",
         950: "#27180E",
     ]
 
     public static let yellow: [Int: String] = [
-        50:  "#FAEEC6", 100: "#F6E2A0", 150: "#F1D67E", 200: "#ECCB60",
+         50: "#FAEEC6", 100: "#F6E2A0", 150: "#F1D67E", 200: "#ECCB60",
         300: "#DFB431", 400: "#D0A215", 500: "#BE9207", 600: "#AD8301",
         700: "#8E6B01", 800: "#664D01", 850: "#503D02", 900: "#3A2D04",
         950: "#241E08",
     ]
 
     public static let green: [Int: String] = [
-        50:  "#EDEECF", 100: "#DDE2B2", 150: "#CDD597", 200: "#BEC97E",
+         50: "#EDEECF", 100: "#DDE2B2", 150: "#CDD597", 200: "#BEC97E",
         300: "#A0AF54", 400: "#879A39", 500: "#768D21", 600: "#66800B",
         700: "#536907", 800: "#3D4C07", 850: "#313D07", 900: "#252D09",
         950: "#1A1E0C",
     ]
 
     public static let cyan: [Int: String] = [
-        50:  "#DDF1E4", 100: "#BFE8D9", 150: "#A2DECE", 200: "#87D3C3",
+         50: "#DDF1E4", 100: "#BFE8D9", 150: "#A2DECE", 200: "#87D3C3",
         300: "#5ABDAC", 400: "#3AA99F", 500: "#2F968D", 600: "#24837B",
         700: "#1C6C66", 800: "#164F4A", 850: "#143F3C", 900: "#122F2C",
         950: "#101F1D",
     ]
 
     public static let blue: [Int: String] = [
-        50:  "#E1ECEB", 100: "#C6DDE8", 150: "#ABCFE2", 200: "#92BFDB",
+         50: "#E1ECEB", 100: "#C6DDE8", 150: "#ABCFE2", 200: "#92BFDB",
         300: "#66A0C8", 400: "#4385BE", 500: "#3171B2", 600: "#205EA6",
         700: "#1A4F8C", 800: "#163B66", 850: "#133051", 900: "#12253B",
         950: "#101A24",
     ]
 
     public static let purple: [Int: String] = [
-        50:  "#F0EAEC", 100: "#E2D9E9", 150: "#D3CAE6", 200: "#C4B9E0",
+         50: "#F0EAEC", 100: "#E2D9E9", 150: "#D3CAE6", 200: "#C4B9E0",
         300: "#A699D0", 400: "#8B7EC8", 500: "#735EB5", 600: "#5E409D",
         700: "#4F3685", 800: "#3C2A62", 850: "#31234E", 900: "#261C39",
         950: "#1A1623",
     ]
 
     public static let magenta: [Int: String] = [
-        50:  "#FEE4E5", 100: "#FCCFDA", 150: "#F9B9CF", 200: "#F4A4C2",
+         50: "#FEE4E5", 100: "#FCCFDA", 150: "#F9B9CF", 200: "#F4A4C2",
         300: "#E47DA8", 400: "#CE5D97", 500: "#B74583", 600: "#A02F6F",
         700: "#87285E", 800: "#641F46", 850: "#4F1B39", 900: "#39172B",
         950: "#24131D",
@@ -94,14 +94,22 @@ public enum FlexokiRaw {
     /// Look up a hue's ramp by the `FlexokiHue` case.
     public static func ramp(for hue: FlexokiHue) -> [Int: String] {
         switch hue {
-        case .red: return red
-        case .orange: return orange
-        case .yellow: return yellow
-        case .green: return green
-        case .cyan: return cyan
-        case .blue: return blue
-        case .purple: return purple
-        case .magenta: return magenta
+        case .red:
+            return red
+        case .orange:
+            return orange
+        case .yellow:
+            return yellow
+        case .green:
+            return green
+        case .cyan:
+            return cyan
+        case .blue:
+            return blue
+        case .purple:
+            return purple
+        case .magenta:
+            return magenta
         }
     }
 
@@ -136,24 +144,24 @@ public enum FlexokiRaw {
         switch background {
         case .paper:
             return BackgroundTokens(
-                bg:  paper,
+                bg: paper,
                 bg2: base[50]!,
-                ui:  base[100]!,
+                ui: base[100]!,
                 ui2: base[150]!,
                 ui3: base[200]!,
-                tx:  black,
+                tx: black,
                 tx2: base[600]!,
                 tx3: base[300]!,
                 isDark: false
             )
         case .white:
             return BackgroundTokens(
-                bg:  "#FFFFFF",
+                bg: "#FFFFFF",
                 bg2: base[50]!,
-                ui:  base[100]!,
+                ui: base[100]!,
                 ui2: base[150]!,
                 ui3: base[200]!,
-                tx:  black,
+                tx: black,
                 tx2: base[600]!,
                 tx3: base[300]!,
                 isDark: false
@@ -164,24 +172,24 @@ public enum FlexokiRaw {
             // intentionally carry more yellow than the cool `base` ramp so
             // accent hues feel grounded in the same warm light.
             return BackgroundTokens(
-                bg:  "#F4EBD4",
+                bg: "#F4EBD4",
                 bg2: "#EBDFC2",
-                ui:  "#DCCFAD",
+                ui: "#DCCFAD",
                 ui2: "#D1C29A",
                 ui3: "#C4B280",
-                tx:  base[950]!,
+                tx: base[950]!,
                 tx2: base[700]!,
                 tx3: base[500]!,
                 isDark: false
             )
         case .black:
             return BackgroundTokens(
-                bg:  base[950]!,
+                bg: base[950]!,
                 bg2: base[900]!,
-                ui:  base[850]!,
+                ui: base[850]!,
                 ui2: base[800]!,
                 ui3: base[700]!,
-                tx:  base[200]!,
+                tx: base[200]!,
                 tx2: base[500]!,
                 tx3: base[700]!,
                 isDark: true
@@ -205,17 +213,17 @@ public enum FlexokiRaw {
     public static func accent(_ hue: FlexokiHue, isDark: Bool) -> AccentShades {
         if isDark {
             return AccentShades(
-                main:  shade(hue, 400),
+                main: shade(hue, 400),
                 muted: shade(hue, 300),
-                fill:  shade(hue, 800),
-                wash:  shade(hue, 900)
+                fill: shade(hue, 800),
+                wash: shade(hue, 900)
             )
         } else {
             return AccentShades(
-                main:  shade(hue, 600),
+                main: shade(hue, 600),
                 muted: shade(hue, 700),
-                fill:  shade(hue, 100),
-                wash:  shade(hue, 50)
+                fill: shade(hue, 100),
+                wash: shade(hue, 50)
             )
         }
     }

--- a/StowerPackage/Sources/StowerData/Domain/LibraryFilter.swift
+++ b/StowerPackage/Sources/StowerData/Domain/LibraryFilter.swift
@@ -24,7 +24,7 @@ public struct LibraryListCounts: Equatable, Sendable {
     public var untagged: Int
     public var all: Int
     public var recentlyDeleted: Int
-    public var byTag: [UUID: Int]
+    public var byTag: [UUID: Int] // swiftlint:disable:this prefer_let_over_var
 
     public init(
         unread: Int = 0,

--- a/StowerPackage/Sources/StowerData/Domain/Models.swift
+++ b/StowerPackage/Sources/StowerData/Domain/Models.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable function_default_parameter_at_end
 import Foundation
 
 public struct SavedItem: Equatable, Identifiable, Sendable {
@@ -28,7 +29,7 @@ public struct SavedItem: Equatable, Identifiable, Sendable {
     public var deletedAt: Date?
     /// IDs of tags assigned to this item. Populated by repository reads via a
     /// batched junction-table query (never N+1).
-    public var tagIDs: [UUID]
+    public var tagIDs: [UUID] // swiftlint:disable:this prefer_let_over_var
 
     public init(
         id: UUID = UUID(),
@@ -104,11 +105,11 @@ public struct ImageDownloadSettings: Equatable, Sendable {
 }
 
 public enum ReaderFontStyle: String, Codable, CaseIterable, Equatable, Sendable {
-    case newYork
-    case timesNewRoman
-    case helveticaNeue
-    case avenirNext
-    case menlo
+    case newYork = "newYork"
+    case timesNewRoman = "timesNewRoman"
+    case helveticaNeue = "helveticaNeue"
+    case avenirNext = "avenirNext"
+    case menlo = "menlo"
 
     public var displayName: String {
         switch self {
@@ -127,8 +128,8 @@ public enum ReaderFontStyle: String, Codable, CaseIterable, Equatable, Sendable 
 }
 
 public enum ReaderJustification: String, Codable, CaseIterable, Equatable, Sendable {
-    case leading
-    case justified
+    case leading = "leading"
+    case justified = "justified"
 }
 
 /// The background palette driving the whole app — not just the reader.
@@ -136,17 +137,21 @@ public enum ReaderJustification: String, Codable, CaseIterable, Equatable, Senda
 /// switch it into light mode. Sepia is a custom warm-cream palette tuned to
 /// harmonise with Flexoki accent hues.
 public enum ReaderBackground: String, Codable, CaseIterable, Equatable, Sendable {
-    case paper
-    case white
-    case sepia
-    case black
+    case paper = "paper"
+    case white = "white"
+    case sepia = "sepia"
+    case black = "black"
 
     public var displayName: String {
         switch self {
-        case .paper: return "Paper"
-        case .white: return "White"
-        case .sepia: return "Sepia"
-        case .black: return "Black"
+        case .paper:
+            return "Paper"
+        case .white:
+            return "White"
+        case .sepia:
+            return "Sepia"
+        case .black:
+            return "Black"
         }
     }
 
@@ -156,11 +161,16 @@ public enum ReaderBackground: String, Codable, CaseIterable, Equatable, Sendable
     /// inserted by older app versions mid-migration, sync replay, etc.).
     public static func fromStored(_ raw: String?) -> ReaderBackground {
         guard let raw else { return .paper }
-        if let exact = ReaderBackground(rawValue: raw) { return exact }
+        if let exact = ReaderBackground(rawValue: raw) {
+            return exact
+        }
         switch raw {
-        case "dark": return .black
-        case "white": return .white
-        default: return .paper
+        case "dark":
+            return .black
+        case "white":
+            return .white
+        default:
+            return .paper
         }
     }
 }
@@ -169,18 +179,33 @@ public enum ReaderBackground: String, Codable, CaseIterable, Equatable, Sendable
 /// different shades depending on whether the current background is light or
 /// dark — see `FlexokiRaw.accent(_:isDark:)`.
 public enum FlexokiHue: String, Codable, CaseIterable, Equatable, Sendable {
-    case red, orange, yellow, green, cyan, blue, purple, magenta
+    case red = "red"
+    case orange = "orange"
+    case yellow = "yellow"
+    case green = "green"
+    case cyan = "cyan"
+    case blue = "blue"
+    case purple = "purple"
+    case magenta = "magenta"
 
     public var displayName: String {
         switch self {
-        case .red: return "Red"
-        case .orange: return "Orange"
-        case .yellow: return "Yellow"
-        case .green: return "Green"
-        case .cyan: return "Cyan"
-        case .blue: return "Blue"
-        case .purple: return "Purple"
-        case .magenta: return "Magenta"
+        case .red:
+            return "Red"
+        case .orange:
+            return "Orange"
+        case .yellow:
+            return "Yellow"
+        case .green:
+            return "Green"
+        case .cyan:
+            return "Cyan"
+        case .blue:
+            return "Blue"
+        case .purple:
+            return "Purple"
+        case .magenta:
+            return "Magenta"
         }
     }
 
@@ -240,10 +265,10 @@ public struct ReaderAppearanceSettings: Equatable, Sendable {
 
 public struct IngestionJob: Equatable, Identifiable, Sendable {
     public enum Kind: String, Codable, Sendable {
-        case url
-        case text
-        case hydrate
-        case pdf
+        case url = "url"
+        case text = "text"
+        case hydrate = "hydrate"
+        case pdf = "pdf"
     }
 
     public let id: UUID
@@ -268,3 +293,4 @@ public struct HydrationPayload: Codable, Equatable, Sendable {
         self.url = url
     }
 }
+// swiftlint:enable function_default_parameter_at_end

--- a/StowerPackage/Sources/StowerData/Domain/ReaderDocument.swift
+++ b/StowerPackage/Sources/StowerData/Domain/ReaderDocument.swift
@@ -1,19 +1,20 @@
+// swiftlint:disable function_default_parameter_at_end
 import Foundation
 
 public enum RenderFormat: String, Codable, Equatable, Sendable {
-    case structuredV1
-    case htmlFallback
-    case plainText
-    case webView
-    case pdf
+    case structuredV1 = "structuredV1"
+    case htmlFallback = "htmlFallback"
+    case plainText = "plainText"
+    case webView = "webView"
+    case pdf = "pdf"
 }
 
 public enum ProcessingState: String, Codable, Equatable, Sendable {
-    case queued
-    case extracting
-    case ready
-    case failed
-    case partial
+    case queued = "queued"
+    case extracting = "extracting"
+    case ready = "ready"
+    case failed = "failed"
+    case partial = "partial"
 }
 
 public struct ReaderDocument: Codable, Equatable, Sendable {
@@ -63,10 +64,10 @@ public enum ReaderInline: Codable, Equatable, Sendable {
 
 public struct MediaDescriptor: Codable, Equatable, Sendable {
     public enum Kind: String, Codable, Equatable, Sendable {
-        case image
-        case video
-        case audio
-        case embed
+        case image = "image"
+        case video = "video"
+        case audio = "audio"
+        case embed = "embed"
     }
 
     public var kind: Kind
@@ -231,3 +232,4 @@ public struct IngestionResult: Equatable, Sendable {
         )
     }
 }
+// swiftlint:enable function_default_parameter_at_end

--- a/StowerPackage/Sources/StowerData/Domain/ReaderDocumentSanitizer.swift
+++ b/StowerPackage/Sources/StowerData/Domain/ReaderDocumentSanitizer.swift
@@ -16,15 +16,15 @@ public func sanitizeLoadedBlocks(_ blocks: [ReaderBlock]) -> [ReaderBlock] {
 
 private func sanitizeBlock(_ block: ReaderBlock) -> ReaderBlock {
     switch block {
-    case .paragraph(let inlines):
+    case let .paragraph(inlines):
         return .paragraph(sanitizeInlines(inlines))
-    case .heading(let level, let inlines):
+    case let .heading(level, inlines):
         return .heading(level: level, inlines: sanitizeInlines(inlines))
-    case .list(let ordered, let items):
+    case let .list(ordered, items):
         return .list(ordered: ordered, items: items.map(sanitizeInlines))
-    case .blockquote(let inlines):
+    case let .blockquote(inlines):
         return .blockquote(sanitizeInlines(inlines))
-    case .callout(let title, let inlines):
+    case let .callout(title, inlines):
         return .callout(
             title: title.map { stripPilcrows($0).trimmingCharacters(in: .whitespacesAndNewlines) },
             inlines: sanitizeInlines(inlines)
@@ -35,19 +35,19 @@ private func sanitizeBlock(_ block: ReaderBlock) -> ReaderBlock {
 }
 
 private func sanitizeInlines(_ inlines: [ReaderInline]) -> [ReaderInline] {
-    var output: [ReaderInline] = []
+    var output: [ReaderInline] = [] // swiftlint:disable:this prefer_let_over_var
     output.reserveCapacity(inlines.count)
 
     for inline in inlines {
         switch inline {
-        case .text(let value):
+        case let .text(value):
             // Preserve boundary whitespace — the parser intentionally emits
             // segments like `"word "` so the downstream renderer doesn't
             // smoosh links/bold runs against their neighbours.
             let cleaned = stripPilcrows(value)
             if !cleaned.isEmpty { output.append(.text(cleaned)) }
 
-        case .link(let label, let url):
+        case let .link(label, url):
             let cleanedLabel = stripPilcrows(label).trimmingCharacters(in: .whitespacesAndNewlines)
             if cleanedLabel.isEmpty { continue }
             // Drop fragment-only links with symbol-only or very short labels —
@@ -57,19 +57,19 @@ private func sanitizeInlines(_ inlines: [ReaderInline]) -> [ReaderInline] {
             }
             output.append(.link(label: cleanedLabel, url: url))
 
-        case .emphasis(let value):
+        case let .emphasis(value):
             let cleaned = stripPilcrows(value).trimmingCharacters(in: .whitespacesAndNewlines)
             if !cleaned.isEmpty { output.append(.emphasis(cleaned)) }
 
-        case .strong(let value):
+        case let .strong(value):
             let cleaned = stripPilcrows(value).trimmingCharacters(in: .whitespacesAndNewlines)
             if !cleaned.isEmpty { output.append(.strong(cleaned)) }
 
-        case .code(let value):
+        case let .code(value):
             // Don't strip pilcrows from code — they may be meaningful literals.
             output.append(.code(value))
 
-        case .strikethrough(let value):
+        case let .strikethrough(value):
             let cleaned = stripPilcrows(value).trimmingCharacters(in: .whitespacesAndNewlines)
             if !cleaned.isEmpty { output.append(.strikethrough(cleaned)) }
         }
@@ -112,7 +112,7 @@ private func isSymbolOnly(_ text: String) -> Bool {
 }
 
 private func mergeAdjacentText(_ inlines: [ReaderInline]) -> [ReaderInline] {
-    var merged: [ReaderInline] = []
+    var merged: [ReaderInline] = [] // swiftlint:disable:this prefer_let_over_var
     merged.reserveCapacity(inlines.count)
     for inline in inlines {
         if case .text(let current) = inline,

--- a/StowerPackage/Sources/StowerData/Domain/Tag.swift
+++ b/StowerPackage/Sources/StowerData/Domain/Tag.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable function_default_parameter_at_end
 import Foundation
 
 /// A user-created tag that can be applied to multiple saved items.
@@ -24,3 +25,4 @@ public struct Tag: Equatable, Identifiable, Sendable, Hashable {
         self.updatedAt = updatedAt
     }
 }
+// swiftlint:enable function_default_parameter_at_end

--- a/StowerPackage/Sources/StowerData/Domain/YouTubeURLDetector.swift
+++ b/StowerPackage/Sources/StowerData/Domain/YouTubeURLDetector.swift
@@ -8,14 +8,13 @@ import Foundation
 /// code that both the ingestion pipeline (in `StowerFeatureV2`) and the reader
 /// renderer call into. No regex — everything flows through `URLComponents`.
 public enum YouTubeURLDetector {
-
     /// The structural form of the original link. The reader renderer uses this
     /// to pick between a 16:9 or 9:16 wrapper.
     public enum Form: String, Sendable, Equatable {
-        case watch            // youtube.com/watch?v=…
-        case shortsVertical   // youtube.com/shorts/…
-        case embed            // youtube.com/embed/… or /v/…
-        case youtuBe          // youtu.be/…
+        case watch = "watch"
+        case shortsVertical = "shortsVertical"
+        case embed = "embed"
+        case youtuBe = "youtuBe"
     }
 
     public struct Match: Sendable, Equatable {
@@ -57,7 +56,7 @@ public enum YouTubeURLDetector {
                 return isValidVideoID(id) ? Match(videoID: id, form: .shortsVertical) : nil
             }
             // /embed/ID or /v/ID
-            if (pathComponents.first == "embed" || pathComponents.first == "v"),
+            if pathComponents.first == "embed" || pathComponents.first == "v",
                pathComponents.count >= 2 {
                 let id = pathComponents[1]
                 return isValidVideoID(id) ? Match(videoID: id, form: .embed) : nil

--- a/StowerPackage/Sources/StowerData/Support/ShareIngestionClient.swift
+++ b/StowerPackage/Sources/StowerData/Support/ShareIngestionClient.swift
@@ -18,7 +18,8 @@ public enum ShareIngestionClient {
             // Share extension should avoid CloudKit work.
             try $0.bootstrapStowerDatabase(enableSync: false)
         }
-        @Dependency(\.stowerRepository) var repository
+        @Dependency(\.stowerRepository)
+        var repository
         Task {
             try? await repository.enqueueIngestionJob(.url, url.absoluteString)
         }
@@ -29,7 +30,8 @@ public enum ShareIngestionClient {
             // Share extension should avoid CloudKit work.
             try $0.bootstrapStowerDatabase(enableSync: false)
         }
-        @Dependency(\.stowerRepository) var repository
+        @Dependency(\.stowerRepository)
+        var repository
         Task {
             try? await repository.enqueueIngestionJob(.text, text)
         }
@@ -71,7 +73,8 @@ public enum ShareIngestionClient {
         let destination = pendingDir.appendingPathComponent(filename)
         try FileManager.default.copyItem(at: sourceURL, to: destination)
 
-        @Dependency(\.stowerRepository) var repository
+        @Dependency(\.stowerRepository)
+        var repository
         let path = destination.path
         Task {
             try? await repository.enqueueIngestionJob(.pdf, path)

--- a/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
@@ -92,14 +92,22 @@ public struct AppFeature {
         }
     }
 
-    @Dependency(\.cloudSyncClient) var cloudSyncClient
-    @Dependency(\.stowerRepository) var repository
-    @Dependency(\.urlIngestionClient) var ingestionClient
-    @Dependency(\.pdfIngestionClient) var pdfIngestionClient
-    @Dependency(\.defaultDatabase) var database
-    @Dependency(\.defaultSyncEngine) var syncEngine
-    @Dependency(\.continuousClock) var clock
-    @Dependency(\.context) var context
+    @Dependency(\.cloudSyncClient)
+    var cloudSyncClient
+    @Dependency(\.stowerRepository)
+    var repository
+    @Dependency(\.urlIngestionClient)
+    var ingestionClient
+    @Dependency(\.pdfIngestionClient)
+    var pdfIngestionClient
+    @Dependency(\.defaultDatabase)
+    var database
+    @Dependency(\.defaultSyncEngine)
+    var syncEngine
+    @Dependency(\.continuousClock)
+    var clock
+    @Dependency(\.context)
+    var context
 
     public var body: some ReducerOf<Self> {
         Scope(state: \.sidebar, action: \.sidebar) {

--- a/StowerPackage/Sources/StowerFeatureV2/ContentView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/ContentView.swift
@@ -1,10 +1,11 @@
 import ComposableArchitecture
-import SwiftUI
 import StowerData
+import SwiftUI
 
 public struct ContentView: View {
     let store: StoreOf<AppFeature>
-    @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.scenePhase)
+    private var scenePhase
 
     public init(store: StoreOf<AppFeature>) {
         self.store = store
@@ -33,7 +34,8 @@ public struct AppView: View {
     @Bindable var store: StoreOf<AppFeature>
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
     #if os(iOS)
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.horizontalSizeClass)
+    private var horizontalSizeClass
     @State private var isFilterSheetPresented = false
     #endif
 
@@ -85,9 +87,10 @@ public struct AppView: View {
         if horizontalSizeClass == .compact {
             NavigationStack {
                 LibraryScreen(
-                    store: store.scope(state: \.library, action: \.library),
-                    onOpenFilters: { isFilterSheetPresented = true }
-                )
+                    store: store.scope(state: \.library, action: \.library)
+                ) {
+                    isFilterSheetPresented = true
+                }
                     .scrollContentBackground(.hidden)
                     .background(palette.bg)
                     .navigationDestination(
@@ -146,9 +149,10 @@ public struct AppView: View {
     private func splitNavigationView(palette: FlexokiPalette) -> some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             SidebarScreen(
-                store: store.scope(state: \.sidebar, action: \.sidebar),
-                onOpenSettings: { store.send(.openSettings) }
-            )
+                store: store.scope(state: \.sidebar, action: \.sidebar)
+            ) {
+                store.send(.openSettings)
+            }
             .scrollContentBackground(.hidden)
             .background(palette.bg2)
             .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 320)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryFeature.swift
@@ -7,6 +7,7 @@ public struct LibraryFeature {
 
     @ObservableState
     public struct State: Equatable {
+        // swiftlint:disable:next prefer_let_over_var
         public var items: [SavedItem] = []
         public var query = ""
         public var sourceURL = ""
@@ -18,7 +19,7 @@ public struct LibraryFeature {
         public var filter: LibraryFilter = .all
         /// All tags known to the repository — drives the "Tags" submenu in the
         /// library row context menu. Refreshed lazily via observeLibraryChanges.
-        public var availableTags: [Tag] = []
+        public var availableTags: [Tag] = [] // swiftlint:disable:this prefer_let_over_var
 
         /// Library search matches against title, URL, site name, author,
         /// excerpt, AND full body text (`item.content`). The body-text
@@ -30,14 +31,28 @@ public struct LibraryFeature {
         /// library window, which is fine at typical library sizes; a
         /// future optimization could push this into a SQLite FTS5 index.
         public var filteredItems: [SavedItem] {
-            guard !query.isEmpty else { return items }
+            guard !query.isEmpty else {
+                return items
+            }
             return items.filter { item in
-                if item.title.localizedStandardContains(query) { return true }
-                if let url = item.sourceURL, url.localizedStandardContains(query) { return true }
-                if let site = item.siteName, site.localizedStandardContains(query) { return true }
-                if let author = item.author, author.localizedStandardContains(query) { return true }
-                if let excerpt = item.excerpt, excerpt.localizedStandardContains(query) { return true }
-                if !item.content.isEmpty, item.content.localizedStandardContains(query) { return true }
+                if item.title.localizedStandardContains(query) {
+                    return true
+                }
+                if let url = item.sourceURL, url.localizedStandardContains(query) {
+                    return true
+                }
+                if let site = item.siteName, site.localizedStandardContains(query) {
+                    return true
+                }
+                if let author = item.author, author.localizedStandardContains(query) {
+                    return true
+                }
+                if let excerpt = item.excerpt, excerpt.localizedStandardContains(query) {
+                    return true
+                }
+                if !item.content.isEmpty, item.content.localizedStandardContains(query) {
+                    return true
+                }
                 return false
             }
         }
@@ -79,9 +94,12 @@ public struct LibraryFeature {
         case observeChanges
     }
 
-    @Dependency(\.stowerRepository) var repository
-    @Dependency(\.urlIngestionClient) var ingestionClient
-    @Dependency(\.pdfIngestionClient) var pdfIngestionClient
+    @Dependency(\.stowerRepository)
+    var repository
+    @Dependency(\.urlIngestionClient)
+    var ingestionClient
+    @Dependency(\.pdfIngestionClient)
+    var pdfIngestionClient
 
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -121,7 +139,7 @@ public struct LibraryFeature {
                 state.availableTags = tags
                 return .none
 
-            case .toggleTagOnItem(let itemID, let tagID):
+            case let .toggleTagOnItem(itemID, tagID):
                 guard let idx = state.items.firstIndex(where: { $0.id == itemID }) else {
                     return .none
                 }
@@ -450,12 +468,19 @@ private func normalizeSourceURL(_ value: String) -> String? {
 /// whether newly-saved items should be pre-inserted at the top of the list.
 private func shouldShowInFilter(_ item: SavedItem, filter: LibraryFilter) -> Bool {
     switch filter {
-    case .all: return item.deletedAt == nil
-    case .unread: return item.deletedAt == nil && !item.isRead
-    case .read: return item.deletedAt == nil && item.isRead
-    case .starred: return item.deletedAt == nil && item.isStarred
-    case .untagged: return item.deletedAt == nil && item.tagIDs.isEmpty
-    case .recentlyDeleted: return item.deletedAt != nil
-    case .tag(let id): return item.deletedAt == nil && item.tagIDs.contains(id)
+    case .all:
+        return item.deletedAt == nil
+    case .unread:
+        return item.deletedAt == nil && !item.isRead
+    case .read:
+        return item.deletedAt == nil && item.isRead
+    case .starred:
+        return item.deletedAt == nil && item.isStarred
+    case .untagged:
+        return item.deletedAt == nil && item.tagIDs.isEmpty
+    case .recentlyDeleted:
+        return item.deletedAt != nil
+    case let .tag(id):
+        return item.deletedAt == nil && item.tagIDs.contains(id)
     }
 }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
@@ -216,7 +216,7 @@ public struct LibraryScreen: View {
             }
         }
         .scrollContentBackground(.hidden)
-        // Obscure rows as they scroll behind the Liquid Glass nav bar so
+        // Obscure rows as they scroll beneath the Liquid Glass nav bar so
         // the first row stays legible against the glass material.
         .scrollEdgeEffectStyle(.soft, for: .top)
         .navigationTitle(navigationTitle)
@@ -452,7 +452,7 @@ public struct LibraryScreen: View {
                 .padding(.vertical, 7)
                 // Liquid Glass input chip — the composer floats above the
                 // library list as frosted glass, refracting whatever rows
-                // sit behind it instead of the old flat 6% opacity fill.
+                // sit beneath it instead of the old flat 6% opacity fill.
                 .glassEffect(.regular, in: .rect(cornerRadius: 6))
                 .onSubmit { store.send(.saveURLTapped) }
 
@@ -502,7 +502,7 @@ public struct LibraryScreen: View {
             // Liquid Glass pill. The semantic state color becomes the
             // tint on the glass capsule so warning / error / extracting
             // still read at a glance over a scrolling list, while the
-            // capsule itself refracts the row content behind it.
+            // capsule itself refracts the row content beneath it.
             .glassEffect(.regular.tint(badgeBackground(state)), in: .capsule)
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
@@ -10,8 +10,10 @@ import AppKit
 
 public struct LibraryScreen: View {
     @Bindable var store: StoreOf<LibraryFeature>
-    @Environment(\.flexokiPalette) private var palette
-    @Environment(\.openURL) private var openURL
+    @Environment(\.flexokiPalette)
+    private var palette
+    @Environment(\.openURL)
+    private var openURL
     /// Invoked when the user taps the settings gear in the iOS toolbar.
     /// nil on macOS (the sidebar already has its own settings button).
     private let onOpenSettings: (() -> Void)?
@@ -341,8 +343,7 @@ public struct LibraryScreen: View {
 
     #if os(iOS)
     /// Modal URL-entry form shown when the user taps the toolbar "+".
-    @ViewBuilder
-    private var addURLSheet: some View {
+    @ViewBuilder private var addURLSheet: some View {
         NavigationStack {
             Form {
                 Section {
@@ -418,19 +419,24 @@ public struct LibraryScreen: View {
 
     private var navigationTitle: String {
         switch store.filter {
-        case .all: return "All"
-        case .unread: return "Unread"
-        case .read: return "Read"
-        case .starred: return "Starred"
-        case .untagged: return "Untagged"
-        case .recentlyDeleted: return "Recently Deleted"
-        case .tag(let id):
-            return store.availableTags.first(where: { $0.id == id })?.name ?? "Tag"
+        case .all:
+            return "All"
+        case .unread:
+            return "Unread"
+        case .read:
+            return "Read"
+        case .starred:
+            return "Starred"
+        case .untagged:
+            return "Untagged"
+        case .recentlyDeleted:
+            return "Recently Deleted"
+        case let .tag(id):
+            return store.availableTags.first { $0.id == id }?.name ?? "Tag"
         }
     }
 
-    @ViewBuilder
-    private var urlComposer: some View {
+    @ViewBuilder private var urlComposer: some View {
         HStack(spacing: 10) {
             TextField("Paste Source URL", text: $store.sourceURL.sending(\.sourceURLChanged))
                 .autocorrectionDisabled()
@@ -480,8 +486,10 @@ public struct LibraryScreen: View {
     /// the other.
     private func shouldShowBadge(for state: ProcessingState) -> Bool {
         switch state {
-        case .ready, .queued: return false
-        case .extracting, .partial, .failed: return true
+        case .ready, .queued:
+            return false
+        case .extracting, .partial, .failed:
+            return true
         }
     }
 
@@ -500,21 +508,31 @@ public struct LibraryScreen: View {
 
     private func badgeBackground(_ state: ProcessingState) -> Color {
         switch state {
-        case .ready: return palette.success.opacity(0.16)
-        case .partial: return palette.warning.opacity(0.16)
-        case .failed: return palette.error.opacity(0.16)
-        case .extracting: return palette.info.opacity(0.16)
-        case .queued: return palette.tx3.opacity(0.16)
+        case .ready:
+            return palette.success.opacity(0.16)
+        case .partial:
+            return palette.warning.opacity(0.16)
+        case .failed:
+            return palette.error.opacity(0.16)
+        case .extracting:
+            return palette.info.opacity(0.16)
+        case .queued:
+            return palette.tx3.opacity(0.16)
         }
     }
 
     private func badgeForeground(_ state: ProcessingState) -> Color {
         switch state {
-        case .ready: return palette.success
-        case .partial: return palette.warning
-        case .failed: return palette.error
-        case .extracting: return palette.info
-        case .queued: return palette.tx2
+        case .ready:
+            return palette.success
+        case .partial:
+            return palette.warning
+        case .failed:
+            return palette.error
+        case .extracting:
+            return palette.info
+        case .queued:
+            return palette.tx2
         }
     }
 }
@@ -566,6 +584,7 @@ private struct LibraryItemThumbnail: View {
             Image(systemName: "doc.text")
                 .font(.title2)
                 .foregroundStyle(.secondary.opacity(0.45))
+                .accessibilityLabel("Document placeholder")
         }
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/PDFReaderSheet.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/PDFReaderSheet.swift
@@ -89,6 +89,8 @@ struct PDFReaderSheet: View {
             Image(systemName: "icloud.slash")
                 .font(.system(size: 48, weight: .regular))
                 .foregroundStyle(.secondary)
+                .accessibilityLabel("PDF not available")
+            // swiftlint:disable:next no_hardcoded_strings
             Text("Original PDF not available")
                 .font(.headline)
             Text("This PDF was shared from another device. The extracted text is synced to this device, but the original PDF file isn't. Re-share the PDF on this device to restore the original view.")

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAIControls.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAIControls.swift
@@ -15,7 +15,8 @@ import SwiftUI
 /// with a per-reason explanation instead of the tabs.
 struct ReaderAIControls: View {
     @Bindable var store: StoreOf<ReaderAIFeature>
-    @Environment(\.flexokiPalette) private var palette
+    @Environment(\.flexokiPalette)
+    private var palette
     let document: ReaderDocument?
     let plainText: String
 
@@ -30,11 +31,11 @@ struct ReaderAIControls: View {
 
     // MARK: - Header
 
-    @ViewBuilder
-    private var header: some View {
+    @ViewBuilder private var header: some View {
         HStack {
             Image(systemName: "sparkles")
                 .foregroundStyle(.secondary)
+                .accessibilityLabel("AI")
             Picker("Mode", selection: $store.mode.sending(\.modeChanged)) {
                 Text("Summary").tag(ReaderAIFeature.State.Mode.summary)
                 Text("Ask").tag(ReaderAIFeature.State.Mode.ask)
@@ -47,8 +48,7 @@ struct ReaderAIControls: View {
 
     // MARK: - Content routing
 
-    @ViewBuilder
-    private var content: some View {
+    @ViewBuilder private var content: some View {
         switch store.availability {
         case .available:
             switch store.mode {
@@ -96,8 +96,7 @@ struct ReaderAIControls: View {
 
     // MARK: - Summary tab
 
-    @ViewBuilder
-    private var summaryTab: some View {
+    @ViewBuilder private var summaryTab: some View {
         VStack(alignment: .leading, spacing: 12) {
             if !store.summaryText.isEmpty {
                 ScrollView {
@@ -140,6 +139,7 @@ struct ReaderAIControls: View {
                     Button {
                         store.send(.summarizeRequested(document: document, plainText: plainText))
                     } label: {
+                        // swiftlint:disable:next no_hardcoded_strings
                         Label("Summarize this article", systemImage: "sparkles")
                             .frame(maxWidth: .infinity)
                     }
@@ -158,8 +158,7 @@ struct ReaderAIControls: View {
         }
     }
 
-    @ViewBuilder
-    private var summaryFootnote: some View {
+    @ViewBuilder private var summaryFootnote: some View {
         if store.summaryWasCached, let date = store.summaryGeneratedAt {
             Text("Cached \(relativeDateText(date))")
                 .font(.caption2)
@@ -181,8 +180,7 @@ struct ReaderAIControls: View {
 
     // MARK: - Ask tab
 
-    @ViewBuilder
-    private var askTab: some View {
+    @ViewBuilder private var askTab: some View {
         VStack(alignment: .leading, spacing: 12) {
             if store.transcript.isEmpty && store.pendingAnswer.isEmpty && !store.isAnswering {
                 VStack(alignment: .leading, spacing: 8) {
@@ -234,6 +232,7 @@ struct ReaderAIControls: View {
                     submitQuestion()
                 } label: {
                     Image(systemName: "paperplane.fill")
+                        .accessibilityLabel("Send")
                 }
                 .buttonStyle(.borderedProminent)
                 .disabled(store.isAnswering || store.question.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || plainText.isEmpty)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAIFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAIFeature.swift
@@ -35,14 +35,16 @@ public struct ReaderAIFeature {
         // MARK: Ask tab
         public var question: String = ""
         public var pendingAnswer: String = ""
+        // swiftlint:disable:next prefer_let_over_var
         public var transcript: [QAEntry] = []
         public var isAnswering = false
         public var isRetrieving = false
         public var askError: String?
 
+        // swiftlint:disable:next explicit_enum_raw_value
         public enum Mode: String, Equatable, Sendable {
-            case summary
-            case ask
+            case summary // swiftlint:disable:this explicit_enum_raw_value
+            case ask // swiftlint:disable:this explicit_enum_raw_value
         }
 
         public struct QAEntry: Equatable, Identifiable, Sendable {
@@ -50,7 +52,7 @@ public struct ReaderAIFeature {
             public let question: String
             public let answer: String
 
-            public init(id: UUID = UUID(), question: String, answer: String) {
+            public init(question: String, answer: String, id: UUID = UUID()) {
                 self.id = id
                 self.question = question
                 self.answer = answer
@@ -88,8 +90,10 @@ public struct ReaderAIFeature {
         case ask
     }
 
-    @Dependency(\.stowerRepository) var repository
-    @Dependency(\.articleAIClient) var ai
+    @Dependency(\.stowerRepository)
+    var repository
+    @Dependency(\.articleAIClient)
+    var ai
 
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -105,7 +109,7 @@ public struct ReaderAIFeature {
                     await send(.cacheLoaded(text: cached?.text, generatedAt: cached?.generatedAt))
                 }
 
-            case .cacheLoaded(let text, let generatedAt):
+            case let .cacheLoaded(text, generatedAt):
                 if let text, !text.isEmpty {
                     state.summaryText = text
                     state.summaryGeneratedAt = generatedAt
@@ -117,7 +121,7 @@ public struct ReaderAIFeature {
                 state.mode = mode
                 return .none
 
-            case .summarizeRequested(let document, let plainText):
+            case let .summarizeRequested(document, plainText):
                 guard state.availability == .available else {
                     return .none
                 }
@@ -195,7 +199,7 @@ public struct ReaderAIFeature {
                 state.question = text
                 return .none
 
-            case .askSubmitted(let document, let plainText):
+            case let .askSubmitted(document, plainText):
                 guard state.availability == .available else { return .none }
                 let trimmed = state.question.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !trimmed.isEmpty else { return .none }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAppearanceControls.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAppearanceControls.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import StowerData
+import SwiftUI
 
 struct ReaderAppearanceControls: View {
     let appearance: ReaderAppearanceSettings
@@ -87,8 +87,7 @@ struct ReaderAppearanceControls: View {
 
     // MARK: - Swatch sections
 
-    @ViewBuilder
-    private var backgroundSection: some View {
+    @ViewBuilder private var backgroundSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             controlTitle("Background", value: appearance.background.displayName)
             HStack(spacing: 12) {
@@ -106,8 +105,7 @@ struct ReaderAppearanceControls: View {
         }
     }
 
-    @ViewBuilder
-    private var primaryAccentSection: some View {
+    @ViewBuilder private var primaryAccentSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             controlTitle("Primary Accent", value: appearance.primaryAccent.displayName)
             AccentSwatchRow(
@@ -120,8 +118,7 @@ struct ReaderAppearanceControls: View {
         }
     }
 
-    @ViewBuilder
-    private var secondaryAccentSection: some View {
+    @ViewBuilder private var secondaryAccentSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             controlTitle("Secondary Accent", value: appearance.secondaryAccent.displayName)
             AccentSwatchRow(

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAppearanceSettings+Theme.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAppearanceSettings+Theme.swift
@@ -8,8 +8,8 @@ import AppKit
 public typealias PlatformFont = NSFont
 public typealias PlatformColor = NSColor
 #endif
-import SwiftUI
 import StowerData
+import SwiftUI
 
 extension ReaderAppearanceSettings {
     public var bodyFont: Font {
@@ -48,18 +48,25 @@ extension ReaderAppearanceSettings {
 
     public var familyName: String {
         switch fontStyle {
-        case .newYork: return "NewYork"
-        case .timesNewRoman: return "Times New Roman"
-        case .helveticaNeue: return "Helvetica Neue"
-        case .avenirNext: return "Avenir Next"
-        case .menlo: return "Menlo"
+        case .newYork:
+            return "NewYork"
+        case .timesNewRoman:
+            return "Times New Roman"
+        case .helveticaNeue:
+            return "Helvetica Neue"
+        case .avenirNext:
+            return "Avenir Next"
+        case .menlo:
+            return "Menlo"
         }
     }
 
     public var textAlignment: TextAlignment {
         switch justification {
-        case .leading: return .leading
-        case .justified: return .leading
+        case .leading:
+            return .leading
+        case .justified:
+            return .leading
         }
     }
 
@@ -80,11 +87,16 @@ extension ReaderAppearanceSettings {
 
     var italicFamilyName: String {
         switch fontStyle {
-        case .newYork: return "NewYork-Italic"
-        case .timesNewRoman: return "Times New Roman Italic"
-        case .helveticaNeue: return "HelveticaNeue-Italic"
-        case .avenirNext: return "AvenirNext-Italic"
-        case .menlo: return "Menlo-Italic"
+        case .newYork:
+            return "NewYork-Italic"
+        case .timesNewRoman:
+            return "Times New Roman Italic"
+        case .helveticaNeue:
+            return "HelveticaNeue-Italic"
+        case .avenirNext:
+            return "AvenirNext-Italic"
+        case .menlo:
+            return "Menlo-Italic"
         }
     }
 
@@ -101,10 +113,14 @@ extension ReaderAppearanceSettings {
         case .heading(let level):
             let multiplier: Double
             switch level {
-            case 1: multiplier = 2.05
-            case 2: multiplier = 1.65
-            case 3: multiplier = 1.4
-            default: multiplier = 1.2
+            case 1:
+                multiplier = 2.05
+            case 2:
+                multiplier = 1.65
+            case 3:
+                multiplier = 1.4
+            default:
+                multiplier = 1.2
             }
             size = max(baseSize * multiplier, 14)
         }
@@ -118,13 +134,17 @@ extension ReaderAppearanceSettings {
     public func platformTextColor(for role: ReaderInlineTextRole) -> PlatformColor {
         #if canImport(UIKit)
         switch role {
-        case .blockquote: return UIColor(secondaryTextColor)
-        case .body, .list, .heading: return UIColor(primaryTextColor)
+        case .blockquote:
+            return UIColor(secondaryTextColor)
+        case .body, .list, .heading:
+            return UIColor(primaryTextColor)
         }
         #elseif canImport(AppKit)
         switch role {
-        case .blockquote: return NSColor(secondaryTextColor)
-        case .body, .list, .heading: return NSColor(primaryTextColor)
+        case .blockquote:
+            return NSColor(secondaryTextColor)
+        case .body, .list, .heading:
+            return NSColor(primaryTextColor)
         }
         #endif
     }
@@ -194,11 +214,16 @@ extension ReaderAppearanceSettings {
 
     private var cssFont: String {
         switch fontStyle {
-        case .newYork: return "'New York'"
-        case .timesNewRoman: return "'Times New Roman'"
-        case .helveticaNeue: return "'Helvetica Neue'"
-        case .avenirNext: return "'Avenir Next'"
-        case .menlo: return "Menlo"
+        case .newYork:
+            return "'New York'"
+        case .timesNewRoman:
+            return "'Times New Roman'"
+        case .helveticaNeue:
+            return "'Helvetica Neue'"
+        case .avenirNext:
+            return "'Avenir Next'"
+        case .menlo:
+            return "Menlo"
         }
     }
 }
@@ -212,8 +237,10 @@ public enum ReaderInlineTextRole: Equatable {
 
     public var isItalic: Bool {
         switch self {
-        case .blockquote: return true
-        case .body, .list, .heading: return false
+        case .blockquote:
+            return true
+        case .body, .list, .heading:
+            return false
         }
     }
 }
@@ -221,8 +248,10 @@ public enum ReaderInlineTextRole: Equatable {
 extension ReaderJustification {
     public var displayName: String {
         switch self {
-        case .leading: return "Left"
-        case .justified: return "Justified"
+        case .leading:
+            return "Left"
+        case .justified:
+            return "Justified"
         }
     }
 }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderDocumentHTMLBuilder.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderDocumentHTMLBuilder.swift
@@ -23,7 +23,6 @@ import AppKit
 /// This is a pure function — no dependencies on the filesystem, database,
 /// or main actor. Safe to call off the main thread.
 public enum ReaderDocumentHTMLBuilder {
-
     public static func buildReaderHTML(
         item: SavedItem,
         document: ReaderDocument,
@@ -94,9 +93,13 @@ public enum ReaderDocumentHTMLBuilder {
     /// i.e. the reader's visible content is entirely non-textual.
     /// Currently only PDF items produce this shape.
     private static func documentHasOnlyFigureBlocks(_ document: ReaderDocument) -> Bool {
-        guard !document.blocks.isEmpty else { return false }
+        guard !document.blocks.isEmpty else {
+            return false
+        }
         return document.blocks.allSatisfy { block in
-            if case .figure = block { return true }
+            if case .figure = block {
+                return true
+            }
             return false
         }
     }
@@ -124,6 +127,7 @@ public enum ReaderDocumentHTMLBuilder {
 
         html += "  <h1 class=\"stower-title\">\(escapeHTML(item.title))</h1>\n"
 
+        // swiftlint:disable:next prefer_let_over_var
         var metaPieces: [String] = []
         if let siteName = item.siteName, !siteName.isEmpty {
             metaPieces.append("<span class=\"stower-site\">\(escapeHTML(siteName))</span>")
@@ -155,11 +159,11 @@ public enum ReaderDocumentHTMLBuilder {
         case .paragraph(let inlines):
             return "<p \(idAttr)>\(renderInlines(inlines))</p>"
 
-        case .heading(let level, let inlines):
+        case let .heading(level, inlines):
             let clamped = min(max(level, 1), 6)
             return "<h\(clamped) \(idAttr)>\(renderInlines(inlines))</h\(clamped)>"
 
-        case .list(let ordered, let items):
+        case let .list(ordered, items):
             let tag = ordered ? "ol" : "ul"
             var out = "<\(tag) \(idAttr)>"
             for item in items {
@@ -171,7 +175,7 @@ public enum ReaderDocumentHTMLBuilder {
         case .blockquote(let inlines):
             return "<blockquote \(idAttr)><p>\(renderInlines(inlines))</p></blockquote>"
 
-        case .code(let language, let code):
+        case let .code(language, code):
             let langAttr: String
             if let language, !language.isEmpty {
                 langAttr = " class=\"language-\(attrEscape(language))\""
@@ -195,7 +199,7 @@ public enum ReaderDocumentHTMLBuilder {
         case .horizontalRule:
             return "<hr \(idAttr)>"
 
-        case .callout(let title, let inlines):
+        case let .callout(title, inlines):
             var out = "<aside class=\"stower-callout\" \(idAttr)>"
             if let title, !title.isEmpty {
                 out += "<h4>\(escapeHTML(title))</h4>"
@@ -389,7 +393,7 @@ public enum ReaderDocumentHTMLBuilder {
             case .text(let value):
                 out += escapeHTML(value)
 
-            case .link(let label, let url):
+            case let .link(label, url):
                 if isSafeLinkURL(url) {
                     out += "<a href=\"\(attrEscape(url))\" target=\"_blank\" rel=\"noopener noreferrer\">\(escapeHTML(label))</a>"
                 } else {
@@ -450,7 +454,9 @@ public enum ReaderDocumentHTMLBuilder {
 
     /// Allow only http(s), mailto, and fragment-local URLs for inline links.
     private static func isSafeLinkURL(_ url: String) -> Bool {
-        if url.hasPrefix("#") { return true }
+        if url.hasPrefix("#") {
+            return true
+        }
         guard let parsed = URL(string: url), let scheme = parsed.scheme?.lowercased() else {
             return false
         }
@@ -465,12 +471,18 @@ public enum ReaderDocumentHTMLBuilder {
         result.reserveCapacity(s.count)
         for scalar in s.unicodeScalars {
             switch scalar {
-            case "&": result += "&amp;"
-            case "<": result += "&lt;"
-            case ">": result += "&gt;"
-            case "\"": result += "&quot;"
-            case "'": result += "&#39;"
-            default: result.unicodeScalars.append(scalar)
+            case "&":
+                result += "&amp;"
+            case "<":
+                result += "&lt;"
+            case ">":
+                result += "&gt;"
+            case "\"":
+                result += "&quot;"
+            case "'":
+                result += "&#39;"
+            default:
+                result.unicodeScalars.append(scalar)
             }
         }
         return result

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderFeature.swift
@@ -32,8 +32,12 @@ public struct ReaderFeature {
         ///    the case) silently broke every interactive-SVG page.
         /// 3. `.structuredV1` if the item hasn't loaded yet.
         public var effectiveRenderFormat: RenderFormat {
-            if let renderModeOverride { return renderModeOverride }
-            if let item { return item.renderFormat }
+            if let renderModeOverride {
+                return renderModeOverride
+            }
+            if let item {
+                return item.renderFormat
+            }
             return .structuredV1
         }
 
@@ -97,10 +101,14 @@ public struct ReaderFeature {
         case progressPoll
     }
 
-    @Dependency(\.stowerRepository) var repository
-    @Dependency(\.urlIngestionClient) var ingestionClient
-    @Dependency(\.continuousClock) var continuousClock
-    @Dependency(\.readerProgressClient) var readerProgressClient
+    @Dependency(\.stowerRepository)
+    var repository
+    @Dependency(\.urlIngestionClient)
+    var ingestionClient
+    @Dependency(\.continuousClock)
+    var continuousClock
+    @Dependency(\.readerProgressClient)
+    var readerProgressClient
 
     public var body: some ReducerOf<Self> {
         Scope(state: \.speech, action: \.speech) {
@@ -146,7 +154,7 @@ public struct ReaderFeature {
                     }
                 )
 
-            case .loaded(let item, let document, let sourceHTML):
+            case let .loaded(item, document, sourceHTML):
                 state.isLoading = false
                 if let item { state.item = item }
                 state.document = document
@@ -405,9 +413,13 @@ public struct ReaderFeature {
             var lastReported: Int?
             while !Task.isCancelled {
                 try? await clock.sleep(for: .seconds(1.5))
-                if Task.isCancelled { return }
+                if Task.isCancelled {
+                    return
+                }
                 guard let top = await client.topBlockIndex() else { continue }
-                if Task.isCancelled { return }
+                if Task.isCancelled {
+                    return
+                }
                 if top != lastReported {
                     lastReported = top
                     await send(.scrollProgressChanged(top), animation: nil)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderListenControls.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderListenControls.swift
@@ -7,7 +7,8 @@ import UIKit
 // Rendered as the contents of a popover anchored to the Reader toolbar's Listen
 // button. Kept in its own file to keep ReaderScreen type-check times under control.
 struct ReaderListenControls: View {
-    @Environment(\.flexokiPalette) private var palette
+    @Environment(\.flexokiPalette)
+    private var palette
     let speech: ReaderSpeechFeature.State
     let speechBlocks: [SpeechBlock]
     let onListen: () -> Void
@@ -19,7 +20,7 @@ struct ReaderListenControls: View {
     let onRateChanged: (Float) -> Void
     let onVoiceChanged: (String?) -> Void
 
-    @State private var catalog: ReaderSpeechVoiceCatalog.Catalog = ReaderSpeechVoiceCatalog.Catalog(
+    @State private var catalog = ReaderSpeechVoiceCatalog.Catalog(
         preferredGroups: [],
         otherGroups: [],
         onlyDefaultQualityForPreferred: false
@@ -68,8 +69,7 @@ struct ReaderListenControls: View {
         return current >= last
     }
 
-    @ViewBuilder
-    private var playbackRow: some View {
+    @ViewBuilder private var playbackRow: some View {
         HStack(spacing: 10) {
             if speech.isSpeaking {
                 Button(action: onSkipBackward) {
@@ -144,8 +144,7 @@ struct ReaderListenControls: View {
         )
     }
 
-    @ViewBuilder
-    private var speedSection: some View {
+    @ViewBuilder private var speedSection: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text("Speed")
                 .font(.caption)
@@ -166,13 +165,12 @@ struct ReaderListenControls: View {
     /// a value that's no longer in the bucket list.
     private func roundedSpeedBucket(for rate: Float) -> Float {
         let buckets: [Float] = [0.8, 1.0, 1.2, 1.5]
-        return buckets.min(by: { abs($0 - rate) < abs($1 - rate) }) ?? 1.0
+        return buckets.min { abs($0 - rate) < abs($1 - rate) } ?? 1.0
     }
 
     // MARK: - Voice
 
-    @ViewBuilder
-    private var voiceSection: some View {
+    @ViewBuilder private var voiceSection: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text("Voice")
                 .font(.caption)
@@ -183,6 +181,7 @@ struct ReaderListenControls: View {
                 HStack(spacing: 8) {
                     Image(systemName: "waveform")
                         .foregroundStyle(.secondary)
+                        .accessibilityLabel("Voice")
                     Text(currentVoiceLabel)
                         .lineLimit(1)
                         .foregroundStyle(.primary)
@@ -190,6 +189,7 @@ struct ReaderListenControls: View {
                     Image(systemName: "chevron.up.chevron.down")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 10)
@@ -201,8 +201,7 @@ struct ReaderListenControls: View {
         }
     }
 
-    @ViewBuilder
-    private var voiceMenuContents: some View {
+    @ViewBuilder private var voiceMenuContents: some View {
         Button("Automatic") { onVoiceChanged(nil) }
         Divider()
         ForEach(catalog.preferredGroups) { group in
@@ -229,14 +228,13 @@ struct ReaderListenControls: View {
     private var currentVoiceLabel: String {
         guard let id = speech.selectedVoiceID else { return "Automatic" }
         let all = catalog.preferredGroups.flatMap(\.voices) + catalog.otherGroups.flatMap(\.voices)
-        return all.first(where: { $0.id == id })?.displayName ?? "Automatic"
+        return all.first { $0.id == id }?.displayName ?? "Automatic"
     }
 
     // MARK: - Download voices footer
 
     #if os(iOS)
-    @ViewBuilder
-    private var downloadVoicesRow: some View {
+    @ViewBuilder private var downloadVoicesRow: some View {
         Button {
             openVoiceSettings()
         } label: {
@@ -258,8 +256,7 @@ struct ReaderListenControls: View {
 
     // MARK: - Footer messages
 
-    @ViewBuilder
-    private var footerMessages: some View {
+    @ViewBuilder private var footerMessages: some View {
         if let error = speech.errorMessage {
             Text(error)
                 .font(.caption)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderProgressClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderProgressClient.swift
@@ -56,13 +56,11 @@ public struct ReaderProgressClient: Sendable {
 }
 
 extension ReaderProgressClient {
-    public static let live = Self(
-        topBlockIndex: {
-            await ReaderProgressCoordinator.shared.topBlockIndex()
-        }
-    )
+    public static let live = Self {
+        await ReaderProgressCoordinator.shared.topBlockIndex()
+    }
 
-    public static let noop = Self(topBlockIndex: { nil })
+    public static let noop = Self { nil }
 }
 
 // MARK: - Dependency registration

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
@@ -128,16 +128,16 @@ public struct ReaderScreen: View {
             .sheet(isPresented: $isPDFViewerPresented) {
                 PDFReaderSheet(
                     itemID: store.itemID,
-                    title: store.item?.title ?? "PDF",
-                    onDismiss: { isPDFViewerPresented = false }
-                )
+                    title: store.item?.title ?? "PDF"
+                ) {
+                    isPDFViewerPresented = false
+                }
             }
     }
 
     // MARK: - Content
 
-    @ViewBuilder
-    private var content: some View {
+    @ViewBuilder private var content: some View {
         if let item = store.item, let resolvedHTML = resolvedHTML(for: item) {
             ReaderWebView(
                 html: resolvedHTML,
@@ -146,9 +146,10 @@ public struct ReaderScreen: View {
                 appearance: store.appearance,
                 isWebViewFormat: store.effectiveRenderFormat == .webView,
                 highlightedBlockIndex: store.speech.currentBlockIndex,
-                restoreBlockIndex: item.lastReadBlockIndex,
-                onOpenInlineEmbed: { urlString in store.send(.openInlineWebEmbed(urlString)) }
-            )
+                restoreBlockIndex: item.lastReadBlockIndex
+            ) { urlString in
+                store.send(.openInlineWebEmbed(urlString))
+            }
         } else if let item = store.item, item.content.isEmpty {
             downloadPrompt(item: item)
         } else if store.isLoading {
@@ -171,8 +172,7 @@ public struct ReaderScreen: View {
     ///
     /// Label + icon reflect the destination, not the current mode, so the
     /// user can always read it as "this is what I'm about to get".
-    @ViewBuilder
-    private var switchModeButton: some View {
+    @ViewBuilder private var switchModeButton: some View {
         let isCurrentlyInteractive = store.effectiveRenderFormat == .webView
         let nextMode: RenderFormat = isCurrentlyInteractive ? .structuredV1 : .webView
         Button {
@@ -241,8 +241,7 @@ public struct ReaderScreen: View {
 // MARK: - Listen toolbar button
 
 extension ReaderScreen {
-    @ViewBuilder
-    fileprivate var listenToolbarButton: some View {
+    @ViewBuilder private var listenToolbarButton: some View {
         let isActive = store.speech.isSpeaking && !store.speech.isPaused
         Button {
             isListenPanelPresented.toggle()
@@ -265,15 +264,14 @@ extension ReaderScreen {
         }
     }
 
-    fileprivate var listenButtonSymbol: String {
+    private var listenButtonSymbol: String {
         if store.speech.isSpeaking {
             return store.speech.isPaused ? "speaker.slash" : "speaker.wave.2.fill"
         }
         return "speaker.wave.2"
     }
 
-    @ViewBuilder
-    fileprivate var listenPanelContent: some View {
+    @ViewBuilder private var listenPanelContent: some View {
         // Start from block-level speech output (one unit per paragraph /
         // heading / list / etc.) and then expand each block into
         // sentence-level units so the Listen skip buttons move by
@@ -304,8 +302,7 @@ extension ReaderScreen {
 // MARK: - AI toolbar button
 
 extension ReaderScreen {
-    @ViewBuilder
-    fileprivate var aiToolbarButton: some View {
+    @ViewBuilder private var aiToolbarButton: some View {
         let isActive = store.ai.isSummarizing || store.ai.isAnswering
         Button {
             isAIPanelPresented.toggle()
@@ -337,7 +334,7 @@ extension ReaderScreen {
         }
     }
 
-    fileprivate var aiButtonSymbol: String {
+    private var aiButtonSymbol: String {
         if store.ai.isSummarizing || store.ai.isAnswering {
             return "sparkles.rectangle.stack"
         }
@@ -350,7 +347,7 @@ extension ReaderScreen {
     /// be empty for articles that were ingested without persisting a
     /// plain-text copy (webView items, older ingestions). Falls back to
     /// `item.content` so plain-text notes still work.
-    fileprivate var resolvedAIPlainText: String {
+    private var resolvedAIPlainText: String {
         if let document = store.document {
             let blocks = ReaderSpeechTextBuilder.speechBlocks(document: document)
             if !blocks.isEmpty {

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderSpeechFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderSpeechFeature.swift
@@ -33,7 +33,7 @@ public struct ReaderSpeechFeature {
         /// typical case, so filter operations use `sequence` for
         /// identity rather than `index` (which is non-unique across
         /// sentences of the same block).
-        var currentBlocks: [SpeechBlock] = []
+        var currentBlocks: [SpeechBlock] = [] // swiftlint:disable:this prefer_let_over_var
 
         var errorMessage: String?
     }
@@ -60,8 +60,10 @@ public struct ReaderSpeechFeature {
         case speech
     }
 
-    @Dependency(\.readerSpeechClient) var speechClient
-    @Dependency(\.readerSpeechPreferencesClient) var preferencesClient
+    @Dependency(\.readerSpeechClient)
+    var speechClient
+    @Dependency(\.readerSpeechPreferencesClient)
+    var preferencesClient
 
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -152,7 +154,7 @@ public struct ReaderSpeechFeature {
                 let reference = state.currentSequence
                     ?? state.currentBlocks.first?.sequence
                     ?? 0
-                let previous = state.currentBlocks.last(where: { $0.sequence < reference })
+                let previous = state.currentBlocks.last { $0.sequence < reference }
                 let targetSequence = previous?.sequence
                     ?? state.currentBlocks.first?.sequence
                     ?? reference
@@ -236,13 +238,13 @@ public struct ReaderSpeechFeature {
 
             case .speechEvent(let event):
                 switch event {
-                case .didStart(let blockIndex, let sequence):
+                case let .didStart(blockIndex, sequence):
                     state.currentBlockIndex = blockIndex
                     state.currentSequence = sequence
                     state.currentRangeInBlockUTF16 = nil
                     return .none
 
-                case .willSpeak(let blockIndex, let sequence, let range):
+                case let .willSpeak(blockIndex, sequence, range):
                     state.currentBlockIndex = blockIndex
                     state.currentSequence = sequence
                     state.currentRangeInBlockUTF16 = range

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebPage.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebPage.swift
@@ -48,7 +48,6 @@ struct ReaderNavigationDecider: WebPage.NavigationDeciding {
 
 /// Creates configured `WebPage` instances for the reader.
 enum ReaderWebPageFactory {
-
     /// Creates a new `WebPage` with link interception.
     /// CSS is injected directly into the HTML before loading — no WKUserScript needed.
     @MainActor

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebView.swift
@@ -28,7 +28,8 @@ public struct ReaderWebView: View {
     @State private var page: WebPage?
     @State private var archiveServer: LocalArchiveServer?
     @State private var hasRestoredPosition = false
-    @Environment(\.openURL) private var openURL
+    @Environment(\.openURL)
+    private var openURL
 
     public init(
         html: String,
@@ -208,7 +209,7 @@ public struct ReaderWebView: View {
     /// WKWebView blocks `file://` asset loads from documents loaded over
     /// HTTP — the symlinks keep the page images in the same origin as
     /// the HTML.
-    private nonisolated static func prepareStructuredServer(
+    nonisolated private static func prepareStructuredServer(
         html: String,
         itemID: UUID
     ) async -> (URL, LocalArchiveServer)? {
@@ -242,7 +243,7 @@ public struct ReaderWebView: View {
     }
 
     /// Prepares archive content off the main actor: patches HTML, injects CSS, starts server.
-    private nonisolated static func prepareArchive(
+    nonisolated private static func prepareArchive(
         html: String,
         sourceURL: String?,
         itemID: UUID,
@@ -336,5 +337,4 @@ public struct ReaderWebView: View {
             await ReaderWebPageFactory.scrollToBlock(restoreBlockIndex, on: page)
         }
     }
-
 }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsFeature.swift
@@ -27,8 +27,10 @@ public struct SettingsFeature {
         case diagnosticsLoaded(SyncDiagnostics)
     }
 
-    @Dependency(\.stowerRepository) var repository
-    @Dependency(\.syncDiagnosticsClient) var syncDiagnosticsClient
+    @Dependency(\.stowerRepository)
+    var repository
+    @Dependency(\.syncDiagnosticsClient)
+    var syncDiagnosticsClient
 
     public var body: some ReducerOf<Self> {
         Reduce { state, action in

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsScreen.swift
@@ -3,7 +3,8 @@ import SwiftUI
 
 public struct SettingsScreen: View {
     @Bindable var store: StoreOf<SettingsFeature>
-    @Environment(\.flexokiPalette) private var palette
+    @Environment(\.flexokiPalette)
+    private var palette
 
     public init(store: StoreOf<SettingsFeature>) {
         self.store = store

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Sidebar/SidebarFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Sidebar/SidebarFeature.swift
@@ -9,6 +9,7 @@ public struct SidebarFeature {
     public struct State: Equatable {
         public var selection: LibraryFilter = .all
         public var counts: LibraryListCounts = .zero
+        // swiftlint:disable:next prefer_let_over_var
         public var tags: [Tag] = []
         public var isLoading = false
         public var errorMessage: String?
@@ -55,7 +56,8 @@ public struct SidebarFeature {
         case observedChange
     }
 
-    @Dependency(\.stowerRepository) var repository
+    @Dependency(\.stowerRepository)
+    var repository
 
     enum CancelID: Hashable { case observeChanges }
 
@@ -89,7 +91,7 @@ public struct SidebarFeature {
                     }
                 }
 
-            case .loaded(let counts, let tags):
+            case let .loaded(counts, tags):
                 state.isLoading = false
                 state.counts = counts
                 state.tags = tags

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Sidebar/SidebarScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Sidebar/SidebarScreen.swift
@@ -3,13 +3,14 @@ import SwiftUI
 
 public struct SidebarScreen: View {
     @Bindable var store: StoreOf<SidebarFeature>
-    @Environment(\.flexokiPalette) private var palette
+    @Environment(\.flexokiPalette)
+    private var palette
     /// Optional hook so the parent (AppFeature) can present Settings on demand.
-    public var onOpenSettings: (() -> Void)? = nil
+    public var onOpenSettings: (() -> Void)?
     /// When non-nil, rows render as Buttons instead of NavigationLinks. Used
     /// by the iPhone filter sheet, where the sidebar is presented modally and
     /// row selection should dismiss the sheet rather than push a column.
-    public var onSelect: ((LibraryFilter) -> Void)? = nil
+    public var onSelect: ((LibraryFilter) -> Void)?
 
     public init(
         store: StoreOf<SidebarFeature>,
@@ -125,6 +126,7 @@ public struct SidebarScreen: View {
                     if store.selection == filter {
                         Image(systemName: "checkmark")
                             .foregroundStyle(palette.primary)
+                            .accessibilityLabel("Selected")
                     }
                 }
             }
@@ -168,6 +170,7 @@ public struct SidebarScreen: View {
                         if store.selection == filter {
                             Image(systemName: "checkmark")
                                 .foregroundStyle(palette.primary)
+                                .accessibilityLabel("Selected")
                         }
                     }
                 }
@@ -196,6 +199,6 @@ public struct SidebarScreen: View {
         // Color parsing is a follow-up; for now every tag uses the current
         // palette's secondary accent so tags visually contrast with the
         // primary-tinted system tint without clashing.
-        return palette.secondary
+        palette.secondary
     }
 }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Sidebar/SidebarScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Sidebar/SidebarScreen.swift
@@ -56,7 +56,7 @@ public struct SidebarScreen: View {
                 }
             }
         }
-        // Obscure list rows as they scroll behind the Liquid Glass nav
+        // Obscure list rows as they scroll beneath the Liquid Glass nav
         // bar (top) and the floating Settings footer (bottom).
         .scrollEdgeEffectStyle(.soft, for: .top)
         .scrollEdgeEffectStyle(.soft, for: .bottom)

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ArticleAIClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ArticleAIClient.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable no_sensitive_logging
 import Dependencies
 import Foundation
 import FoundationModels
@@ -130,7 +131,7 @@ extension ArticleAIClient {
     /// (summarization, Q&A) over content that isn't itself being asked
     /// to cause harm. That's exactly the transformation surface this
     /// client operates on.
-    fileprivate static let permissiveModel: SystemLanguageModel = {
+    private static let permissiveModel: SystemLanguageModel = {
         SystemLanguageModel(
             useCase: .general,
             guardrails: .permissiveContentTransformations
@@ -182,7 +183,7 @@ extension ArticleAIClient {
         )
     }()
 
-    public static let test: ArticleAIClient = ArticleAIClient(
+    public static let test = ArticleAIClient(
         availability: { .available },
         summarize: { _, _ in
             AsyncThrowingStream { continuation in
@@ -224,16 +225,23 @@ extension ArticleAIClient {
 
     // MARK: - Token budgeting
 
-    /// Split of the context window: reserve room for instructions and
-    /// response, give the rest to the input. Uses `contextSize` rather than
-    /// hard-coding 4096 so future model updates are picked up automatically.
-    ///
-    /// The reserves are deliberately generous (roughly 1/4 of a 4096 window).
-    /// The token estimator can undercount by ~25% on real articles, so the
-    /// extra headroom keeps even mis-estimated inputs from colliding with
-    /// the real context ceiling.
+    // Split of the context window: reserve room for instructions and
+    // response, give the rest to the input.
+    //
+    // The reserves are deliberately generous (roughly 1/4 of a 4096 window).
+    // The token estimator can undercount by ~25% on real articles, so the
+    // extra headroom keeps even mis-estimated inputs from colliding with
+    // the real context ceiling.
+    //
+    // Uses `SystemLanguageModel.contextSize` when available (iOS 26.4+),
+    // otherwise falls back to the known 4 096-token window.
     private static func computeInputBudget() -> Int {
-        let total = SystemLanguageModel.default.contextSize
+        let total: Int
+        if #available(iOS 26.4, macOS 26.4, *) {
+            total = SystemLanguageModel.default.contextSize
+        } else {
+            total = 4096
+        }
         let instructionsReserve = 256
         let responseReserve = 768
         return max(512, total - instructionsReserve - responseReserve)
@@ -296,6 +304,7 @@ extension ArticleAIClient {
             return
         }
 
+        // swiftlint:disable:next prefer_let_over_var
         var sectionSummaries: [String] = []
         sectionSummaries.reserveCapacity(chunks.count)
 
@@ -512,3 +521,4 @@ extension ArticleAIClient {
         continuation.yield(.finished(lastContent))
     }
 }
+// swiftlint:enable no_sensitive_logging

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ArticleAIClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ArticleAIClient.swift
@@ -233,15 +233,9 @@ extension ArticleAIClient {
     // extra headroom keeps even mis-estimated inputs from colliding with
     // the real context ceiling.
     //
-    // Uses `SystemLanguageModel.contextSize` when available (iOS 26.4+),
-    // otherwise falls back to the known 4 096-token window.
+    // Hard-codes 4096 tokens — the current on-device model window size.
     private static func computeInputBudget() -> Int {
-        let total: Int
-        if #available(iOS 26.4, macOS 26.4, *) {
-            total = SystemLanguageModel.default.contextSize
-        } else {
-            total = 4096
-        }
+        let total = 4096
         let instructionsReserve = 256
         let responseReserve = 768
         return max(512, total - instructionsReserve - responseReserve)

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ArticleChunker.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ArticleChunker.swift
@@ -1,18 +1,19 @@
+// swiftlint:disable no_sensitive_logging
 import Foundation
 import NaturalLanguage
 import StowerData
 
-/// Splits an article into chunks sized for the on-device Foundation Model's
-/// context window. Prefers splitting on block boundaries (paragraphs, headings,
-/// lists) to keep each chunk semantically coherent. Falls back to sentence-
-/// level splitting when a single block exceeds the budget.
-///
-/// Token counts are approximated at 4 characters per token for English, per
-/// Apple's TN3193. Callers that need precision can supply their own
-/// `tokenCounter` (e.g. wired to `SystemLanguageModel.tokenCount(for:)` for
-/// instructions), but the approximation is accurate enough for budgeting
-/// decisions in practice.
-public struct ArticleChunker {
+// Splits an article into chunks sized for the on-device Foundation Model's
+// context window. Prefers splitting on block boundaries (paragraphs, headings,
+// lists) to keep each chunk semantically coherent. Falls back to sentence-
+// level splitting when a single block exceeds the budget.
+//
+// Token counts are approximated at 4 characters per token for English, per
+// Apple's TN3193. Callers that need precision can supply their own
+// `tokenCounter` (e.g. wired to `SystemLanguageModel.tokenCount(for:)` for
+// instructions), but the approximation is accurate enough for budgeting
+// decisions in practice.
+public enum ArticleChunker {
     public struct Chunk: Equatable, Sendable {
         public let index: Int
         public let text: String
@@ -41,11 +42,15 @@ public struct ArticleChunker {
     ) -> [Chunk] {
         let rawBlocks = blockTexts(document: document, plainText: plainText)
         guard !rawBlocks.isEmpty else {
-            if plainText.isEmpty { return [] }
+            if plainText.isEmpty {
+                return []
+            }
             return [Chunk(index: 0, text: plainText, approxTokens: tokenCounter(plainText))]
         }
 
+        // swiftlint:disable:next prefer_let_over_var
         var chunks: [Chunk] = []
+        // swiftlint:disable:next prefer_let_over_var
         var currentBlocks: [String] = []
         var currentTokens = 0
         var chunkIndex = 0
@@ -85,13 +90,13 @@ public struct ArticleChunker {
         return chunks
     }
 
-    /// Rough token estimator. Apple's TN3193 gives 3–4 characters per token
-    /// for English; we deliberately pick the conservative end (3) because
-    /// real articles routinely tokenize worse than the optimistic end
-    /// (punctuation, URLs, inline code, numbers, emoji). Underestimating
-    /// tokens pushes borderline articles out of the single-session fast path
-    /// and into chunking, which is always recoverable — overestimating and
-    /// then throwing `exceededContextWindowSize` mid-generation is not.
+    // Rough token estimator. Apple's TN3193 gives 3-4 characters per token
+    // for English; we deliberately pick the conservative end (3) because
+    // real articles routinely tokenize worse than the optimistic end
+    // (punctuation, URLs, inline code, numbers, emoji). Underestimating
+    // tokens pushes borderline articles out of the single-session fast path
+    // and into chunking, which is always recoverable -- overestimating and
+    // then throwing `exceededContextWindowSize` mid-generation is not.
     public static func approxTokenCount(_ text: String) -> Int {
         (text.count + 2) / 3
     }
@@ -140,7 +145,9 @@ public struct ArticleChunker {
             return [Chunk(index: 0, text: text, approxTokens: tokenCounter(text))]
         }
 
+        // swiftlint:disable:next prefer_let_over_var
         var chunks: [Chunk] = []
+        // swiftlint:disable:next prefer_let_over_var
         var current: [String] = []
         var currentTokens = 0
 
@@ -168,6 +175,7 @@ public struct ArticleChunker {
     private static func splitIntoSentences(_ text: String) -> [String] {
         let tokenizer = NLTokenizer(unit: .sentence)
         tokenizer.string = text
+        // swiftlint:disable:next prefer_let_over_var
         var sentences: [String] = []
         tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) { range, _ in
             let sentence = String(text[range]).trimmingCharacters(in: .whitespacesAndNewlines)
@@ -177,3 +185,4 @@ public struct ArticleChunker {
         return sentences
     }
 }
+// swiftlint:enable no_sensitive_logging

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ArticleRetriever.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ArticleRetriever.swift
@@ -8,7 +8,7 @@ import NaturalLanguage
 /// v1 is per-question and in-memory: the embedding is computed for each
 /// chunk on every Ask call. If latency becomes a problem on very long
 /// articles, this can be cached per itemID inside the AI client.
-public struct ArticleRetriever {
+public enum ArticleRetriever {
     public static func topChunks(
         question: String,
         chunks: [ArticleChunker.Chunk],
@@ -28,6 +28,7 @@ public struct ArticleRetriever {
             return Array(chunks.prefix(k))
         }
 
+        // swiftlint:disable:next prefer_let_over_var
         var scored: [(chunk: ArticleChunker.Chunk, score: Double)] = []
         scored.reserveCapacity(chunks.count)
 
@@ -68,6 +69,7 @@ public struct ArticleRetriever {
             return nil
         }
 
+        // swiftlint:disable:next prefer_let_over_var
         var sum: [Double] = []
         var count = 0
 
@@ -98,6 +100,7 @@ public struct ArticleRetriever {
     private static func splitSentences(_ text: String) -> [String] {
         let tokenizer = NLTokenizer(unit: .sentence)
         tokenizer.string = text
+        // swiftlint:disable:next prefer_let_over_var
         var sentences: [String] = []
         tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) { range, _ in
             let sentence = String(text[range]).trimmingCharacters(in: .whitespacesAndNewlines)

--- a/StowerPackage/Sources/StowerFeatureV2/Support/AssetArchiver.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/AssetArchiver.swift
@@ -6,7 +6,6 @@ import Foundation
 /// The archive is stored at `Documents/StowerArchive/{itemID}/` with the original
 /// URL path structure preserved, so a WKURLSchemeHandler can serve them.
 enum AssetArchiver {
-
     /// Archives all assets referenced by the HTML page.
     /// Returns the set of archived file paths relative to the archive root.
     @discardableResult
@@ -52,10 +51,8 @@ enum AssetArchiver {
                 if let jsContent = try? String(contentsOf: filePath, encoding: .utf8) {
                     let jsFileURL = URL(string: "/" + asset.relativePath, relativeTo: baseURL)?.absoluteURL ?? baseURL
                     let imports = discoverJSImports(in: jsContent, baseURL: jsFileURL)
-                    for importURL in imports {
-                        if !fetched.contains(importURL.absoluteString) {
-                            nextLevel.insert(importURL)
-                        }
+                    for importURL in imports where !fetched.contains(importURL.absoluteString) {
+                        nextLevel.insert(importURL)
                     }
                 }
             }
@@ -67,10 +64,8 @@ enum AssetArchiver {
                 if let cssContent = try? String(contentsOf: filePath, encoding: .utf8) {
                     let cssFileURL = URL(string: "/" + asset.relativePath, relativeTo: baseURL)?.absoluteURL ?? baseURL
                     let refs = discoverCSSURLs(in: cssContent, baseURL: cssFileURL)
-                    for refURL in refs {
-                        if !fetched.contains(refURL.absoluteString) {
-                            nextLevel.insert(refURL)
-                        }
+                    for refURL in refs where !fetched.contains(refURL.absoluteString) {
+                        nextLevel.insert(refURL)
                     }
                 }
             }
@@ -338,6 +333,7 @@ enum AssetArchiver {
                     await fetchAndSaveOne(url: url, baseURL: baseURL, archiveDir: archiveDir, session: session)
                 }
             }
+            // swiftlint:disable:next prefer_let_over_var
             var results: [ArchivedAsset] = []
             for await asset in group {
                 if let asset { results.append(asset) }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/CachedImageView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/CachedImageView.swift
@@ -62,10 +62,12 @@ final class ImageLoader: @unchecked Sendable {
 
                 let image = try Self.makeImage(from: data, targetPixelSize: targetPixelSize)
                 guard !Task.isCancelled else { return }
-                await MainActor.run { self?.phase = .success(image) }
+                let loader = self
+                await MainActor.run { loader?.phase = .success(image) }
             } catch {
                 guard !Task.isCancelled else { return }
-                await MainActor.run { self?.phase = .failure(error) }
+                let loader = self
+                await MainActor.run { loader?.phase = .failure(error) }
             }
         }
     }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/CachedImageView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/CachedImageView.swift
@@ -102,12 +102,14 @@ final class ImageLoader: @unchecked Sendable {
         guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions as CFDictionary) else {
             return nil
         }
+        // swiftlint:disable collection_alignment
         let thumbnailOptions: [CFString: Any] = [
             kCGImageSourceCreateThumbnailFromImageAlways: true,
             kCGImageSourceShouldCacheImmediately: true,
             kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
         ]
+        // swiftlint:enable collection_alignment
         return CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions as CFDictionary)
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Support/FlexokiPalette.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/FlexokiPalette.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import StowerData
+import SwiftUI
 
 /// A fully-resolved palette of SwiftUI colors for a given
 /// `(background, primaryAccent, secondaryAccent)` triple. Every view in the
@@ -76,38 +76,38 @@ public struct FlexokiPalette: Equatable, Sendable {
         let info = FlexokiRaw.accent(.blue, isDark: base.isDark)
 
         return FlexokiPalette(
-            bg:            Color(hex: base.bg),
-            bg2:           Color(hex: base.bg2),
-            ui:            Color(hex: base.ui),
-            ui2:           Color(hex: base.ui2),
-            ui3:           Color(hex: base.ui3),
-            tx:            Color(hex: base.tx),
-            tx2:           Color(hex: base.tx2),
-            tx3:           Color(hex: base.tx3),
-            primary:       Color(hex: primary.main),
-            primaryMuted:  Color(hex: primary.muted),
-            primaryFill:   Color(hex: primary.fill),
-            primaryWash:   Color(hex: primary.wash),
-            secondary:     Color(hex: secondary.main),
+            bg: Color(hex: base.bg),
+            bg2: Color(hex: base.bg2),
+            ui: Color(hex: base.ui),
+            ui2: Color(hex: base.ui2),
+            ui3: Color(hex: base.ui3),
+            tx: Color(hex: base.tx),
+            tx2: Color(hex: base.tx2),
+            tx3: Color(hex: base.tx3),
+            primary: Color(hex: primary.main),
+            primaryMuted: Color(hex: primary.muted),
+            primaryFill: Color(hex: primary.fill),
+            primaryWash: Color(hex: primary.wash),
+            secondary: Color(hex: secondary.main),
             secondaryMuted: Color(hex: secondary.muted),
             secondaryFill: Color(hex: secondary.fill),
             secondaryWash: Color(hex: secondary.wash),
-            error:         Color(hex: error.main),
-            warning:       Color(hex: warning.main),
-            success:       Color(hex: success.main),
-            info:          Color(hex: info.main),
-            colorScheme:   base.isDark ? .dark : .light,
-            isDark:        base.isDark,
-            bgHex:         base.bg,
-            bg2Hex:        base.bg2,
-            uiHex:         base.ui,
-            txHex:         base.tx,
-            tx2Hex:        base.tx2,
-            tx3Hex:        base.tx3,
-            primaryHex:    primary.main,
+            error: Color(hex: error.main),
+            warning: Color(hex: warning.main),
+            success: Color(hex: success.main),
+            info: Color(hex: info.main),
+            colorScheme: base.isDark ? .dark : .light,
+            isDark: base.isDark,
+            bgHex: base.bg,
+            bg2Hex: base.bg2,
+            uiHex: base.ui,
+            txHex: base.tx,
+            tx2Hex: base.tx2,
+            tx3Hex: base.tx3,
+            primaryHex: primary.main,
             primaryMutedHex: primary.muted,
             primaryWashHex: primary.wash,
-            secondaryHex:  secondary.main,
+            secondaryHex: secondary.main,
             secondaryMutedHex: secondary.muted
         )
     }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/HTMLBlockParser.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/HTMLBlockParser.swift
@@ -2,9 +2,11 @@ import Foundation
 import SwiftSoup
 
 struct ParsedBlocks {
+    // swiftlint:disable prefer_let_over_var
     var blocks: [ReaderBlock]
     var media: [MediaDescriptor]
     var embeds: [EmbedDescriptor]
+    // swiftlint:enable prefer_let_over_var
 }
 
 func parseBlocks(root: Element, baseURL: URL) throws -> ParsedBlocks {
@@ -13,22 +15,26 @@ func parseBlocks(root: Element, baseURL: URL) throws -> ParsedBlocks {
         return ParsedBlocks(blocks: [], media: [], embeds: [])
     }
 
-    try body.select(
+    let toRemove = try body.select(
         "script, style, svg, canvas, template, nav, footer, header, aside, form, button, [aria-hidden=true], [hidden], .sr-only, .visually-hidden, .screen-reader-text, .sidebar, .related, .share, .comments"
-    ).remove()
+    )
+    try toRemove.remove()
 
     // Remove permalink/headerlink anchors commonly added next to headings by
     // static site generators (MkDocs, Sphinx, Hugo, Jekyll, Docusaurus, etc.).
     // These typically render as "¶" or "#" and link back to the heading's anchor.
-    try body.select(
+    let anchorLinks = try body.select(
         "a.headerlink, a.anchor, a.anchorlink, a.anchor-link, a.anchor_link, a.permalink, a.heading-link, a.heading_link, a.hash-link, a.header-link, .headerlink, .anchorjs-link"
-    ).remove()
-    try body.select("h1 > a[href^=#], h2 > a[href^=#], h3 > a[href^=#], h4 > a[href^=#], h5 > a[href^=#], h6 > a[href^=#]")
-        .remove()
+    )
+    try anchorLinks.remove()
+    let headingAnchors = try body.select("h1 > a[href^=#], h2 > a[href^=#], h3 > a[href^=#], h4 > a[href^=#], h5 > a[href^=#], h6 > a[href^=#]")
+    try headingAnchors.remove()
 
+    // swiftlint:disable prefer_let_over_var
     var blocks: [ReaderBlock] = []
     var media: [MediaDescriptor] = []
     var embeds: [EmbedDescriptor] = []
+    // swiftlint:enable prefer_let_over_var
 
     for childNode in body.getChildNodes() {
         guard let child = childNode as? Element else { continue }
@@ -66,9 +72,11 @@ func parseBlock(_ element: Element) throws -> ParsedBlocks {
 
     case "p":
         let inlines = try parseInlines(element)
+        // swiftlint:disable prefer_let_over_var
         var blocks: [ReaderBlock] = inlines.isEmpty ? [] : [.paragraph(inlines)]
         var media: [MediaDescriptor] = []
         var embeds: [EmbedDescriptor] = []
+        // swiftlint:enable prefer_let_over_var
 
         let mediaNodes = try element.select("img,picture,video,iframe,figure").array()
         for mediaNode in mediaNodes {
@@ -187,6 +195,7 @@ func parseInlines(_ element: Element) throws -> [ReaderInline] {
 /// leading space on `<span> until the user...</span>` when the span
 /// follows an `<a>` in the same paragraph).
 func parseInlinesRaw(_ element: Element) throws -> [ReaderInline] {
+    // swiftlint:disable:next prefer_let_over_var
     var inlines: [ReaderInline] = []
 
     for node in element.getChildNodes() {
@@ -267,6 +276,7 @@ func parseInlinesRaw(_ element: Element) throws -> [ReaderInline] {
 }
 
 func mergeTextInlines(_ inlines: [ReaderInline]) -> [ReaderInline] {
+    // swiftlint:disable:next prefer_let_over_var
     var merged: [ReaderInline] = []
     for inline in inlines {
         if case .text(let current) = inline,
@@ -335,7 +345,7 @@ func appendWithBoundarySpaces(
 func trimInlineEdges(_ inlines: [ReaderInline]) -> [ReaderInline] {
     var result = inlines
     if case .text(let first)? = result.first {
-        let trimmed = String(first.drop(while: { $0 == " " }))
+        let trimmed = String(first.drop { $0 == " " })
         if trimmed.isEmpty {
             result.removeFirst()
         } else {
@@ -343,7 +353,7 @@ func trimInlineEdges(_ inlines: [ReaderInline]) -> [ReaderInline] {
         }
     }
     if case .text(let last)? = result.last {
-        let trimmed = String(last.reversed().drop(while: { $0 == " " }).reversed())
+        let trimmed = String(last.reversed().drop { $0 == " " }.reversed())
         if trimmed.isEmpty {
             result.removeLast()
         } else {
@@ -354,9 +364,11 @@ func trimInlineEdges(_ inlines: [ReaderInline]) -> [ReaderInline] {
 }
 
 func parseFallbackDescendants(_ body: Element) throws -> ParsedBlocks {
+    // swiftlint:disable prefer_let_over_var
     var blocks: [ReaderBlock] = []
     var media: [MediaDescriptor] = []
     var embeds: [EmbedDescriptor] = []
+    // swiftlint:enable prefer_let_over_var
 
     let candidates = try body.select("h1,h2,h3,h4,h5,h6,p,blockquote,pre,ul,ol,img,video,iframe,figure").array()
     for element in candidates {

--- a/StowerPackage/Sources/StowerFeatureV2/Support/HTMLMediaExtractor.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/HTMLMediaExtractor.swift
@@ -4,7 +4,9 @@ import SwiftSoup
 func imageDescriptor(_ element: Element, captionHint: String?) throws -> MediaDescriptor? {
     let source = bestImageSource(element)
     guard let source else { return nil }
-    if source.lowercased().hasPrefix("data:") { return nil }
+    if source.lowercased().hasPrefix("data:") {
+        return nil
+    }
 
     let width = Int((try? element.attr("width")) ?? "")
     let height = Int((try? element.attr("height")) ?? "")
@@ -97,7 +99,9 @@ func bestImageSource(_ element: Element) -> String? {
     ]
 
     for candidate in candidates {
-        if let candidate { return candidate }
+        if let candidate {
+            return candidate
+        }
     }
     return nil
 }
@@ -138,27 +142,49 @@ func bestSourceFromSrcSet(_ element: Element) -> String? {
 
 func isLikelyAvatarImage(combined: String, width: Int?, height: Int?) -> Bool {
     let avatarTokens = ["avatar", "profile", "author-image", "headshot", "gravatar"]
-    if avatarTokens.contains(where: combined.contains) { return true }
-    if let width, let height, width <= 64, height <= 64 { return true }
-    if let width, width <= 48 { return true }
-    if let height, height <= 48 { return true }
+    if avatarTokens.contains(where: combined.contains) {
+        return true
+    }
+    if let width, let height, width <= 64, height <= 64 {
+        return true
+    }
+    if let width, width <= 48 {
+        return true
+    }
+    if let height, height <= 48 {
+        return true
+    }
     return false
 }
 
 func guessMimeType(_ urlString: String) -> String? {
     let lower = urlString.lowercased()
-    if lower.hasSuffix(".jpg") || lower.hasSuffix(".jpeg") { return "image/jpeg" }
-    if lower.hasSuffix(".png") { return "image/png" }
-    if lower.hasSuffix(".gif") { return "image/gif" }
-    if lower.hasSuffix(".webp") { return "image/webp" }
-    if lower.hasSuffix(".mp4") { return "video/mp4" }
-    if lower.hasSuffix(".m3u8") { return "application/x-mpegURL" }
+    if lower.hasSuffix(".jpg") || lower.hasSuffix(".jpeg") {
+        return "image/jpeg"
+    }
+    if lower.hasSuffix(".png") {
+        return "image/png"
+    }
+    if lower.hasSuffix(".gif") {
+        return "image/gif"
+    }
+    if lower.hasSuffix(".webp") {
+        return "image/webp"
+    }
+    if lower.hasSuffix(".mp4") {
+        return "video/mp4"
+    }
+    if lower.hasSuffix(".m3u8") {
+        return "application/x-mpegURL"
+    }
     return nil
 }
 
 func providerName(_ urlString: String) -> String {
     guard let host = URL(string: urlString)?.host else { return "Embed" }
     let parts = host.split(separator: ".")
-    if parts.count >= 2 { return parts[parts.count - 2].capitalized }
+    if parts.count >= 2 {
+        return parts[parts.count - 2].capitalized
+    }
     return host.capitalized
 }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/HTMLSanitizer.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/HTMLSanitizer.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 func sanitizeBlocks(_ input: [ReaderBlock]) -> [ReaderBlock] {
+    // swiftlint:disable:next prefer_let_over_var
     var output: [ReaderBlock] = []
 
     for block in input {
@@ -25,24 +26,37 @@ func sanitizeBlocks(_ input: [ReaderBlock]) -> [ReaderBlock] {
 
 func shouldAlwaysKeepBlock(_ block: ReaderBlock) -> Bool {
     switch block {
-    case .figure, .video, .embed, .table: return true
-    default: return false
+    case .figure, .video, .embed, .table:
+        return true
+    default:
+        return false
     }
 }
 
 func blockText(_ block: ReaderBlock) -> String {
     switch block {
-    case .paragraph(let inlines): return inlineText(inlines)
-    case .heading(_, let inlines): return inlineText(inlines)
-    case .list(_, let items): return items.map(inlineText).joined(separator: " ")
-    case .blockquote(let inlines): return inlineText(inlines)
-    case .code(_, let code): return code
-    case .figure(let media): return media.caption ?? media.altText ?? ""
-    case .video(let media): return media.caption ?? ""
-    case .embed(let embed): return embed.provider + " " + embed.embedURL
-    case .table(let markdown): return markdown
-    case .horizontalRule: return ""
-    case .callout(let title, let inlines): return (title ?? "") + " " + inlineText(inlines)
+    case .paragraph(let inlines):
+        return inlineText(inlines)
+    case .heading(_, let inlines):
+        return inlineText(inlines)
+    case .list(_, let items):
+        return items.map(inlineText).joined(separator: " ")
+    case .blockquote(let inlines):
+        return inlineText(inlines)
+    case .code(_, let code):
+        return code
+    case .figure(let media):
+        return media.caption ?? media.altText ?? ""
+    case .video(let media):
+        return media.caption ?? ""
+    case .embed(let embed):
+        return embed.provider + " " + embed.embedURL
+    case .table(let markdown):
+        return markdown
+    case .horizontalRule:
+        return ""
+    case let .callout(title, inlines):
+        return (title ?? "") + " " + inlineText(inlines)
     }
 }
 
@@ -61,20 +75,29 @@ func isLikelyBoilerplateText(_ rawText: String) -> Bool {
 
     // Long runs with zero punctuation are likely navigation menus or tag lists.
     // Raised threshold from 14 to 22 to avoid false positives on real article text.
-    if tokenCount >= 22 && punctuationCount == 0 { return true }
+    if tokenCount >= 22 && punctuationCount == 0 {
+        return true
+    }
     // High digit-to-letter ratio suggests hashes, IDs, or machine-generated text.
-    if letterCount > 0, Double(digitCount) / Double(letterCount) > 0.22, tokenCount >= 10 { return true }
+    if letterCount > 0, Double(digitCount) / Double(letterCount) > 0.22, tokenCount >= 10 {
+        return true
+    }
     // Excessive camelCase transitions suggest minified code or CSS class dumps.
-    if camelTransitions >= 6 && punctuationCount <= 1 { return true }
+    if camelTransitions >= 6 && punctuationCount <= 1 {
+        return true
+    }
     // Multiple fused word-number-word patterns (e.g. "Items47Daring") suggest dense UI counters.
     let fusedMatches = text.matches(of: /[A-Za-z]{2,}\d{1,4}[A-Za-z]{2,}/)
-    if fusedMatches.count >= 2 { return true }
+    if fusedMatches.count >= 2 {
+        return true
+    }
 
     return false
 }
 
 func dedupeBlocks(_ input: [ReaderBlock]) -> [ReaderBlock] {
     var seen: Set<String> = []
+    // swiftlint:disable:next prefer_let_over_var
     var output: [ReaderBlock] = []
     for block in input {
         let fingerprint = String(describing: block)
@@ -88,7 +111,9 @@ func dedupeBlocks(_ input: [ReaderBlock]) -> [ReaderBlock] {
 func dedupeMedia(_ input: [MediaDescriptor]) -> [MediaDescriptor] {
     var seen: Set<String> = []
     return input.filter {
-        if seen.contains($0.sourceURL) { return false }
+        if seen.contains($0.sourceURL) {
+            return false
+        }
         seen.insert($0.sourceURL)
         return true
     }
@@ -97,7 +122,9 @@ func dedupeMedia(_ input: [MediaDescriptor]) -> [MediaDescriptor] {
 func dedupeEmbeds(_ input: [EmbedDescriptor]) -> [EmbedDescriptor] {
     var seen: Set<String> = []
     return input.filter {
-        if seen.contains($0.embedURL) { return false }
+        if seen.contains($0.embedURL) {
+            return false
+        }
         seen.insert($0.embedURL)
         return true
     }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/HTMLUtilities.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/HTMLUtilities.swift
@@ -10,26 +10,39 @@ func extractTitle(document: Document, sourceURL: URL) throws -> String {
         sourceURL.absoluteString,
     ]
     for candidate in candidates {
-        if let candidate { return candidate }
+        if let candidate {
+            return candidate
+        }
     }
     return sourceURL.absoluteString
 }
 
 func plainTextFromBlocks(_ blocks: [ReaderBlock]) -> String {
+    // swiftlint:disable:next prefer_let_over_var
     var parts: [String] = []
     for block in blocks {
         switch block {
-        case .paragraph(let inlines): parts.append(inlineText(inlines))
-        case .heading(_, let inlines): parts.append(inlineText(inlines))
-        case .list(_, let items): parts.append(items.map(inlineText).joined(separator: "\n"))
-        case .blockquote(let inlines): parts.append(inlineText(inlines))
-        case .code(_, let code): parts.append(code)
-        case .figure(let media): if let caption = media.caption { parts.append(caption) }
-        case .video(let media): if let caption = media.caption { parts.append(caption) }
-        case .embed: continue
-        case .table(let markdown): parts.append(markdown)
-        case .horizontalRule: continue
-        case .callout(let title, let inlines):
+        case .paragraph(let inlines):
+            parts.append(inlineText(inlines))
+        case .heading(_, let inlines):
+            parts.append(inlineText(inlines))
+        case .list(_, let items):
+            parts.append(items.map(inlineText).joined(separator: "\n"))
+        case .blockquote(let inlines):
+            parts.append(inlineText(inlines))
+        case .code(_, let code):
+            parts.append(code)
+        case .figure(let media):
+            if let caption = media.caption { parts.append(caption) }
+        case .video(let media):
+            if let caption = media.caption { parts.append(caption) }
+        case .embed:
+            continue
+        case .table(let markdown):
+            parts.append(markdown)
+        case .horizontalRule:
+            continue
+        case let .callout(title, inlines):
             if let title { parts.append(title) }
             parts.append(inlineText(inlines))
         }
@@ -44,12 +57,18 @@ func plainTextFromBlocks(_ blocks: [ReaderBlock]) -> String {
 func inlineText(_ inlines: [ReaderInline]) -> String {
     inlines.map {
         switch $0 {
-        case .text(let value): return value
-        case .link(let label, _): return label
-        case .emphasis(let value): return value
-        case .strong(let value): return value
-        case .code(let value): return value
-        case .strikethrough(let value): return value
+        case .text(let value):
+            return value
+        case .link(let label, _):
+            return label
+        case .emphasis(let value):
+            return value
+        case .strong(let value):
+            return value
+        case .code(let value):
+            return value
+        case .strikethrough(let value):
+            return value
         }
     }
     .joined(separator: " ")
@@ -70,7 +89,9 @@ func estimateReadingTime(text: String) -> Int {
 
 func parseDate(_ raw: String) -> Date? {
     let iso = ISO8601DateFormatter()
-    if let value = iso.date(from: raw) { return value }
+    if let value = iso.date(from: raw) {
+        return value
+    }
 
     let formatter = DateFormatter()
     formatter.locale = Locale(identifier: "en_US_POSIX")
@@ -120,15 +141,21 @@ func cleanInlineText(_ text: String) -> String {
         .replacingOccurrences(of: "\u{FEFF}", with: "")    // zero-width no-break space
         .replacingOccurrences(of: "[\\t\\n\\r ]+", with: " ", options: .regularExpression)
 
-    if normalized.isEmpty { return "" }
-    if normalized == " " { return " " }
+    if normalized.isEmpty {
+        return ""
+    }
+    if normalized == " " {
+        return " "
+    }
 
     // Preserve boundary whitespace explicitly so string trimming elsewhere
     // can't accidentally strip it.
     let hasLeading = normalized.first == " "
     let hasTrailing = normalized.last == " "
     let trimmed = normalized.trimmingCharacters(in: .whitespacesAndNewlines)
-    if trimmed.isEmpty { return " " }
+    if trimmed.isEmpty {
+        return " "
+    }
 
     return (hasLeading ? " " : "") + trimmed + (hasTrailing ? " " : "")
 }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/LocalArchiveServer.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/LocalArchiveServer.swift
@@ -108,13 +108,13 @@ final class LocalArchiveServer: @unchecked Sendable {
     ) {
         connection.start(queue: queue)
 
-        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { data, _, _, error in
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { data, _, _, error in
             guard let data, error == nil else {
                 connection.cancel()
                 return
             }
 
-            let requestString = String(decoding: data, as: UTF8.self)
+            let requestString = String(bytes: data, encoding: .utf8) ?? ""
 
             guard let firstLine = requestString.split(separator: "\r\n").first else {
                 connection.cancel()
@@ -142,7 +142,7 @@ final class LocalArchiveServer: @unchecked Sendable {
                 : decodedPath
 
             if normalizedRequest == normalizedArticlePath
-                || normalizedRequest == ""
+                || normalizedRequest.isEmpty
                 || normalizedRequest == "/" {
                 fileURL = archiveDir.appendingPathComponent("index.html")
             } else {
@@ -207,6 +207,7 @@ final class LocalArchiveServer: @unchecked Sendable {
         path: String,
         fileURL: URL
     ) {
+        // swiftlint:disable:next no_print_statements
         print("[ArchiveServer] 404: \(path) → \(fileURL.path)")
         let response = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
         connection.send(
@@ -259,6 +260,7 @@ final class LocalArchiveServer: @unchecked Sendable {
                 withIntermediateDirectories: true
             )
             try? data.write(to: destination)
+            // swiftlint:disable:next no_print_statements
             print("[ArchiveServer] fetched-through: \(path)")
             return data
         } catch {
@@ -270,26 +272,46 @@ final class LocalArchiveServer: @unchecked Sendable {
 
     private static func mimeType(for ext: String) -> String {
         switch ext.lowercased() {
-        case "html", "htm": return "text/html; charset=utf-8"
-        case "js", "mjs": return "application/javascript; charset=utf-8"
-        case "css": return "text/css; charset=utf-8"
-        case "json": return "application/json; charset=utf-8"
-        case "svg": return "image/svg+xml"
-        case "png": return "image/png"
-        case "jpg", "jpeg": return "image/jpeg"
-        case "gif": return "image/gif"
-        case "webp": return "image/webp"
-        case "avif": return "image/avif"
-        case "ico": return "image/x-icon"
-        case "woff": return "font/woff"
-        case "woff2": return "font/woff2"
-        case "ttf": return "font/ttf"
-        case "otf": return "font/otf"
-        case "eot": return "application/vnd.ms-fontobject"
-        case "map": return "application/json"
-        case "xml": return "application/xml"
-        case "txt": return "text/plain"
-        default: return "application/octet-stream"
+        case "html", "htm":
+            return "text/html; charset=utf-8"
+        case "js", "mjs":
+            return "application/javascript; charset=utf-8"
+        case "css":
+            return "text/css; charset=utf-8"
+        case "json":
+            return "application/json; charset=utf-8"
+        case "svg":
+            return "image/svg+xml"
+        case "png":
+            return "image/png"
+        case "jpg", "jpeg":
+            return "image/jpeg"
+        case "gif":
+            return "image/gif"
+        case "webp":
+            return "image/webp"
+        case "avif":
+            return "image/avif"
+        case "ico":
+            return "image/x-icon"
+        case "woff":
+            return "font/woff"
+        case "woff2":
+            return "font/woff2"
+        case "ttf":
+            return "font/ttf"
+        case "otf":
+            return "font/otf"
+        case "eot":
+            return "application/vnd.ms-fontobject"
+        case "map":
+            return "application/json"
+        case "xml":
+            return "application/xml"
+        case "txt":
+            return "text/plain"
+        default:
+            return "application/octet-stream"
         }
     }
 }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/PDFArchiver.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/PDFArchiver.swift
@@ -139,7 +139,7 @@ enum PDFArchiver {
         guard name.hasPrefix(pageImagePrefix) else { return .max }
         let stripped = name
             .dropFirst(pageImagePrefix.count)
-            .prefix(while: { $0.isNumber })
+            .prefix { $0.isNumber }
         return Int(stripped) ?? .max
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Support/PDFIngestionClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/PDFIngestionClient.swift
@@ -104,7 +104,7 @@ private func pdfIngest(url: URL) async throws -> IngestionResult {
 
     // Wipe any stale page images from a previous ingestion of the same
     // SHA. Without this, re-ingesting a PDF that had more pages last
-    // time would leave orphaned `pdf-page-N.jpg` files behind.
+    // time would leave orphaned `pdf-page-N.jpg` files remaining.
     PDFArchiver.deletePageImages(for: itemID)
 
     let attributes = pdf.documentAttributes ?? [:]

--- a/StowerPackage/Sources/StowerFeatureV2/Support/PDFIngestionClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/PDFIngestionClient.swift
@@ -13,7 +13,7 @@ import UIKit
 import AppKit
 #endif
 
-private let pdfIngestLog = Logger(
+private let kPDFIngestLog = Logger(
     subsystem: "com.ryanleewilliams.stower",
     category: "PDFIngest"
 )
@@ -28,6 +28,7 @@ public enum PDFIngestionError: Error, LocalizedError {
         case .unreadable:
             return "The PDF couldn't be opened. It may be corrupted or not a valid PDF."
         case .passwordProtected:
+            // swiftlint:disable:next no_sensitive_logging
             return "This PDF is password-protected. Open it in another app to remove the password, then re-share it."
         case .emptyDocument:
             return "The PDF contains no pages."
@@ -63,13 +64,13 @@ public struct PDFIngestionClient: Sendable {
         self.ingest = ingest
     }
 
-    public static let failing = PDFIngestionClient(
-        ingest: { _ in throw PDFIngestionError.unreadable }
-    )
+    public static let failing = PDFIngestionClient { _ in
+        throw PDFIngestionError.unreadable
+    }
 
-    public static let live = PDFIngestionClient(
-        ingest: { url in try await pdfIngest(url: url) }
-    )
+    public static let live = PDFIngestionClient { url in
+        try await pdfIngest(url: url)
+    }
 }
 
 // MARK: - Pipeline
@@ -114,15 +115,19 @@ private func pdfIngest(url: URL) async throws -> IngestionResult {
     let creationDate = attributes[PDFDocumentAttribute.creationDateAttribute] as? Date
     let fallbackTitle = url.deletingPathExtension().lastPathComponent
     let title: String = {
-        if let metaTitle, !metaTitle.isEmpty { return metaTitle }
+        if let metaTitle, !metaTitle.isEmpty {
+            return metaTitle
+        }
         return fallbackTitle.isEmpty ? "Untitled PDF" : fallbackTitle
     }()
 
-    pdfIngestLog.notice(
+    kPDFIngestLog.notice(
         "Ingesting PDF \"\(title, privacy: .public)\" (\(pdf.pageCount, privacy: .public) pages, sha=\(hexHash, privacy: .public))"
     )
 
+    // swiftlint:disable:next prefer_let_over_var
     var blocks: [ReaderBlock] = []
+    // swiftlint:disable:next prefer_let_over_var
     var plainTextChunks: [String] = []
     var sawOCRFallback = false
 
@@ -134,7 +139,7 @@ private func pdfIngest(url: URL) async throws -> IngestionResult {
         // storage or memory. This same image is used both for display
         // and, when needed, for Vision OCR text extraction.
         guard let image = rasterizePage(page, scale: 2.0) else {
-            pdfIngestLog.error("Failed to rasterize page \(pageIndex, privacy: .public)")
+            kPDFIngestLog.error("Failed to rasterize page \(pageIndex, privacy: .public)")
             continue
         }
 
@@ -145,7 +150,7 @@ private func pdfIngest(url: URL) async throws -> IngestionResult {
         do {
             try PDFArchiver.archivePageImage(image, for: itemID, pageIndex: pageIndex)
         } catch {
-            pdfIngestLog.error(
+            kPDFIngestLog.error(
                 "Failed to archive page image \(pageIndex, privacy: .public): \(String(describing: error), privacy: .public)"
             )
             continue
@@ -209,7 +214,9 @@ private func pdfIngest(url: URL) async throws -> IngestionResult {
     )
 
     let media = blocks.compactMap { block -> MediaDescriptor? in
-        if case .figure(let descriptor) = block { return descriptor }
+        if case .figure(let descriptor) = block {
+            return descriptor
+        }
         return nil
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ReaderSpeechClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ReaderSpeechClient.swift
@@ -59,7 +59,7 @@ extension ReaderSpeechClient {
         )
     }()
 
-    public static let test: ReaderSpeechClient = ReaderSpeechClient(
+    public static let test = ReaderSpeechClient(
         start: { _, _ in
             AsyncThrowingStream { continuation in
                 continuation.finish()
@@ -104,6 +104,7 @@ private final class LiveReaderSpeechSynthDriver: NSObject {
         let blockIndex: Int
         let sequence: Int
     }
+    // swiftlint:disable:next prefer_let_over_var
     private var utteranceToPosition: [ObjectIdentifier: UtterancePosition] = [:]
     private var isCancelled = false
 
@@ -174,7 +175,7 @@ private final class LiveReaderSpeechSynthDriver: NSObject {
         continuation = nil
     }
 
-    fileprivate func handleDidStart(utteranceID: ObjectIdentifier) {
+    private func handleDidStart(utteranceID: ObjectIdentifier) {
         guard !isCancelled else { return }
         guard let position = utteranceToPosition[utteranceID] else { return }
         continuation?.yield(
@@ -182,7 +183,7 @@ private final class LiveReaderSpeechSynthDriver: NSObject {
         )
     }
 
-    fileprivate func handleWillSpeak(_ characterRange: NSRange, utteranceID: ObjectIdentifier) {
+    private func handleWillSpeak(_ characterRange: NSRange, utteranceID: ObjectIdentifier) {
         guard !isCancelled else { return }
         guard let position = utteranceToPosition[utteranceID] else { return }
         continuation?.yield(
@@ -194,7 +195,7 @@ private final class LiveReaderSpeechSynthDriver: NSObject {
         )
     }
 
-    fileprivate func handleDidFinish(utteranceID: ObjectIdentifier) {
+    private func handleDidFinish(utteranceID: ObjectIdentifier) {
         guard !isCancelled else { return }
         utteranceToPosition[utteranceID] = nil
 
@@ -242,7 +243,7 @@ private final class LiveReaderSpeechSynthDriver: NSObject {
     /// `AVSpeechUtteranceMaximumSpeechRate` keeps us inside the legal
     /// rate range even if the upstream multiplier somehow escapes its
     /// clamp.
-    fileprivate static func avSpeechRate(fromMultiplier multiplier: Float) -> Float {
+    private static func avSpeechRate(fromMultiplier multiplier: Float) -> Float {
         let clamped = max(0.2, min(multiplier, 2.0))
         let raw: Float
         if clamped < 1.0 {

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ReaderSpeechPreferencesClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ReaderSpeechPreferencesClient.swift
@@ -22,7 +22,7 @@ extension ReaderSpeechPreferencesClient {
         static let rate = "stower.reader.speech.rate"
     }
 
-    public static let live: ReaderSpeechPreferencesClient = ReaderSpeechPreferencesClient(
+    public static let live = ReaderSpeechPreferencesClient(
         load: {
             let defaults = UserDefaults.standard
             let voiceID = defaults.string(forKey: Keys.voiceID)
@@ -41,7 +41,7 @@ extension ReaderSpeechPreferencesClient {
         }
     )
 
-    public static let test: ReaderSpeechPreferencesClient = ReaderSpeechPreferencesClient(
+    public static let test = ReaderSpeechPreferencesClient(
         load: { ReaderSpeechPreferences() },
         save: { _ in }
     )

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ReaderSpeechTextBuilder.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ReaderSpeechTextBuilder.swift
@@ -29,7 +29,7 @@ public struct SpeechBlock: Equatable, Sendable {
     public let kind: Kind
     public let text: String
 
-    public init(index: Int, sequence: Int? = nil, kind: Kind, text: String) {
+    public init(index: Int, kind: Kind, text: String, sequence: Int? = nil) {
         self.index = index
         self.sequence = sequence ?? index
         self.kind = kind
@@ -39,6 +39,7 @@ public struct SpeechBlock: Equatable, Sendable {
 
 enum ReaderSpeechTextBuilder {
     static func speechBlocks(document: ReaderDocument) -> [SpeechBlock] {
+        // swiftlint:disable:next prefer_let_over_var
         var output: [SpeechBlock] = []
         output.reserveCapacity(document.blocks.count)
 
@@ -68,7 +69,7 @@ enum ReaderSpeechTextBuilder {
                     output.append(SpeechBlock(index: index, kind: .blockquote, text: text))
                 }
 
-            case .callout(let title, let inlines):
+            case let .callout(title, inlines):
                 let body = ReaderTextLayoutSupport.inlinePlainText(from: inlines)
                 let combined: String
                 if let title, !title.isEmpty, !body.isEmpty {
@@ -146,6 +147,7 @@ enum ReaderSpeechTextBuilder {
     /// getting block-level output, so summarization, retrieval, and
     /// position saving are unaffected.
     static func sentenceSplit(_ blocks: [SpeechBlock]) -> [SpeechBlock] {
+        // swiftlint:disable:next prefer_let_over_var
         var output: [SpeechBlock] = []
         output.reserveCapacity(blocks.count * 3)
         var sequence = 0
@@ -159,9 +161,9 @@ enum ReaderSpeechTextBuilder {
                 output.append(
                     SpeechBlock(
                         index: block.index,
-                        sequence: sequence,
                         kind: block.kind,
-                        text: block.text
+                        text: block.text,
+                        sequence: sequence
                     )
                 )
                 sequence += 1
@@ -171,9 +173,9 @@ enum ReaderSpeechTextBuilder {
                 output.append(
                     SpeechBlock(
                         index: block.index,
-                        sequence: sequence,
                         kind: block.kind,
-                        text: sentence
+                        text: sentence,
+                        sequence: sequence
                     )
                 )
                 sequence += 1
@@ -191,6 +193,7 @@ enum ReaderSpeechTextBuilder {
 
         let tokenizer = NLTokenizer(unit: .sentence)
         tokenizer.string = trimmed
+        // swiftlint:disable:next prefer_let_over_var
         var sentences: [String] = []
         tokenizer.enumerateTokens(in: trimmed.startIndex..<trimmed.endIndex) { range, _ in
             let sentence = String(trimmed[range]).trimmingCharacters(in: .whitespacesAndNewlines)
@@ -216,7 +219,7 @@ enum ReaderSpeechTextBuilder {
 
         // Collapse whitespace.
         let components = text
-            .split(whereSeparator: { $0.isWhitespace || $0.isNewline })
+            .split { $0.isWhitespace || $0.isNewline }
             .map(String.init)
         return components.joined(separator: " ")
     }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ReaderSpeechVoiceCatalog.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ReaderSpeechVoiceCatalog.swift
@@ -32,8 +32,10 @@ enum ReaderSpeechVoiceCatalog {
 
         let groupsByLanguage = Dictionary(grouping: AVSpeechSynthesisVoice.speechVoices(), by: \.language)
 
+        // swiftlint:disable prefer_let_over_var
         var preferred: [LanguageGroup] = []
         var other: [LanguageGroup] = []
+        // swiftlint:enable prefer_let_over_var
 
         for (language, voices) in groupsByLanguage {
             let entries = voices
@@ -69,7 +71,9 @@ enum ReaderSpeechVoiceCatalog {
         preferred.sort { lhs, rhs in
             let lhsRank = preferredPrefixes.firstIndex(of: String(lhs.id.prefix(2)).lowercased()) ?? Int.max
             let rhsRank = preferredPrefixes.firstIndex(of: String(rhs.id.prefix(2)).lowercased()) ?? Int.max
-            if lhsRank != rhsRank { return lhsRank < rhsRank }
+            if lhsRank != rhsRank {
+                return lhsRank < rhsRank
+            }
             return lhs.id < rhs.id
         }
         other.sort { $0.displayName < $1.displayName }
@@ -106,6 +110,7 @@ enum ReaderSpeechVoiceCatalog {
 
     private static func preferredLanguagePrefixes() -> [String] {
         var seen = Set<String>()
+        // swiftlint:disable:next prefer_let_over_var
         var result: [String] = []
         let sources = Locale.preferredLanguages.isEmpty
             ? [Locale.current.identifier]
@@ -132,9 +137,12 @@ enum ReaderSpeechVoiceCatalog {
 
     private static func qualityRank(_ quality: AVSpeechSynthesisVoiceQuality) -> Int {
         switch quality {
-        case .premium: return 3
-        case .enhanced: return 2
-        default: return 1
+        case .premium:
+            return 3
+        case .enhanced:
+            return 2
+        default:
+            return 1
         }
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ReaderTextLayoutSupport.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ReaderTextLayoutSupport.swift
@@ -35,8 +35,10 @@ enum ReaderTextLayoutSupport {
     }
 
     static func listSpeechTextAndRanges(items: [[ReaderInline]]) -> (text: String, itemRanges: [NSRange]) {
+        // swiftlint:disable prefer_let_over_var
         var itemRanges: [NSRange] = []
         var pieces: [String] = []
+        // swiftlint:enable prefer_let_over_var
         pieces.reserveCapacity(items.count)
 
         var cursorUTF16 = 0
@@ -85,7 +87,7 @@ enum ReaderTextLayoutSupport {
         switch inline {
         case .text(let value):
             return AttributedString(value)
-        case .link(let label, let url):
+        case let .link(label, url):
             var link = AttributedString(label)
             link.link = URL(string: url)
             return link
@@ -110,15 +112,20 @@ enum ReaderTextLayoutSupport {
 
     private static func shouldInsertSpace(previous: Character?, next: Character) -> Bool {
         guard let previous else { return false }
-        if previous.isWhitespace || next.isWhitespace { return false }
+        if previous.isWhitespace || next.isWhitespace {
+            return false
+        }
 
         let noLeadingSpaceBefore: Set<Character> = [",", ".", "!", "?", ";", ":", ")", "]", "}", "”", "’", "%"]
-        if noLeadingSpaceBefore.contains(next) { return false }
+        if noLeadingSpaceBefore.contains(next) {
+            return false
+        }
 
         let noTrailingSpaceAfter: Set<Character> = ["(", "[", "{", "“", "‘", "/", "-"]
-        if noTrailingSpaceAfter.contains(previous) { return false }
+        if noTrailingSpaceAfter.contains(previous) {
+            return false
+        }
 
         return true
     }
 }
-

--- a/StowerPackage/Sources/StowerFeatureV2/Support/URLIngestionClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/URLIngestionClient.swift
@@ -51,7 +51,7 @@ public struct URLIngestionClient: Sendable {
         )
 
         let (data, _) = try await URLSession.shared.data(for: request)
-        let html = String(decoding: data, as: UTF8.self)
+        let html = String(bytes: data, encoding: .utf8) ?? ""
 
         var result = try await ExtractionPipelineClient.live.extract(html, url)
         result.media = try await MediaResolutionClient.live.resolve(result.media)
@@ -96,7 +96,7 @@ public struct ExtractionPipelineClient: Sendable {
 
         let heroImageURL = nonEmpty(try? document.select("meta[property=og:image]").first()?.attr("abs:content"))
             ?? nonEmpty(try? document.select("meta[name=twitter:image]").first()?.attr("abs:content"))
-            ?? parsed.media.first(where: { $0.kind == .image })?.sourceURL
+            ?? parsed.media.first { $0.kind == .image }?.sourceURL
 
         let publishedRaw = nonEmpty(try? document.select("meta[property=article:published_time]").first()?.attr("content"))
             ?? nonEmpty(try? document.select("meta[name=date]").first()?.attr("content"))
@@ -201,6 +201,7 @@ public struct MediaResolutionClient: Sendable {
                 }
             }
 
+            // swiftlint:disable:next prefer_let_over_var
             var results: [(Int, MediaDescriptor)] = []
             for await result in group {
                 results.append(result)
@@ -333,7 +334,9 @@ private func maybeIngestAsPDF(url: URL) async throws -> IngestionResult? {
     // URL ends in `.pdf`.
     let header = data.prefix(5)
     let looksLikePDF: Bool = {
-        if isPDFFromHead { return true }
+        if isPDFFromHead {
+            return true
+        }
         guard header.count == 5 else { return false }
         return header[header.startIndex] == 0x25    // %
             && header[header.startIndex + 1] == 0x50 // P
@@ -392,13 +395,16 @@ private func maybeIngestAsPDF(url: URL) async throws -> IngestionResult? {
 func detectInteractiveContent(document: Document) -> Bool {
     // Canvas elements always require JS.
     let canvasCount = (try? document.select("canvas").array().count) ?? 0
-    if canvasCount > 0 { return true }
+    if canvasCount > 0 {
+        return true
+    }
 
     // SVGs that carry real interactivity: embedded <script>, SMIL animation,
     // or <foreignObject>. Child-count alone is a bad heuristic because
     // icon SVGs commonly have dozens of <path> children.
     let svgs = (try? document.select("svg").array()) ?? []
     for svg in svgs {
+        // swiftlint:disable:next for_where
         if (try? svg.select("script, animate, animateTransform, animateMotion, set, foreignObject").first()) != nil {
             return true
         }
@@ -410,7 +416,9 @@ func detectInteractiveContent(document: Document) -> Bool {
     let vizPatterns = ["d3.js", "d3.min.js", "/d3/", "chart.js", "chartjs", "highcharts", "plotly", "vega", "observablehq"]
     for script in scripts {
         let src = ((try? script.attr("src")) ?? "").lowercased()
-        if vizPatterns.contains(where: src.contains) { return true }
+        if vizPatterns.contains(where: src.contains) {
+            return true
+        }
     }
 
     // Inline scripts that construct charts or drive SVG animations. Match on
@@ -420,7 +428,9 @@ func detectInteractiveContent(document: Document) -> Bool {
     let vizCallPatterns = ["d3.select(", "new Chart(", "Highcharts.chart(", "Plotly.newPlot(", "vega.embed(", "createElementNS(\"http://www.w3.org/2000/svg\""]
     for script in inlineScripts {
         let content = (try? script.html()) ?? ""
-        if vizCallPatterns.contains(where: content.contains) { return true }
+        if vizCallPatterns.contains(where: content.contains) {
+            return true
+        }
     }
 
     return false

--- a/StowerPackage/Sources/StowerFeatureV2/Support/YouTubeIngestionClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/YouTubeIngestionClient.swift
@@ -77,6 +77,7 @@ public struct YouTubeIngestionClient: Sendable {
 
             // 5. Compose the ReaderDocument: video card, then description
             //    paragraphs.
+            // swiftlint:disable:next prefer_let_over_var
             var blocks: [ReaderBlock] = [.video(media: descriptor)]
             blocks.append(contentsOf: descriptionBlocks(description))
 
@@ -240,7 +241,7 @@ private func fetchWatchPageHTML(
         if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
             return nil
         }
-        return String(decoding: data, as: UTF8.self)
+        return String(bytes: data, encoding: .utf8)
     } catch {
         return nil
     }
@@ -354,7 +355,7 @@ private func descriptionBlocks(_ description: String?) -> [ReaderBlock] {
     guard !trimmed.isEmpty else { return [] }
 
     return trimmed
-        .split(omittingEmptySubsequences: false, whereSeparator: { $0.isNewline })
+        .split(omittingEmptySubsequences: false) { $0.isNewline }
         .map { $0.trimmingCharacters(in: .whitespaces) }
         .filter { !$0.isEmpty }
         .map { .paragraph([.text($0)]) }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/AddItemExtractorTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/AddItemExtractorTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Testing
 @testable import StowerFeature
+import Testing
 
 @Suite
 struct AddItemExtractorTests {
@@ -35,8 +35,8 @@ struct AddItemExtractorTests {
         #expect(result.siteName == "Terry Godier")
         #expect(result.processingState == .ready || result.processingState == .partial)
         #expect(result.document.blocks.count >= 3)
-        #expect(result.media.contains(where: { $0.kind == .image }))
-        #expect(result.embeds.contains(where: { $0.provider == "Youtube" || $0.provider == "YouTube" }))
+        #expect(result.media.contains { $0.kind == .image })
+        #expect(result.embeds.contains { $0.provider == "Youtube" || $0.provider == "YouTube" })
     }
 
     @Test
@@ -65,7 +65,7 @@ struct AddItemExtractorTests {
         }
 
         #expect(paragraphCount >= 2)
-        #expect(result.media.contains(where: { $0.kind == .image }))
+        #expect(result.media.contains { $0.kind == .image })
         #expect(!result.plainText.contains("All Items 47 Daring Fireball"))
     }
 
@@ -116,9 +116,9 @@ struct AddItemExtractorTests {
             URL(string: "https://example.com/images")!
         )
 
-        #expect(!result.media.contains(where: { $0.sourceURL.contains("avatar") }))
-        #expect(result.media.contains(where: { $0.sourceURL.contains("hero.webp") }))
-        #expect(result.media.contains(where: { $0.caption == "Revenue trend, 2020-2026" }))
+        #expect(!result.media.contains { $0.sourceURL.contains("avatar") })
+        #expect(result.media.contains { $0.sourceURL.contains("hero.webp") })
+        #expect(result.media.contains { $0.caption == "Revenue trend, 2020-2026" })
     }
 
     @Test
@@ -140,7 +140,7 @@ struct AddItemExtractorTests {
             URL(string: "https://example.com/noscript")!
         )
 
-        #expect(result.media.contains(where: { $0.sourceURL.contains("fallback-image.jpg") }))
+        #expect(result.media.contains { $0.sourceURL.contains("fallback-image.jpg") })
     }
 
     @Test
@@ -167,9 +167,11 @@ struct AddItemExtractorTests {
             URL(string: "https://example.com/substack-image-links")!
         )
 
-        #expect(result.media.contains(where: { $0.sourceURL.contains("ec5279eb-e12f-408f-8727-ffcc7b1f3ba7") }))
+        #expect(result.media.contains { $0.sourceURL.contains("ec5279eb-e12f-408f-8727-ffcc7b1f3ba7") })
         #expect(result.document.blocks.contains { block in
-            if case .figure = block { return true }
+            if case .figure = block {
+                return true
+            }
             return false
         })
     }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/AppFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/AppFeatureTests.swift
@@ -1,8 +1,8 @@
 import ComposableArchitecture
 import Foundation
-import Testing
 @testable import StowerData
 @testable import StowerFeature
+import Testing
 
 @MainActor
 @Suite
@@ -19,7 +19,7 @@ struct AppFeatureTests {
 
         // 2) Verify fetchLibrary returns it
         let library = try await repository.fetchLibrary(.all)
-        #expect(library.contains(where: { $0.id == created.id }))
+        #expect(library.contains { $0.id == created.id })
 
         // 3) Test the reader load flow with TCA
         let store = TestStore(initialState: ReaderFeature.State(itemID: created.id)) {

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ArchiveServerFetchThroughTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ArchiveServerFetchThroughTests.swift
@@ -1,12 +1,11 @@
 import Foundation
-import Testing
 @testable import StowerFeature
+import Testing
 
 /// Tests here must run serialized because `StubProtocol` keeps a static
 /// URL→response registry that would race under the default parallel runner.
 @Suite(.serialized)
 struct ArchiveServerFetchThroughTests {
-
     // MARK: - Metadata sidecar
 
     @Test
@@ -75,8 +74,8 @@ struct ArchiveServerFetchThroughTests {
         StubProtocol.reset()
         StubProtocol.register(
             url: "https://stub.test/api/get-metrics",
-            status: 404,
-            body: Data()
+            body: Data(),
+            status: 404
         )
 
         let session = makeStubSession()
@@ -141,7 +140,7 @@ final class StubProtocol: URLProtocol {
     }
 
     private static let lock = NSLock()
-    nonisolated(unsafe) private static var registry: [String: StubbedResponse] = [:]
+    nonisolated(unsafe) private static var registry: [String: StubbedResponse] = [:] // swiftlint:disable:this prefer_let_over_var
 
     static func reset() {
         lock.lock()
@@ -149,20 +148,20 @@ final class StubProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func register(url: String, status: Int = 200, body: Data) {
+    static func register(url: String, body: Data, status: Int = 200) {
         lock.lock()
         registry[url] = StubbedResponse(status: status, body: body)
         lock.unlock()
     }
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override static func canInit(with request: URLRequest) -> Bool {
         guard let url = request.url?.absoluteString else { return false }
         lock.lock()
         defer { lock.unlock() }
         return registry[url] != nil
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
         guard let url = request.url, let urlString = request.url?.absoluteString else {

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ArticleChunkerTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ArticleChunkerTests.swift
@@ -1,7 +1,7 @@
 import Foundation
-import Testing
 @testable import StowerData
 @testable import StowerFeature
+import Testing
 
 @Suite
 struct ArticleChunkerTests {

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ArticleRetrieverTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ArticleRetrieverTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Testing
 @testable import StowerFeature
+import Testing
 
 @Suite
 struct ArticleRetrieverTests {

--- a/StowerPackage/Tests/StowerFeatureV2Tests/DatabaseTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/DatabaseTests.swift
@@ -1,7 +1,7 @@
 import Foundation
-import Testing
 @testable import StowerData
 @testable import StowerFeature
+import Testing
 
 @Suite
 struct DatabaseTests {
@@ -15,7 +15,7 @@ struct DatabaseTests {
         let items = try await repository.fetchLibrary(.all)
 
         #expect(items.count >= 1)
-        #expect(items.contains(where: { $0.id == saved.id }))
+        #expect(items.contains { $0.id == saved.id })
     }
 
     @Test
@@ -44,7 +44,7 @@ struct DatabaseTests {
         try await repository.markIngestionJobProcessed(first.id)
 
         let remaining = try await repository.fetchPendingIngestionJobs()
-        #expect(!remaining.contains(where: { $0.id == first.id }))
+        #expect(!remaining.contains { $0.id == first.id })
     }
 
     @Test
@@ -58,7 +58,7 @@ struct DatabaseTests {
 
         // Simulate what fetchLibrary does (user sees item in list)
         let library = try await repository.fetchLibrary(.all)
-        let libraryItem = try #require(library.first(where: { $0.id == created.id }))
+        let libraryItem = try #require(library.first { $0.id == created.id })
 
         // Simulate what ReaderFeature.load does (user taps item)
         let loadedItem = try await repository.loadItem(libraryItem.id)

--- a/StowerPackage/Tests/StowerFeatureV2Tests/HTMLBlockParserTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/HTMLBlockParserTests.swift
@@ -1,7 +1,7 @@
 import Foundation
+@testable import StowerFeature
 import SwiftSoup
 import Testing
-@testable import StowerFeature
 
 @Suite
 struct HTMLBlockParserTests {
@@ -24,14 +24,21 @@ struct HTMLBlockParserTests {
     private func concatenatedRawText(_ inlines: [ReaderInline]) -> String {
         inlines.map { inline -> String in
             switch inline {
-            case .text(let value): return value
-            case .link(let label, _): return label
-            case .emphasis(let value): return value
-            case .strong(let value): return value
-            case .code(let value): return value
-            case .strikethrough(let value): return value
+            case .text(let value):
+                return value
+            case .link(let label, _):
+                return label
+            case .emphasis(let value):
+                return value
+            case .strong(let value):
+                return value
+            case .code(let value):
+                return value
+            case .strikethrough(let value):
+                return value
             }
-        }.joined()
+        }
+        .joined()
     }
 
     @Test
@@ -166,14 +173,21 @@ struct HTMLBlockParserTests {
         func textOf(_ inlines: [ReaderInline]) -> String {
             inlines.map { inline -> String in
                 switch inline {
-                case .text(let value): return value
-                case .link(let label, _): return label
-                case .emphasis(let value): return value
-                case .strong(let value): return value
-                case .code(let value): return value
-                case .strikethrough(let value): return value
+                case .text(let value):
+                    return value
+                case .link(let label, _):
+                    return label
+                case .emphasis(let value):
+                    return value
+                case .strong(let value):
+                    return value
+                case .code(let value):
+                    return value
+                case .strikethrough(let value):
+                    return value
                 }
-            }.joined()
+            }
+            .joined()
         }
 
         var foundPhishing: String?
@@ -187,7 +201,8 @@ struct HTMLBlockParserTests {
                     let t = textOf(item)
                     if t.contains("phishing attempts") { foundPhishing = t }
                 }
-            default: break
+            default:
+                break
             }
         }
 
@@ -218,7 +233,8 @@ struct HTMLBlockParserTests {
                     let t = textOf(item)
                     if t.contains("phishing attempts") { foundAfterSanitize = t }
                 }
-            default: break
+            default:
+                break
             }
         }
         let afterSanitize = try #require(foundAfterSanitize)
@@ -268,14 +284,21 @@ struct HTMLBlockParserTests {
             for item in items {
                 let text = item.map { inline -> String in
                     switch inline {
-                    case .text(let value): return value
-                    case .link(let label, _): return label
-                    case .emphasis(let value): return value
-                    case .strong(let value): return value
-                    case .code(let value): return value
-                    case .strikethrough(let value): return value
+                    case .text(let value):
+                        return value
+                    case .link(let label, _):
+                        return label
+                    case .emphasis(let value):
+                        return value
+                    case .strong(let value):
+                        return value
+                    case .code(let value):
+                        return value
+                    case .strikethrough(let value):
+                        return value
                     }
-                }.joined()
+                }
+                .joined()
                 if text.contains("phishing") {
                     foundText = text
                     break

--- a/StowerPackage/Tests/StowerFeatureV2Tests/LibraryFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/LibraryFeatureTests.swift
@@ -1,7 +1,7 @@
 import ComposableArchitecture
 import Foundation
-import Testing
 @testable import StowerFeature
+import Testing
 
 @MainActor
 @Suite
@@ -51,9 +51,12 @@ struct LibraryFeatureTests {
         } withDependencies: {
             $0.stowerRepository.fetchLibrary = { filter in
                 switch filter {
-                case .read: return [readItem]
-                case .unread: return [unreadItem]
-                default: return [unreadItem, readItem]
+                case .read:
+                    return [readItem]
+                case .unread:
+                    return [unreadItem]
+                default:
+                    return [unreadItem, readItem]
                 }
             }
         }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderAIFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderAIFeatureTests.swift
@@ -1,8 +1,8 @@
 import ComposableArchitecture
 import Foundation
-import Testing
 @testable import StowerData
 @testable import StowerFeature
+import Testing
 
 @MainActor
 @Suite

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderDocumentSanitizerTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderDocumentSanitizerTests.swift
@@ -12,14 +12,21 @@ struct ReaderDocumentSanitizerTests {
     private func concatenated(_ inlines: [ReaderInline]) -> String {
         inlines.map { inline -> String in
             switch inline {
-            case .text(let value): return value
-            case .link(let label, _): return label
-            case .emphasis(let value): return value
-            case .strong(let value): return value
-            case .code(let value): return value
-            case .strikethrough(let value): return value
+            case .text(let value):
+                return value
+            case .link(let label, _):
+                return label
+            case .emphasis(let value):
+                return value
+            case .strong(let value):
+                return value
+            case .code(let value):
+                return value
+            case .strikethrough(let value):
+                return value
             }
-        }.joined()
+        }
+        .joined()
     }
 
     private func sanitizedParagraph(_ inlines: [ReaderInline]) -> [ReaderInline] {

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderFeatureTests.swift
@@ -1,8 +1,8 @@
 import ComposableArchitecture
 import Foundation
-import Testing
 @testable import StowerData
 @testable import StowerFeature
+import Testing
 
 @MainActor
 @Suite

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderSpeechFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderSpeechFeatureTests.swift
@@ -1,7 +1,7 @@
 import ComposableArchitecture
 import Foundation
-import Testing
 @testable import StowerFeature
+import Testing
 
 @MainActor
 @Suite
@@ -118,4 +118,3 @@ struct ReaderSpeechFeatureTests {
         #expect(stopCalled.value == true)
     }
 }
-

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderSpeechTextBuilderTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderSpeechTextBuilderTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Testing
 @testable import StowerFeature
+import Testing
 
 @Suite
 struct ReaderSpeechTextBuilderTests {

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderTextLayoutSupportTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderTextLayoutSupportTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Testing
 @testable import StowerFeature
+import Testing
 
 @Suite
 struct ReaderTextLayoutSupportTests {
@@ -9,7 +9,7 @@ struct ReaderTextLayoutSupportTests {
         let inlines: [ReaderInline] = [
             .text("Hello"),
             .strong("world"),
-            .emphasis("again")
+            .emphasis("again"),
         ]
 
         let output = ReaderTextLayoutSupport.makeInlineAttributedString(from: inlines)
@@ -28,7 +28,7 @@ struct ReaderTextLayoutSupportTests {
             .emphasis("em"),
             .strong("strong"),
             .code("code"),
-            .strikethrough("strike")
+            .strikethrough("strike"),
         ]
         let attributed = ReaderTextLayoutSupport.makeInlineAttributedString(from: inlines)
         let rendered = String(attributed.characters)

--- a/StowerPackage/Tests/StowerFeatureV2Tests/RepositoryFilterTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/RepositoryFilterTests.swift
@@ -1,11 +1,10 @@
 import Foundation
-import Testing
 @testable import StowerData
 @testable import StowerFeature
+import Testing
 
 @Suite
 struct RepositoryFilterTests {
-
     private func makeRepository() throws -> StowerRepository {
         let database = try StowerDatabase.makeDatabase()
         return StowerRepository.live(database: database, cloudSyncClient: .noop)
@@ -91,7 +90,7 @@ struct RepositoryFilterTests {
         #expect(taggedIDs == Set([a.id, b.id]))
 
         // Domain model should surface the tag IDs on the item.
-        let taggedA = try #require(tagged.first(where: { $0.id == a.id }))
+        let taggedA = try #require(tagged.first { $0.id == a.id })
         #expect(taggedA.tagIDs == [work.id])
     }
 
@@ -131,7 +130,7 @@ struct RepositoryFilterTests {
         let untagged = try await repository.fetchLibrary(.untagged)
         #expect(untagged.map(\.id).contains(a.id))
         let tags = try await repository.fetchTags()
-        #expect(!tags.contains(where: { $0.id == label.id }))
+        #expect(!tags.contains { $0.id == label.id })
     }
 
     @Test

--- a/StowerPackage/Tests/StowerFeatureV2Tests/SidebarFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/SidebarFeatureTests.swift
@@ -1,17 +1,21 @@
 import ComposableArchitecture
 import Foundation
-import Testing
 @testable import StowerData
 @testable import StowerFeature
+import Testing
 
 @MainActor
 @Suite
 struct SidebarFeatureTests {
-
     @Test
     func reload_loadsCountsAndTags() async {
         let counts = LibraryListCounts(
-            unread: 2, read: 1, starred: 1, untagged: 1, all: 3, recentlyDeleted: 1,
+            unread: 2,
+            read: 1,
+            starred: 1,
+            untagged: 1,
+            all: 3,
+            recentlyDeleted: 1,
             byTag: [:]
         )
         let tag = Tag(name: "inbox")

--- a/StowerPackage/Tests/StowerFeatureV2Tests/YouTubeIngestionClientTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/YouTubeIngestionClientTests.swift
@@ -1,11 +1,10 @@
 import Foundation
-import Testing
-@testable import StowerFeature
 import StowerData
+@testable import StowerFeature
+import Testing
 
 @Suite
 struct YouTubeIngestionClientTests {
-
     private static let videoID = "dQw4w9WgXcQ"
     private static let watchURL = URL(string: "https://www.youtube.com/watch?v=\(videoID)")!
 
@@ -66,8 +65,8 @@ struct YouTubeIngestionClientTests {
     /// Returns 404 for anything else so a regression would surface loudly.
     private static func makeFetch(
         oembedBody: String?,
-        oembedStatus: Int = 200,
         watchBody: String?,
+        oembedStatus: Int = 200,
         watchStatus: Int = 200
     ) -> @Sendable (URLRequest) async throws -> (Data, URLResponse) {
         { request in
@@ -138,8 +137,13 @@ struct YouTubeIngestionClientTests {
         let paragraphTexts: [String] = blocks.dropFirst().compactMap { block in
             guard case let .paragraph(inlines) = block else { return nil }
             return inlines.compactMap { inline in
-                if case let .text(value) = inline { return value } else { return nil }
-            }.joined()
+                if case let .text(value) = inline {
+                    return value
+                } else {
+                    return nil
+                }
+            }
+            .joined()
         }
         #expect(paragraphTexts == [
             "First paragraph of the full description.",
@@ -220,8 +224,8 @@ struct YouTubeIngestionClientTests {
         let client = YouTubeIngestionClient.make(
             fetch: Self.makeFetch(
                 oembedBody: "",
-                oembedStatus: 401,
-                watchBody: Self.watchPageHTMLWithoutPlayerResponse
+                watchBody: Self.watchPageHTMLWithoutPlayerResponse,
+                oembedStatus: 401
             ),
             downloadImage: { _ in Data([0xFF, 0xD8, 0xFF]) },
             imageStorageDirectory: scratch

--- a/StowerPackage/Tests/StowerFeatureV2Tests/YouTubeURLDetectorTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/YouTubeURLDetectorTests.swift
@@ -1,11 +1,10 @@
 import Foundation
-import Testing
-@testable import StowerFeature
 import StowerData
+@testable import StowerFeature
+import Testing
 
 @Suite
 struct YouTubeURLDetectorTests {
-
     private static let validID = "dQw4w9WgXcQ"
 
     @Test(arguments: [

--- a/StowerShare/Info.plist
+++ b/StowerShare/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleExecutable</key>

--- a/StowerShare/ShareViewController.swift
+++ b/StowerShare/ShareViewController.swift
@@ -305,9 +305,12 @@ final class ShareViewController: UIViewController {
         apply(phase: phase)
         let hold: TimeInterval
         switch phase {
-        case .loading: hold = 0.0
-        case .success: hold = 0.9
-        case .failure: hold = 1.8
+        case .loading:
+            hold = 0.0
+        case .success:
+            hold = 0.9
+        case .failure:
+            hold = 1.8
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + hold) { [weak self] in
             self?.completeRequest()

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Xcode Cloud doesn't automatically trust Swift macro targets from
+# third-party packages. This script applies the default settings to
+# allow them, matching what happens when you click "Trust & Enable"
+# in Xcode locally.
+
+defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow with separate **Lint**, **Build**, and **Test** status checks
- Add SwiftLint configuration with security-focused and modern Swift/SwiftUI rules
- Add Xcode Cloud `ci_post_clone.sh` to trust Swift macro targets (ComposableArchitecture, swift-dependencies)
- Fix interface orientation values in pbxproj (remove duplicate short-form names)
- Fix StowerShare `CFBundleVersion` mismatch by using `$(CURRENT_PROJECT_VERSION)` build variable
- Fix corrupted `BuildableName` in shared Xcode scheme

## Test plan
- [x] Verify all three GitHub Actions status checks (Lint, Build, Test) appear on this PR
- [ ] Confirm Xcode Cloud picks up the `ci_post_clone.sh` script on next cloud build
- [ ] Validate interface orientations resolve the App Store validation error
- [ ] Confirm StowerShare extension version matches parent app