### PR TITLE
Fix PDF pages showing blank/broken images

### DIFF
--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebView.swift
@@ -225,16 +225,9 @@ public struct ReaderWebView: View {
         }
 
         // Symlink PDF page images from the archive into the scratch dir.
-        // Idempotent: if a symlink already exists from a previous load,
-        // `removeItem` clears it so the fresh one points at the current
-        // archive file. Safe to fail silently — if symlinks can't be
-        // created the HTML just renders with broken images, which is no
-        // worse than the pre-PDF-page baseline.
-        for source in PDFArchiver.pageImageURLs(for: itemID) {
-            let link = scratchDir.appendingPathComponent(source.lastPathComponent)
-            try? FileManager.default.removeItem(at: link)
-            try? FileManager.default.createSymbolicLink(at: link, withDestinationURL: source)
-        }
+        // Skips any source file that doesn't exist on disk to prevent
+        // dangling symlinks (which would cause the local server to 404).
+        PDFArchiver.symlinkPageImages(for: itemID, into: scratchDir)
 
         let server = LocalArchiveServer(archiveDir: scratchDir, articlePath: "/", originURL: nil)
         guard let port = try? await server.start() else { return nil }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/LocalArchiveServer.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/LocalArchiveServer.swift
@@ -207,8 +207,13 @@ final class LocalArchiveServer: @unchecked Sendable {
         path: String,
         fileURL: URL
     ) {
-        // swiftlint:disable:next no_print_statements
-        print("[ArchiveServer] 404: \(path) → \(fileURL.path)")
+        if fileURL.lastPathComponent.hasPrefix(PDFArchiver.pageImagePrefix) {
+            // swiftlint:disable:next no_print_statements
+            print("[ArchiveServer] 404 PDF page image: \(path) — file missing at \(fileURL.path). Check ingestion fsync and on-disk verification.")
+        } else {
+            // swiftlint:disable:next no_print_statements
+            print("[ArchiveServer] 404: \(path) → \(fileURL.path)")
+        }
         let response = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
         connection.send(
             content: Data(response.utf8),

--- a/StowerPackage/Sources/StowerFeatureV2/Support/PDFArchiver.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/PDFArchiver.swift
@@ -88,6 +88,30 @@ enum PDFArchiver {
         guard CGImageDestinationFinalize(dest) else {
             throw ArchiveError.imageDestinationFinalizeFailed
         }
+
+        // Flush to durable storage so downstream readers (symlink creation,
+        // block emission, local archive server) never see a zero-length or
+        // partial file. F_FULLFSYNC forces the drive to commit to persistent
+        // media — plain fsync() on Apple platforms only flushes to the
+        // drive's volatile write cache.
+        let fd = open(destination.path, O_RDONLY)
+        if fd >= 0 {
+            fcntl(fd, F_FULLFSYNC)
+            close(fd)
+        }
+    }
+
+    /// Returns `true` iff the page image file exists on disk with non-zero
+    /// size. Used as a gate before emitting reader blocks that reference the
+    /// file — ensures downstream consumers never point at empty or missing
+    /// images.
+    static func verifyPageImageOnDisk(for itemID: UUID, pageIndex: Int) -> Bool {
+        let url = pageImageURL(for: itemID, pageIndex: pageIndex)
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let size = attrs[.size] as? UInt64 else {
+            return false
+        }
+        return size > 0
     }
 
     /// Removes the archived PDF and every `pdf-page-N.jpg` file for an
@@ -128,6 +152,52 @@ enum PDFArchiver {
             .sorted { lhs, rhs in
                 pageIndex(from: lhs) < pageIndex(from: rhs)
             }
+    }
+
+    /// Moves all `pdf-page-N.jpg` files from one item's archive directory to
+    /// another's. Used when the canonical URL (and therefore the stable item
+    /// ID) is overridden after page images have already been written — e.g.
+    /// when `URLIngestionClient` replaces the `pdf-sha256:` canonical URL
+    /// with the original HTTP URL for dedup purposes.
+    ///
+    /// No-op when source and destination IDs are equal or when the source
+    /// directory contains no page images.
+    static func relocatePageImages(from sourceItemID: UUID, to destinationItemID: UUID) throws {
+        guard sourceItemID != destinationItemID else { return }
+        let sourceURLs = pageImageURLs(for: sourceItemID)
+        guard !sourceURLs.isEmpty else { return }
+
+        let destDir = AssetArchiver.archiveDirectory(for: destinationItemID)
+        try FileManager.default.createDirectory(at: destDir, withIntermediateDirectories: true)
+
+        for source in sourceURLs {
+            let dest = destDir.appendingPathComponent(source.lastPathComponent)
+            if FileManager.default.fileExists(atPath: dest.path) {
+                try FileManager.default.removeItem(at: dest)
+            }
+            try FileManager.default.moveItem(at: source, to: dest)
+        }
+    }
+
+    /// Symlinks all existing page images for `itemID` from the archive into
+    /// `targetDir`. Skips any source file that does not exist on disk,
+    /// preventing dangling symlinks that would cause the local archive server
+    /// to 404. Returns the count of successfully created symlinks.
+    @discardableResult
+    static func symlinkPageImages(for itemID: UUID, into targetDir: URL) -> Int {
+        var count = 0
+        for source in pageImageURLs(for: itemID) {
+            guard FileManager.default.fileExists(atPath: source.path) else { continue }
+            let link = targetDir.appendingPathComponent(source.lastPathComponent)
+            try? FileManager.default.removeItem(at: link)
+            do {
+                try FileManager.default.createSymbolicLink(at: link, withDestinationURL: source)
+                count += 1
+            } catch {
+                // Partial symlinks are better than crashing the reader.
+            }
+        }
+        return count
     }
 
     /// Parses the numeric index out of a `pdf-page-N.jpg` URL for sorting.

--- a/StowerPackage/Sources/StowerFeatureV2/Support/PDFIngestionClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/PDFIngestionClient.swift
@@ -156,6 +156,13 @@ private func pdfIngest(url: URL) async throws -> IngestionResult {
             continue
         }
 
+        guard PDFArchiver.verifyPageImageOnDisk(for: itemID, pageIndex: pageIndex) else {
+            kPDFIngestLog.error(
+                "Page image \(pageIndex, privacy: .public) written but failed on-disk verification — skipping block"
+            )
+            continue
+        }
+
         // Emit the figure block pointing at the image on disk.
         // `MediaDescriptor.sourceURL` uses a custom `stower://pdf-page/N`
         // scheme as a marker so `ReaderDocumentHTMLBuilder.resolveMediaURL`

--- a/StowerPackage/Sources/StowerFeatureV2/Support/URLIngestionClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/URLIngestionClient.swift
@@ -365,6 +365,21 @@ private func maybeIngestAsPDF(url: URL) async throws -> IngestionResult? {
     // Override source/canonical to the real URL so URL-based dedup and
     // hydrate-on-second-device both work. The pdfSHA256 stays on the result
     // so AppFeature.processIngestionJobs can locate the staged file below.
+    //
+    // Because pdfIngest() wrote page images keyed on the SHA-based canonical
+    // URL, and createItemFromIngestion will compute the item ID from the
+    // HTTP URL below, we must relocate the page images to the correct
+    // archive directory. Without this, the reader would look for images
+    // under the HTTP-based item ID and find an empty directory.
+    if let hash = result.pdfSHA256 {
+        let shaCanonical = "pdf-sha256:\(hash)"
+        let shaItemID = StowerRepository.stableItemID(from: shaCanonical)
+        let urlItemID = StowerRepository.stableItemID(from: url.absoluteString)
+        if shaItemID != urlItemID {
+            try? PDFArchiver.relocatePageImages(from: shaItemID, to: urlItemID)
+        }
+    }
+
     result.sourceURL = url.absoluteString
     result.canonicalURL = url.absoluteString
     result.document.sourceURL = url.absoluteString

--- a/StowerPackage/Tests/StowerFeatureV2Tests/PDFArchiverTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/PDFArchiverTests.swift
@@ -10,7 +10,6 @@ import UniformTypeIdentifiers
 /// directory on the real filesystem.
 @Suite(.serialized)
 struct PDFArchiverTests {
-
     // MARK: - Phase 1: archivePageImage writes a durable, readable JPEG
 
     @Test
@@ -148,9 +147,10 @@ struct PDFArchiverTests {
         let count = PDFArchiver.symlinkPageImages(for: id, into: targetDir)
 
         #expect(count == 2)
-        let names = try FileManager.default.contentsOfDirectory(
-            at: targetDir, includingPropertiesForKeys: nil
-        ).map(\.lastPathComponent).sorted()
+        let names = try FileManager.default
+            .contentsOfDirectory(at: targetDir, includingPropertiesForKeys: nil)
+            .map(\.lastPathComponent)
+            .sorted()
         #expect(names == ["pdf-page-0.jpg", "pdf-page-2.jpg"])
     }
 

--- a/StowerPackage/Tests/StowerFeatureV2Tests/PDFArchiverTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/PDFArchiverTests.swift
@@ -1,0 +1,284 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+@testable import StowerFeature
+import Testing
+import UniformTypeIdentifiers
+
+/// Tests for PDF page-image archiving, on-disk verification, and symlink
+/// creation. Serialized because tests write to the shared `StowerArchive`
+/// directory on the real filesystem.
+@Suite(.serialized)
+struct PDFArchiverTests {
+
+    // MARK: - Phase 1: archivePageImage writes a durable, readable JPEG
+
+    @Test
+    func archivePageImage_writesReadableJPEG() throws {
+        let id = UUID()
+        defer { AssetArchiver.deleteArchive(for: id) }
+
+        let image = makeTestImage()
+        try PDFArchiver.archivePageImage(image, for: id, pageIndex: 0)
+
+        let url = PDFArchiver.pageImageURL(for: id, pageIndex: 0)
+        #expect(FileManager.default.fileExists(atPath: url.path))
+
+        let data = try Data(contentsOf: url)
+        #expect(data.count > 0)
+        // JPEG SOI marker
+        #expect(data[0] == 0xFF)
+        #expect(data[1] == 0xD8)
+    }
+
+    @Test
+    func archivePageImage_fileIsDurablyDecodable() throws {
+        let id = UUID()
+        defer { AssetArchiver.deleteArchive(for: id) }
+
+        let image = makeTestImage(width: 10, height: 10)
+        try PDFArchiver.archivePageImage(image, for: id, pageIndex: 0)
+
+        let url = PDFArchiver.pageImageURL(for: id, pageIndex: 0)
+        let data = try Data(contentsOf: url)
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let decoded = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            Issue.record("Written file does not decode as a valid image")
+            return
+        }
+        #expect(decoded.width == 10)
+        #expect(decoded.height == 10)
+    }
+
+    // MARK: - Phase 2: on-disk verification
+
+    @Test
+    func verifyPageImageOnDisk_returnsFalseForMissingFile() {
+        let id = UUID()
+        #expect(PDFArchiver.verifyPageImageOnDisk(for: id, pageIndex: 0) == false)
+    }
+
+    @Test
+    func verifyPageImageOnDisk_returnsTrueAfterWrite() throws {
+        let id = UUID()
+        defer { AssetArchiver.deleteArchive(for: id) }
+
+        let image = makeTestImage()
+        try PDFArchiver.archivePageImage(image, for: id, pageIndex: 0)
+
+        #expect(PDFArchiver.verifyPageImageOnDisk(for: id, pageIndex: 0) == true)
+    }
+
+    @Test
+    func archivePageImage_producesNonEmptyFile() throws {
+        let id = UUID()
+        defer { AssetArchiver.deleteArchive(for: id) }
+
+        let image = makeTestImage()
+        try PDFArchiver.archivePageImage(image, for: id, pageIndex: 0)
+
+        let url = PDFArchiver.pageImageURL(for: id, pageIndex: 0)
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        let size = attrs[.size] as? UInt64
+        #expect((size ?? 0) > 0)
+    }
+
+    // MARK: - Phase 3: symlink creation with target verification
+
+    @Test
+    func symlinkPageImages_skipsNonexistentSources() throws {
+        let id = UUID()
+        let targetDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: targetDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: targetDir) }
+
+        let count = PDFArchiver.symlinkPageImages(for: id, into: targetDir)
+
+        #expect(count == 0)
+        let contents = try FileManager.default.contentsOfDirectory(
+            at: targetDir, includingPropertiesForKeys: nil
+        )
+        #expect(contents.isEmpty)
+    }
+
+    @Test
+    func symlinkPageImages_linksExistingImages() throws {
+        let id = UUID()
+        defer { AssetArchiver.deleteArchive(for: id) }
+
+        let targetDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: targetDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: targetDir) }
+
+        let image = makeTestImage()
+        for i in 0..<3 {
+            try PDFArchiver.archivePageImage(image, for: id, pageIndex: i)
+        }
+
+        let count = PDFArchiver.symlinkPageImages(for: id, into: targetDir)
+
+        #expect(count == 3)
+        let contents = try FileManager.default.contentsOfDirectory(
+            at: targetDir, includingPropertiesForKeys: nil
+        )
+        #expect(contents.count == 3)
+
+        for url in contents {
+            let data = try Data(contentsOf: url)
+            #expect(data.count > 0)
+        }
+    }
+
+    @Test
+    func symlinkPageImages_skipsPartialSet() throws {
+        let id = UUID()
+        defer { AssetArchiver.deleteArchive(for: id) }
+
+        let targetDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: targetDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: targetDir) }
+
+        let image = makeTestImage()
+        try PDFArchiver.archivePageImage(image, for: id, pageIndex: 0)
+        try PDFArchiver.archivePageImage(image, for: id, pageIndex: 2)
+
+        let count = PDFArchiver.symlinkPageImages(for: id, into: targetDir)
+
+        #expect(count == 2)
+        let names = try FileManager.default.contentsOfDirectory(
+            at: targetDir, includingPropertiesForKeys: nil
+        ).map(\.lastPathComponent).sorted()
+        #expect(names == ["pdf-page-0.jpg", "pdf-page-2.jpg"])
+    }
+
+    // MARK: - Phase 5: relocate page images (canonical URL mismatch fix)
+
+    @Test
+    func relocatePageImages_movesAllPagesToNewItemID() throws {
+        let sourceID = UUID()
+        let destID = UUID()
+        defer {
+            AssetArchiver.deleteArchive(for: sourceID)
+            AssetArchiver.deleteArchive(for: destID)
+        }
+
+        let image = makeTestImage()
+        for i in 0..<3 {
+            try PDFArchiver.archivePageImage(image, for: sourceID, pageIndex: i)
+        }
+
+        try PDFArchiver.relocatePageImages(from: sourceID, to: destID)
+
+        // Source should be empty of page images
+        #expect(PDFArchiver.pageImageURLs(for: sourceID).isEmpty)
+
+        // Destination should have all 3
+        let destURLs = PDFArchiver.pageImageURLs(for: destID)
+        #expect(destURLs.count == 3)
+        for url in destURLs {
+            let data = try Data(contentsOf: url)
+            #expect(data.count > 0)
+        }
+    }
+
+    @Test
+    func relocatePageImages_noopWhenSameID() throws {
+        let id = UUID()
+        defer { AssetArchiver.deleteArchive(for: id) }
+
+        let image = makeTestImage()
+        try PDFArchiver.archivePageImage(image, for: id, pageIndex: 0)
+
+        try PDFArchiver.relocatePageImages(from: id, to: id)
+
+        #expect(PDFArchiver.pageImageURLs(for: id).count == 1)
+    }
+
+    @Test
+    func relocatePageImages_noopWhenSourceEmpty() throws {
+        let sourceID = UUID()
+        let destID = UUID()
+
+        // Should not throw even when source has no images
+        try PDFArchiver.relocatePageImages(from: sourceID, to: destID)
+
+        #expect(PDFArchiver.pageImageURLs(for: destID).isEmpty)
+    }
+
+    // MARK: - Phase 4: server integration (PDF page images via symlinks)
+
+    @Test
+    func localArchiveServer_returns404_forMissingPDFPageImage() async throws {
+        let scratchDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratchDir) }
+
+        try Data("<html></html>".utf8).write(
+            to: scratchDir.appendingPathComponent("index.html"),
+            options: .atomic
+        )
+
+        let server = LocalArchiveServer(archiveDir: scratchDir, articlePath: "/", originURL: nil)
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let url = URL(string: "http://localhost:\(port)/pdf-page-0.jpg")!
+        let (_, response) = try await URLSession.shared.data(from: url)
+        let http = try #require(response as? HTTPURLResponse)
+        #expect(http.statusCode == 404)
+    }
+
+    @Test
+    func localArchiveServer_serves200_whenPageImageExists() async throws {
+        let id = UUID()
+        defer { AssetArchiver.deleteArchive(for: id) }
+
+        let scratchDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratchDir) }
+
+        try Data("<html></html>".utf8).write(
+            to: scratchDir.appendingPathComponent("index.html"),
+            options: .atomic
+        )
+
+        let image = makeTestImage(width: 10, height: 10)
+        try PDFArchiver.archivePageImage(image, for: id, pageIndex: 0)
+        PDFArchiver.symlinkPageImages(for: id, into: scratchDir)
+
+        let server = LocalArchiveServer(archiveDir: scratchDir, articlePath: "/", originURL: nil)
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let url = URL(string: "http://localhost:\(port)/pdf-page-0.jpg")!
+        let (data, response) = try await URLSession.shared.data(from: url)
+        let http = try #require(response as? HTTPURLResponse)
+        #expect(http.statusCode == 200)
+        #expect(data.count > 0)
+        #expect(data[0] == 0xFF)
+        #expect(data[1] == 0xD8)
+    }
+
+    // MARK: - Helpers
+
+    private func makeTestImage(width: Int = 1, height: Int = 1) -> CGImage {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        context.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return context.makeImage()!
+    }
+}


