### PR TITLE
Add tag colors, inline creation, library pills, and sync diagnostics

### DIFF
--- a/StowerPackage/Sources/StowerData/Data/Bootstrap+CloudSync.swift
+++ b/StowerPackage/Sources/StowerData/Data/Bootstrap+CloudSync.swift
@@ -21,6 +21,18 @@ extension StowerDatabase {
 
         do {
             let delegate = syncEngineDelegate ?? StowerSyncEngineDelegate { continuation.yield($0) }
+            // TagSyncTable and ItemTagSyncTable are fully self-contained
+            // sync tables — unlike SavedPDFContentSyncTable (which has
+            // _hydratePDFItemsFromSyncedContent), they have no post-receive
+            // hydration step because the domain model reads directly from
+            // the sync tables.
+            //
+            // Known limitation: deleting a tag on Device A removes its
+            // ItemTagSyncTable junction rows locally, but Device B only
+            // receives the TagSyncTable deletion via CloudKit — the orphaned
+            // junction rows on Device B are not automatically cleaned up.
+            // TODO: Add a _reconcileOrphanedJunctionRows sweep on launch or
+            // after sync to garbage-collect junctions referencing deleted tags.
             let syncEngine: SyncEngine = try SyncEngine(
                 for: database,
                 tables: SavedItemSyncTable.self,

--- a/StowerPackage/Sources/StowerData/Data/Bootstrap+Diagnostics.swift
+++ b/StowerPackage/Sources/StowerData/Data/Bootstrap+Diagnostics.swift
@@ -6,6 +6,8 @@ extension StowerDatabase {
         { () async throws -> SyncDiagnostics in
             try await database.read { db -> SyncDiagnostics in
                 let syncedCount: Int = try SavedItemSyncTable.fetchCount(db)
+                let tagCount: Int = try TagSyncTable.fetchCount(db)
+                let itemTagCount: Int = try ItemTagSyncTable.fetchCount(db)
                 let sample: [SyncItemSummary] = try SavedItemSyncTable
                     .order { $0.updatedAt.desc() }
                     .fetchAll(db)
@@ -26,6 +28,8 @@ extension StowerDatabase {
                     syncedItemsCount: syncedCount,
                     pendingChangesCount: pendingCount,
                     metadataCount: metadataCount,
+                    syncedTagsCount: tagCount,
+                    syncedItemTagsCount: itemTagCount,
                     sampleItems: Array(sample)
                 )
             }

--- a/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
+++ b/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
@@ -6,6 +6,8 @@ import SQLiteData
 
 public struct SyncDiagnostics: Equatable, Sendable {
     public var syncedItemsCount: Int
+    public var syncedTagsCount: Int
+    public var syncedItemTagsCount: Int
     public var pendingChangesCount: Int
     public var metadataCount: Int
     public let sampleItems: [SyncItemSummary]
@@ -14,9 +16,13 @@ public struct SyncDiagnostics: Equatable, Sendable {
         syncedItemsCount: Int,
         pendingChangesCount: Int,
         metadataCount: Int,
+        syncedTagsCount: Int = 0,
+        syncedItemTagsCount: Int = 0,
         sampleItems: [SyncItemSummary] = []
     ) {
         self.syncedItemsCount = syncedItemsCount
+        self.syncedTagsCount = syncedTagsCount
+        self.syncedItemTagsCount = syncedItemTagsCount
         self.pendingChangesCount = pendingChangesCount
         self.metadataCount = metadataCount
         self.sampleItems = sampleItems

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Tags.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Tags.swift
@@ -30,6 +30,24 @@ extension StowerRepository {
         }
     }
 
+    static func _fetchTagIDsByItem(
+        database: any DatabaseWriter
+    ) -> @Sendable ([UUID]) async throws -> [UUID: [UUID]] {
+        { (itemIDs: [UUID]) async throws -> [UUID: [UUID]] in
+            guard !itemIDs.isEmpty else { return [:] }
+            return try await database.read { db -> [UUID: [UUID]] in
+                let junctions: [ItemTagSyncTable] = try ItemTagSyncTable
+                    .where { $0.itemID.in(itemIDs) }
+                    .fetchAll(db)
+                var result: [UUID: [UUID]] = [:] // swiftlint:disable:this prefer_let_over_var
+                for row in junctions {
+                    result[row.itemID, default: []].append(row.tagID)
+                }
+                return result
+            }
+        }
+    }
+
     // MARK: Mutations
 
     /// Creates a tag, returning the existing row if a case-insensitive name

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository.swift
@@ -39,6 +39,7 @@ public struct StowerRepository: Sendable {
     // MARK: - Tags
     public var fetchTags: @Sendable () async throws -> [Tag]
     public var fetchTagIDs: @Sendable (UUID) async throws -> [UUID]
+    public var fetchTagIDsByItem: @Sendable ([UUID]) async throws -> [UUID: [UUID]]
     public var createTag: @Sendable (String, String?) async throws -> Tag
     public var renameTag: @Sendable (UUID, String) async throws -> Void
     public var deleteTag: @Sendable (UUID) async throws -> Void
@@ -108,6 +109,7 @@ extension StowerRepository {
             fetchListCounts: { .zero },
             fetchTags: { [] },
             fetchTagIDs: { _ in [] },
+            fetchTagIDsByItem: { _ in [:] },
             createTag: { name, _ in Tag(name: name) },
             renameTag: { _, _ in },
             deleteTag: { _ in },
@@ -231,6 +233,7 @@ extension StowerRepository {
             fetchListCounts: _fetchListCounts(database: database),
             fetchTags: _fetchTags(database: database),
             fetchTagIDs: _fetchTagIDs(database: database),
+            fetchTagIDsByItem: _fetchTagIDsByItem(database: database),
             createTag: _createTag(database: database, scheduleSync: scheduleSyncAndNotify),
             renameTag: _renameTag(database: database, scheduleSync: scheduleSyncAndNotify),
             deleteTag: _deleteTag(database: database, scheduleSync: scheduleSyncAndNotify),

--- a/StowerPackage/Sources/StowerData/Domain/TagColorSuggester.swift
+++ b/StowerPackage/Sources/StowerData/Domain/TagColorSuggester.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public enum TagColorSuggester {
+    /// Returns the hex string for the next unused Flexoki hue at shade 600.
+    ///
+    /// Algorithm: check which `FlexokiHue` values are already represented in
+    /// `existingHexValues` (matching any shade in the hue's ramp), then return
+    /// the first unused hue's shade 600. Wraps to the first hue if all are used.
+    public static func suggestColor(existingHexValues: [String]) -> String {
+        let normalised = Set(existingHexValues.map { $0.uppercased() })
+        let usedHues: Set<FlexokiHue> = Set(
+            FlexokiHue.allCases.filter { hue in
+                let rampValues = Set(FlexokiRaw.ramp(for: hue).values.map { $0.uppercased() })
+                return !rampValues.isDisjoint(with: normalised)
+            }
+        )
+
+        let suggested = FlexokiHue.allCases.first { !usedHues.contains($0) }
+            ?? FlexokiHue.allCases[0]
+
+        return FlexokiRaw.shade(suggested, 600)
+    }
+}

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryFeature.swift
@@ -20,6 +20,8 @@ public struct LibraryFeature {
         /// All tags known to the repository — drives the "Tags" submenu in the
         /// library row context menu. Refreshed lazily via observeLibraryChanges.
         public var availableTags: [Tag] = [] // swiftlint:disable:this prefer_let_over_var
+        /// Non-nil when the user is creating a new tag inline from the tag submenu.
+        public var inlineTagCreation: InlineTagCreation?
 
         /// Library search matches against title, URL, site name, author,
         /// excerpt, AND full body text (`item.content`). The body-text
@@ -60,6 +62,18 @@ public struct LibraryFeature {
         public init() {}
     }
 
+    public struct InlineTagCreation: Equatable {
+        public var itemID: UUID
+        public var name: String = ""
+        public var colorHex: String = ""
+
+        public init(itemID: UUID, name: String = "", colorHex: String = "") {
+            self.itemID = itemID
+            self.name = name
+            self.colorHex = colorHex
+        }
+    }
+
     public enum Action: Equatable {
         case onAppear
         case reload
@@ -86,8 +100,18 @@ public struct LibraryFeature {
         // Tag assignment
         case reloadTags
         case tagsLoaded([Tag])
+        case refreshTagIDs
+        case tagIDsRefreshed([UUID: [UUID]])
         case toggleTagOnItem(UUID, UUID)
         case observedChange
+
+        // Inline tag creation
+        case inlineCreateTagTapped(UUID)
+        case inlineCreateTagNameChanged(String)
+        case inlineCreateTagColorChanged(String)
+        case inlineCreateTagConfirmed
+        case inlineCreateTagDismissed
+        case inlineTagCreated(Tag, UUID)
     }
 
     private enum CancelID: Hashable {
@@ -118,10 +142,13 @@ public struct LibraryFeature {
                 )
 
             case .observedChange:
-                // Background ping: refresh tag list only. Don't re-fetch items
-                // because that would clobber scroll position and any pending
-                // optimistic mutations.
-                return .send(.reloadTags)
+                // Refresh tag list and re-populate tagIDs on existing items.
+                // We avoid re-fetching the full item list to preserve scroll
+                // position and pending optimistic mutations.
+                return .merge(
+                    .send(.reloadTags),
+                    .send(.refreshTagIDs)
+                )
 
             case .reloadTags:
                 let repository = self.repository
@@ -137,6 +164,25 @@ public struct LibraryFeature {
 
             case .tagsLoaded(let tags):
                 state.availableTags = tags
+                return .none
+
+            case .refreshTagIDs:
+                let ids = state.items.map(\.id)
+                let repository = self.repository
+                return .run { send in
+                    let mapping = try await repository.fetchTagIDsByItem(ids)
+                    await send(.tagIDsRefreshed(mapping))
+                }
+
+            case .tagIDsRefreshed(let mapping):
+                for idx in state.items.indices {
+                    let itemID = state.items[idx].id
+                    if let tagIDs = mapping[itemID] {
+                        state.items[idx].tagIDs = tagIDs
+                    } else {
+                        state.items[idx].tagIDs = []
+                    }
+                }
                 return .none
 
             case let .toggleTagOnItem(itemID, tagID):
@@ -173,6 +219,53 @@ public struct LibraryFeature {
                         // observeLibraryChanges ping will reconcile if needed.
                     }
                 }
+
+            case .inlineCreateTagTapped(let itemID):
+                let suggestedColor = TagColorSuggester.suggestColor(
+                    existingHexValues: state.availableTags.compactMap(\.colorHex)
+                )
+                state.inlineTagCreation = InlineTagCreation(
+                    itemID: itemID,
+                    colorHex: suggestedColor
+                )
+                return .none
+
+            case .inlineCreateTagNameChanged(let name):
+                state.inlineTagCreation?.name = name
+                return .none
+
+            case .inlineCreateTagColorChanged(let hex):
+                state.inlineTagCreation?.colorHex = hex
+                return .none
+
+            case .inlineCreateTagDismissed:
+                state.inlineTagCreation = nil
+                return .none
+
+            case .inlineCreateTagConfirmed:
+                guard let creation = state.inlineTagCreation else { return .none }
+                let name = creation.name.trimmingCharacters(in: .whitespacesAndNewlines)
+                let itemID = creation.itemID
+                let colorHex = creation.colorHex.isEmpty ? nil : creation.colorHex
+                state.inlineTagCreation = nil
+                guard !name.isEmpty else { return .none }
+
+                let repository = self.repository
+                return .run { send in
+                    let tag = try await repository.createTag(name, colorHex)
+                    try await repository.addTag(itemID, tag.id)
+                    await send(.inlineTagCreated(tag, itemID))
+                }
+
+            case let .inlineTagCreated(tag, itemID):
+                if !state.availableTags.contains(where: { $0.id == tag.id }) {
+                    state.availableTags.append(tag)
+                }
+                if let idx = state.items.firstIndex(where: { $0.id == itemID }),
+                   !state.items[idx].tagIDs.contains(tag.id) {
+                    state.items[idx].tagIDs.append(tag.id)
+                }
+                return .send(.reloadTags)
 
             case .reload:
                 state.isLoading = true

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
@@ -81,6 +81,8 @@ public struct LibraryScreen: View {
                                 }
                             }
 
+                            tagPillsRow(for: item)
+
                             // When the query matches body text (not title),
                             // surface the hit as a snippet so the user can
                             // tell why the row showed up in results. Nil
@@ -284,6 +286,24 @@ public struct LibraryScreen: View {
         ) { result in
             handlePDFImport(result)
         }
+        .sheet(isPresented: Binding(
+            get: { store.inlineTagCreation != nil },
+            set: { if !$0 { store.send(.inlineCreateTagDismissed) } }
+        )) {
+            NewTagSheet(
+                name: Binding(
+                    get: { store.inlineTagCreation?.name ?? "" },
+                    set: { store.send(.inlineCreateTagNameChanged($0)) }
+                ),
+                colorHex: Binding(
+                    get: { store.inlineTagCreation?.colorHex ?? "" },
+                    set: { store.send(.inlineCreateTagColorChanged($0)) }
+                ),
+                palette: palette,
+                onCancel: { store.send(.inlineCreateTagDismissed) },
+                onCreate: { store.send(.inlineCreateTagConfirmed) }
+            )
+        }
         .task {
             store.send(.onAppear)
         }
@@ -393,27 +413,68 @@ public struct LibraryScreen: View {
     }
     #endif
 
+    // MARK: - Tag Pills
+
+    @ViewBuilder
+    private func tagPillsRow(for item: SavedItem) -> some View {
+        let tags = resolvedTags(for: item)
+        if !tags.isEmpty {
+            let visible = Array(tags.prefix(3))
+            let overflow = tags.count - visible.count
+            HStack(spacing: 4) {
+                ForEach(visible) { tag in
+                    let color = tagPillColor(tag.colorHex)
+                    Text(tag.name)
+                        .font(.caption2.weight(.medium))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .foregroundStyle(color)
+                        .background(color.opacity(0.15), in: .capsule)
+                }
+                if overflow > 0 {
+                    Text("+\(overflow)")
+                        .font(.caption2)
+                        .foregroundStyle(palette.tx2)
+                }
+            }
+        }
+    }
+
+    private func resolvedTags(for item: SavedItem) -> [Tag] {
+        item.tagIDs.compactMap { id in
+            store.availableTags.first { $0.id == id }
+        }
+    }
+
+    private func tagPillColor(_ hex: String?) -> Color {
+        guard let hex, !hex.isEmpty else { return palette.secondary }
+        return Color(hex: hex)
+    }
+
+    // MARK: - Tags Submenu
+
     @ViewBuilder
     private func tagsSubmenu(for item: SavedItem) -> some View {
-        if store.availableTags.isEmpty {
-            Button("Tags…", systemImage: "tag") { }
-                .disabled(true)
-        } else {
-            Menu {
-                ForEach(store.availableTags) { tag in
-                    Button {
-                        store.send(.toggleTagOnItem(item.id, tag.id))
-                    } label: {
-                        if item.tagIDs.contains(tag.id) {
-                            Label(tag.name, systemImage: "checkmark")
-                        } else {
-                            Text(tag.name)
-                        }
+        Menu {
+            ForEach(store.availableTags) { tag in
+                Button {
+                    store.send(.toggleTagOnItem(item.id, tag.id))
+                } label: {
+                    if item.tagIDs.contains(tag.id) {
+                        Label(tag.name, systemImage: "checkmark")
+                    } else {
+                        Text(tag.name)
                     }
                 }
-            } label: {
-                Label("Tags", systemImage: "tag")
             }
+            Divider()
+            Button {
+                store.send(.inlineCreateTagTapped(item.id))
+            } label: {
+                Label("New Tag\u{2026}", systemImage: "plus")
+            }
+        } label: {
+            Label("Tags", systemImage: "tag")
         }
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsScreen.swift
@@ -33,6 +33,14 @@ public struct SettingsScreen: View {
                         Text("\(diagnostics.syncedItemsCount)")
                             .foregroundStyle(.secondary)
                     }
+                    LabeledContent("Synced tags") {
+                        Text("\(diagnostics.syncedTagsCount)")
+                            .foregroundStyle(.secondary)
+                    }
+                    LabeledContent("Synced item-tag links") {
+                        Text("\(diagnostics.syncedItemTagsCount)")
+                            .foregroundStyle(.secondary)
+                    }
                     LabeledContent("Pending changes") {
                         Text("\(diagnostics.pendingChangesCount)")
                             .foregroundStyle(.secondary)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Sidebar/SidebarFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Sidebar/SidebarFeature.swift
@@ -16,6 +16,8 @@ public struct SidebarFeature {
         /// Bound to the "New Tag" sheet.
         public var isCreatingTag: Bool = false
         public var newTagName: String = ""
+        /// Selected color hex for tag creation — pre-populated with a suggestion.
+        public var newTagColorHex: String = ""
         /// Non-nil when the user is renaming a tag — holds the working name.
         public var renamingTag: RenameState?
 
@@ -41,6 +43,7 @@ public struct SidebarFeature {
         case newTagTapped
         case newTagDismissed
         case newTagNameChanged(String)
+        case newTagColorChanged(String)
         case newTagConfirmed
         case tagCreated(Tag)
 
@@ -115,26 +118,37 @@ public struct SidebarFeature {
             case .newTagTapped:
                 state.isCreatingTag = true
                 state.newTagName = ""
+                let existingHexes = state.tags.compactMap(\.colorHex)
+                state.newTagColorHex = TagColorSuggester.suggestColor(
+                    existingHexValues: existingHexes
+                )
                 return .none
 
             case .newTagDismissed:
                 state.isCreatingTag = false
                 state.newTagName = ""
+                state.newTagColorHex = ""
                 return .none
 
             case .newTagNameChanged(let value):
                 state.newTagName = value
                 return .none
 
+            case .newTagColorChanged(let hex):
+                state.newTagColorHex = hex
+                return .none
+
             case .newTagConfirmed:
                 let name = state.newTagName.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !name.isEmpty else { return .none }
+                let colorHex = state.newTagColorHex.isEmpty ? nil : state.newTagColorHex
                 state.isCreatingTag = false
                 state.newTagName = ""
+                state.newTagColorHex = ""
                 let repository = self.repository
                 return .run { send in
                     do {
-                        let tag = try await repository.createTag(name, nil)
+                        let tag = try await repository.createTag(name, colorHex)
                         await send(.tagCreated(tag))
                     } catch {
                         await send(.failed(error.localizedDescription))

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Sidebar/SidebarScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Sidebar/SidebarScreen.swift
@@ -74,19 +74,23 @@ public struct SidebarScreen: View {
                 .padding(12)
             }
         }
-        .alert(
-            "New Tag",
-            isPresented: Binding(
-                get: { store.isCreatingTag },
-                set: { if !$0 { store.send(.newTagDismissed) } }
+        .sheet(isPresented: Binding(
+            get: { store.isCreatingTag },
+            set: { if !$0 { store.send(.newTagDismissed) } }
+        )) {
+            NewTagSheet(
+                name: Binding(
+                    get: { store.newTagName },
+                    set: { store.send(.newTagNameChanged($0)) }
+                ),
+                colorHex: Binding(
+                    get: { store.newTagColorHex },
+                    set: { store.send(.newTagColorChanged($0)) }
+                ),
+                palette: palette,
+                onCancel: { store.send(.newTagDismissed) },
+                onCreate: { store.send(.newTagConfirmed) }
             )
-        ) {
-            TextField("Tag name", text: Binding(
-                get: { store.newTagName },
-                set: { store.send(.newTagNameChanged($0)) }
-            ))
-            Button("Cancel", role: .cancel) { store.send(.newTagDismissed) }
-            Button("Create") { store.send(.newTagConfirmed) }
         }
         .alert(
             "Rename Tag",
@@ -196,9 +200,7 @@ public struct SidebarScreen: View {
     }
 
     private func tagColor(_ hex: String?) -> Color {
-        // Color parsing is a follow-up; for now every tag uses the current
-        // palette's secondary accent so tags visually contrast with the
-        // primary-tinted system tint without clashing.
-        palette.secondary
+        guard let hex, !hex.isEmpty else { return palette.secondary }
+        return Color(hex: hex)
     }
 }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/NewTagSheet.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/NewTagSheet.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+struct NewTagSheet: View {
+    @Binding var name: String
+    @Binding var colorHex: String
+    let palette: FlexokiPalette
+    let onCancel: () -> Void
+    let onCreate: () -> Void
+
+    private let presetHues = FlexokiHue.allCases
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                TextField("Tag name", text: $name)
+                    .textFieldStyle(.roundedBorder)
+
+                HStack(spacing: 10) {
+                    ForEach(presetHues, id: \.self) { hue in
+                        let hex = FlexokiRaw.shade(hue, 600)
+                        Button {
+                            colorHex = hex
+                        } label: {
+                            Circle()
+                                .fill(Color(hex: hex))
+                                .frame(width: 28, height: 28)
+                                .overlay {
+                                    if colorHex.uppercased() == hex.uppercased() {
+                                        Image(systemName: "checkmark")
+                                            .font(.caption2.bold())
+                                            .foregroundStyle(.white)
+                                    }
+                                }
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(hue.displayName)
+                    }
+
+                    Divider()
+                        .frame(height: 20)
+
+                    ColorPicker(
+                        "Custom",
+                        selection: Binding(
+                            get: { colorFromHex(colorHex) },
+                            set: { colorHex = hexFromColor($0) }
+                        )
+                    )
+                    .labelsHidden()
+                    .accessibilityLabel("Custom color")
+                }
+
+                if !trimmedName.isEmpty {
+                    HStack {
+                        let color = resolvedColor
+                        Text(trimmedName)
+                            .font(.caption2.weight(.medium))
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .foregroundStyle(color)
+                            .background(color.opacity(0.15), in: .capsule)
+                        Spacer()
+                    }
+                }
+
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("New Tag")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", action: onCancel)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Create", action: onCreate)
+                        .disabled(trimmedName.isEmpty)
+                }
+            }
+        }
+        .frame(minWidth: 320, idealWidth: 380, minHeight: 220, idealHeight: 260)
+    }
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var resolvedColor: Color {
+        colorHex.isEmpty ? palette.secondary : Color(hex: colorHex)
+    }
+
+    private func colorFromHex(_ hex: String) -> Color {
+        hex.isEmpty ? palette.secondary : Color(hex: hex)
+    }
+
+    private func hexFromColor(_ color: Color) -> String {
+        let resolved = color.resolve(in: EnvironmentValues())
+        let r = Int(resolved.red * 255)
+        let g = Int(resolved.green * 255)
+        let b = Int(resolved.blue * 255)
+        return String(format: "#%02X%02X%02X", r, g, b)
+    }
+}

--- a/StowerPackage/Sources/StowerFeatureV2/Support/PDFArchiver.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/PDFArchiver.swift
@@ -96,7 +96,7 @@ enum PDFArchiver {
         // drive's volatile write cache.
         let fd = open(destination.path, O_RDONLY)
         if fd >= 0 {
-            fcntl(fd, F_FULLFSYNC)
+            _ = fcntl(fd, F_FULLFSYNC)
             close(fd)
         }
     }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/LibraryFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/LibraryFeatureTests.swift
@@ -241,6 +241,77 @@ struct LibraryFeatureTests {
         }
     }
 
+    // MARK: - Inline Tag Creation
+
+    @Test
+    func inlineCreateTag_createsAndAssigns() async {
+        let item = SavedItem(title: "Article", content: "")
+        let newTag = Tag(name: "reading", colorHex: FlexokiRaw.shade(.red, 600))
+        var initial = LibraryFeature.State()
+        initial.items = [item]
+        initial.availableTags = []
+
+        let store = TestStore(initialState: initial) {
+            LibraryFeature()
+        } withDependencies: {
+            $0.stowerRepository.createTag = { _, _ in newTag }
+            $0.stowerRepository.addTag = { _, _ in }
+            $0.stowerRepository.fetchTags = { [newTag] }
+        }
+
+        let suggestedColor = TagColorSuggester.suggestColor(existingHexValues: [])
+        await store.send(.inlineCreateTagTapped(item.id)) {
+            $0.inlineTagCreation = LibraryFeature.InlineTagCreation(
+                itemID: item.id,
+                colorHex: suggestedColor
+            )
+        }
+        await store.send(.inlineCreateTagNameChanged("reading")) {
+            $0.inlineTagCreation?.name = "reading"
+        }
+        await store.send(.inlineCreateTagConfirmed) {
+            $0.inlineTagCreation = nil
+        }
+        await store.receive(.inlineTagCreated(newTag, item.id)) {
+            $0.availableTags = [newTag]
+            $0.items[0].tagIDs = [newTag.id]
+        }
+        await store.receive(.reloadTags)
+        await store.receive(.tagsLoaded([newTag]))
+    }
+
+    @Test
+    func inlineCreateTag_emptyName_isNoOp() async {
+        let item = SavedItem(title: "Article", content: "")
+        var initial = LibraryFeature.State()
+        initial.items = [item]
+        initial.inlineTagCreation = LibraryFeature.InlineTagCreation(itemID: item.id)
+
+        let store = TestStore(initialState: initial) {
+            LibraryFeature()
+        }
+
+        await store.send(.inlineCreateTagConfirmed) {
+            $0.inlineTagCreation = nil
+        }
+        // No effects — createTag and addTag should NOT be called.
+    }
+
+    @Test
+    func inlineCreateTag_dismiss_clearsState() async {
+        let item = SavedItem(title: "Article", content: "")
+        var initial = LibraryFeature.State()
+        initial.inlineTagCreation = LibraryFeature.InlineTagCreation(itemID: item.id, name: "wip")
+
+        let store = TestStore(initialState: initial) {
+            LibraryFeature()
+        }
+
+        await store.send(.inlineCreateTagDismissed) {
+            $0.inlineTagCreation = nil
+        }
+    }
+
     @Test
     func saveURLAddsHttpsWhenSchemeMissing() async {
         let item = SavedItem(title: "Saved", sourceURL: "https://example.com/post", content: "Body")

--- a/StowerPackage/Tests/StowerFeatureV2Tests/RepositoryFilterTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/RepositoryFilterTests.swift
@@ -144,6 +144,64 @@ struct RepositoryFilterTests {
     }
 
     @Test
+    func diagnostics_includesTagAndJunctionCounts() async throws {
+        let database = try StowerDatabase.makeDatabase()
+        let repository = StowerRepository.live(database: database, cloudSyncClient: .noop)
+
+        let item = try await repository.createItemFromIngestion(.sharedText("Alpha"))
+        let tag = try await repository.createTag("work", nil)
+        try await repository.addTag(item.id, tag.id)
+
+        // Query tag/junction counts directly — the full makeDiagnosticsLoad
+        // also queries iCloud metadata tables that are unavailable in the
+        // test-only in-memory database.
+        let (tagCount, junctionCount) = try await database.read { db -> (Int, Int) in
+            let tags = try TagSyncTable.fetchCount(db)
+            let junctions = try ItemTagSyncTable.fetchCount(db)
+            return (tags, junctions)
+        }
+
+        #expect(tagCount == 1)
+        #expect(junctionCount == 1)
+
+        // Verify the SyncDiagnostics model accepts the new fields.
+        let diagnostics = SyncDiagnostics(
+            syncedItemsCount: 1,
+            pendingChangesCount: 0,
+            metadataCount: 0,
+            syncedTagsCount: tagCount,
+            syncedItemTagsCount: junctionCount
+        )
+        #expect(diagnostics.syncedTagsCount == 1)
+        #expect(diagnostics.syncedItemTagsCount == 1)
+    }
+
+    @Test
+    func migration_v6_replacesUniqueIndexes() async throws {
+        let database = try StowerDatabase.makeDatabase()
+
+        let indexes: [String] = try await database.read { db in
+            try String.fetchAll(
+                db,
+                sql: """
+                    SELECT "name" FROM "sqlite_master"
+                    WHERE "type" = 'index'
+                      AND "tbl_name" IN ('tagSyncTables', 'itemTagSyncTables')
+                    ORDER BY "name"
+                    """
+            )
+        }
+
+        // v5 UNIQUE indexes must NOT exist (dropped by v6).
+        #expect(!indexes.contains("idx_tagSyncTables_name"))
+        #expect(!indexes.contains("idx_itemTagSyncTables_item_tag"))
+
+        // v6 non-unique replacements MUST exist.
+        #expect(indexes.contains("idx_tagSyncTables_name_lower"))
+        #expect(indexes.contains("idx_itemTagSyncTables_item_tag_pair"))
+    }
+
+    @Test
     func observeLibraryChanges_firesOnMutation() async throws {
         let repository = try makeRepository()
         let stream = repository.observeLibraryChanges()

--- a/StowerPackage/Tests/StowerFeatureV2Tests/SidebarFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/SidebarFeatureTests.swift
@@ -50,6 +50,7 @@ struct SidebarFeatureTests {
     func newTag_confirmCreatesAndReloads() async {
         let tag = Tag(name: "ai")
         let counts = LibraryListCounts(all: 0)
+        let expectedColor = TagColorSuggester.suggestColor(existingHexValues: [])
 
         let store = TestStore(initialState: SidebarFeature.State()) {
             SidebarFeature()
@@ -62,6 +63,7 @@ struct SidebarFeatureTests {
         await store.send(.newTagTapped) {
             $0.isCreatingTag = true
             $0.newTagName = ""
+            $0.newTagColorHex = expectedColor
         }
         await store.send(.newTagNameChanged("ai")) {
             $0.newTagName = "ai"
@@ -69,6 +71,7 @@ struct SidebarFeatureTests {
         await store.send(.newTagConfirmed) {
             $0.isCreatingTag = false
             $0.newTagName = ""
+            $0.newTagColorHex = ""
         }
         await store.receive(.tagCreated(tag))
         await store.receive(.reload) { $0.isLoading = true }
@@ -77,6 +80,56 @@ struct SidebarFeatureTests {
             $0.counts = counts
             $0.tags = [tag]
         }
+    }
+
+    @Test
+    func newTagConfirmed_passesAutoColor() async {
+        let existingTag = Tag(name: "work", colorHex: FlexokiRaw.shade(.red, 600))
+        let expectedColor = TagColorSuggester.suggestColor(
+            existingHexValues: [FlexokiRaw.shade(.red, 600)]
+        )
+
+        let receivedColor = LockIsolated<String?>(nil)
+        let newTag = Tag(name: "personal", colorHex: expectedColor)
+
+        var state = SidebarFeature.State()
+        state.tags = [existingTag]
+
+        let store = TestStore(initialState: state) {
+            SidebarFeature()
+        } withDependencies: {
+            $0.stowerRepository.createTag = { _, color in
+                receivedColor.setValue(color)
+                return newTag
+            }
+            $0.stowerRepository.fetchListCounts = { .zero }
+            $0.stowerRepository.fetchTags = { [existingTag, newTag] }
+        }
+
+        await store.send(.newTagTapped) {
+            $0.isCreatingTag = true
+            $0.newTagName = ""
+            $0.newTagColorHex = expectedColor
+        }
+        await store.send(.newTagNameChanged("personal")) {
+            $0.newTagName = "personal"
+        }
+        await store.send(.newTagConfirmed) {
+            $0.isCreatingTag = false
+            $0.newTagName = ""
+            $0.newTagColorHex = ""
+        }
+        await store.receive(.tagCreated(newTag))
+        await store.receive(.reload) { $0.isLoading = true }
+        await store.receive(.loaded(.zero, [existingTag, newTag])) {
+            $0.isLoading = false
+            $0.counts = .zero
+            $0.tags = [existingTag, newTag]
+        }
+
+        // Red is taken, so orange-600 should have been passed.
+        #expect(receivedColor.value == expectedColor)
+        #expect(receivedColor.value == FlexokiRaw.shade(.orange, 600))
     }
 
     @Test

--- a/StowerPackage/Tests/StowerFeatureV2Tests/TagColorSuggesterTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/TagColorSuggesterTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+@testable import StowerData
+import Testing
+
+@Suite
+struct TagColorSuggesterTests {
+    @Test
+    func suggestsFirstHue_whenNoTagsExist() {
+        let hex = TagColorSuggester.suggestColor(existingHexValues: [])
+        // First hue in FlexokiHue.allCases is red; shade 600.
+        #expect(hex == FlexokiRaw.shade(.red, 600))
+    }
+
+    @Test
+    func suggestsNextUnusedHue() {
+        let redHex = FlexokiRaw.shade(.red, 600)
+        let orangeHex = FlexokiRaw.shade(.orange, 600)
+        let hex = TagColorSuggester.suggestColor(existingHexValues: [redHex, orangeHex])
+        #expect(hex == FlexokiRaw.shade(.yellow, 600))
+    }
+
+    @Test
+    func cyclesWhenAllHuesUsed() {
+        let allHexes = FlexokiHue.allCases.map { FlexokiRaw.shade($0, 600) }
+        let hex = TagColorSuggester.suggestColor(existingHexValues: allHexes)
+        // When all hues are taken, wraps to first hue.
+        #expect(hex == FlexokiRaw.shade(.red, 600))
+    }
+
+    @Test
+    func skipsUsedHue_inMiddle() {
+        // Only orange is used — should suggest red (first unused).
+        let orangeHex = FlexokiRaw.shade(.orange, 600)
+        let hex = TagColorSuggester.suggestColor(existingHexValues: [orangeHex])
+        #expect(hex == FlexokiRaw.shade(.red, 600))
+    }
+
+    @Test
+    func matchesAnyShadeOfHue() {
+        // Red shade-400 should still count as "red used".
+        let redShade400 = FlexokiRaw.shade(.red, 400)
+        let hex = TagColorSuggester.suggestColor(existingHexValues: [redShade400])
+        // Red is taken, so first suggestion is orange.
+        #expect(hex == FlexokiRaw.shade(.orange, 600))
+    }
+}


### PR DESCRIPTION
## Summary

- **#15 Tag colors**: Auto-suggest unused Flexoki hue when creating tags. Color picker sheet with 8 presets + custom picker + live preview. Tags render in their assigned color throughout the app.
- **#14 Library tag pills**: Colored tag capsules on each article row (max 3 + overflow count).
- **#13 Inline tag creation**: "New Tag…" in library context menu tag submenu opens the same color picker sheet, creates and assigns in one step.
- **#17 Sync diagnostics**: Tag/junction counts in debug panel. Documented hydration gap and cascade-delete limitation. Added `refreshTagIDs` so library items re-populate tagIDs after CloudKit sync.

Closes #13, closes #14, closes #15, closes #17