### PR DESCRIPTION
## Summary
Closes #18.

- **Root cause:** `pdfIngest()` writes page images to `StowerArchive/{stableID("pdf-sha256:HASH")}/`, but `maybeIngestAsPDF()` overrides `canonicalURL` to the HTTP URL before `createItemFromIngestion` computes the final item ID. The reader looks for images under the HTTP-based UUID and finds an empty directory — every page 404s.
- **Fix:** Relocate page images from the SHA-based archive directory to the URL-based archive directory after the canonical URL override in `URLIngestionClient`.
- **Pipeline hardening:** Added `F_FULLFSYNC` after writing page images, on-disk verification before emitting figure blocks, verified symlink creation, and PDF-specific 404 diagnostic logging.

## Changes

| File | What |
|------|------|
| `PDFArchiver.swift` | `F_FULLFSYNC`, `verifyPageImageOnDisk()`, `symlinkPageImages()`, `relocatePageImages()` |
| `PDFIngestionClient.swift` | Verification guard before block creation |
| `URLIngestionClient.swift` | Relocate page images after canonical URL override |
| `ReaderWebView.swift` | Replace inline symlink loop with `PDFArchiver.symlinkPageImages()` |
| `LocalArchiveServer.swift` | PDF-specific 404 logging |
| `PDFArchiverTests.swift` | 13 new tests (125 total pass) |