### PR TITLE
Fix reader width and scroll behavior

### DIFF
--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAppearanceControls.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAppearanceControls.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct ReaderAppearanceControls: View {
     let appearance: ReaderAppearanceSettings
+    let lineWidthPolicy: ReaderLineWidthPolicy
     let onFontSizeChanged: (Double) -> Void
     let onFontStyleChanged: (ReaderFontStyle) -> Void
     let onLineSpacingChanged: (Double) -> Void
@@ -71,10 +72,17 @@ struct ReaderAppearanceControls: View {
             }
 
             VStack(alignment: .leading, spacing: 8) {
-                controlTitle("Line Width", value: appearance.lineWidth.formatted(.number.precision(.fractionLength(0))))
+                controlTitle(
+                    "Line Width",
+                    value: lineWidthPolicy.clamped(appearance.lineWidth)
+                        .formatted(.number.precision(.fractionLength(0)))
+                )
                 Slider(
-                    value: Binding(get: { appearance.lineWidth }, set: { onLineWidthChanged($0) }),
-                    in: ReaderAppearanceSettings.lineWidthRange
+                    value: Binding(
+                        get: { lineWidthPolicy.clamped(appearance.lineWidth) },
+                        set: { onLineWidthChanged($0) }
+                    ),
+                    in: lineWidthPolicy.range
                 )
             }
         }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAppearanceSettings+Theme.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAppearanceSettings+Theme.swift
@@ -155,7 +155,8 @@ extension ReaderAppearanceSettings {
     public func readerCSS(pageWidth: CGFloat) -> String {
         let p = palette
         let font = cssFont
-        let columnWidth = min(lineWidth, pageWidth - 40)
+        let policy = ReaderLineWidthPolicy(viewportWidth: Double(pageWidth))
+        let columnWidth = policy.clamped(lineWidth)
         let colorScheme = p.isDark ? "dark" : "light"
 
         return """
@@ -179,11 +180,24 @@ extension ReaderAppearanceSettings {
           font-family: \(font), -apple-system, serif !important;
           font-size: \(fontSize)px !important;
           line-height: \(1.4 + lineSpacing / 20) !important;
-          max-width: \(columnWidth)px !important;
-          margin: 0 auto !important;
-          padding: 20px 20px 60px 20px !important;
+          width: 100% !important;
+          max-width: 100% !important;
+          margin: 0 !important;
+          overflow-x: hidden !important;
+          overscroll-behavior-x: none !important;
+          touch-action: pan-y pinch-zoom !important;
           word-break: break-word;
           text-align: \(justification == .justified ? "justify" : "left") !important;
+        }
+        body {
+          padding: 20px 20px 60px 20px !important;
+          box-sizing: border-box !important;
+        }
+        .stower-article {
+          width: 100% !important;
+          max-width: \(columnWidth)px !important;
+          margin: 0 auto !important;
+          overflow-x: clip !important;
         }
         a { color: var(--stower-primary) !important; text-decoration-color: color-mix(in srgb, var(--stower-primary) 45%, transparent); }
         a:hover { color: var(--stower-primary-muted) !important; }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderDocumentHTMLBuilder.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderDocumentHTMLBuilder.swift
@@ -715,6 +715,26 @@ public enum ReaderDocumentHTMLBuilder {
     private static let runtimeJS = """
     (function() {
       var currentHighlight = null;
+      var horizontalLockScheduled = false;
+
+      function lockHorizontalScroll() {
+        if (window.scrollX !== 0) {
+          window.scrollTo(0, window.scrollY);
+        }
+      }
+
+      function scheduleHorizontalLock() {
+        if (horizontalLockScheduled) { return; }
+        horizontalLockScheduled = true;
+        window.requestAnimationFrame(function() {
+          horizontalLockScheduled = false;
+          lockHorizontalScroll();
+        });
+      }
+
+      window.addEventListener('scroll', scheduleHorizontalLock, { passive: true });
+      window.addEventListener('touchmove', scheduleHorizontalLock, { passive: true });
+      window.addEventListener('load', lockHorizontalScroll, { once: true });
 
       window.stowerHighlight = function(index) {
         if (currentHighlight) {

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderFeature.swift
@@ -12,6 +12,8 @@ public struct ReaderFeature {
         public var document: ReaderDocument?
         public var sourceHTML: String?
         public var appearance: ReaderAppearanceSettings
+        var viewportWidth: Double?
+        var isChromeHidden = false
         var speech = ReaderSpeechFeature.State()
         var ai = ReaderAIFeature.State()
         public var isLoading = false
@@ -46,6 +48,10 @@ public struct ReaderFeature {
             item?.renderFormat == .webView
         }
 
+        var lineWidthPolicy: ReaderLineWidthPolicy {
+            ReaderLineWidthPolicy(viewportWidth: viewportWidth)
+        }
+
         /// Initialize with a full SavedItem (preferred — instant header render).
         public init(item: SavedItem, appearance: ReaderAppearanceSettings = .init()) {
             self.itemID = item.id
@@ -75,6 +81,7 @@ public struct ReaderFeature {
         case backgroundChanged(ReaderBackground)
         case primaryAccentChanged(FlexokiHue)
         case secondaryAccentChanged(FlexokiHue)
+        case viewportWidthChanged(Double)
         case lineWidthChanged(Double)
         case saveAppearance
         case saveAppearanceFinished
@@ -90,6 +97,7 @@ public struct ReaderFeature {
         /// Triggers a debounced save of the reading position.
         case scrollProgressChanged(Int)
         case saveReadingProgress(Int)
+        case contentAreaTapped
 
         /// User tapped the toolbar mark-read/unread button.
         case toggleReadTapped
@@ -202,15 +210,24 @@ public struct ReaderFeature {
                 state.appearance.secondaryAccent = value
                 return .send(.saveAppearance)
 
+            case .viewportWidthChanged(let width):
+                guard width.isFinite, width > 0 else {
+                    state.viewportWidth = nil
+                    return .none
+                }
+                state.viewportWidth = width
+                return .none
+
             case .lineWidthChanged(let value):
-                state.appearance.lineWidth = value
-                state.appearance.clamp()
+                state.appearance.lineWidth = state.lineWidthPolicy.clamped(value)
                 return .send(.saveAppearance)
 
             case .saveAppearance:
                 let repository = self.repository
+                let clock = self.continuousClock
                 return .run { [appearance = state.appearance] send in
                     do {
+                        try await clock.sleep(for: .milliseconds(150))
                         try await repository.saveReaderAppearanceSettings(appearance.clamped())
                         await send(.saveAppearanceFinished)
                     } catch is CancellationError {
@@ -331,6 +348,10 @@ public struct ReaderFeature {
                 return .run { [id = state.itemID] _ in
                     try? await repository.saveReadingProgress(id, blockIndex)
                 }
+
+            case .contentAreaTapped:
+                state.isChromeHidden.toggle()
+                return .none
 
             case .toggleReadTapped:
                 guard var item = state.item else { return .none }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderLineWidthPolicy.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderLineWidthPolicy.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Derives a meaningful reader line-width range from the current viewport
+/// without introducing device-specific persistence or schema changes.
+struct ReaderLineWidthPolicy: Equatable, Sendable {
+    let range: ClosedRange<Double>
+    let defaultWidth: Double
+
+    init(viewportWidth: Double?) {
+        guard let viewportWidth, viewportWidth.isFinite, viewportWidth > 0 else {
+            self.range = ReaderAppearanceSettings.lineWidthRange
+            self.defaultWidth = ReaderAppearanceSettings().lineWidth
+            return
+        }
+
+        let availableWidth = max(
+            ReaderAppearanceSettings.lineWidthRange.lowerBound,
+            viewportWidth - 40
+        )
+        let upperBound = min(
+            ReaderAppearanceSettings.lineWidthRange.upperBound,
+            availableWidth
+        )
+        let lowerBound = min(
+            upperBound,
+            max(
+                ReaderAppearanceSettings.lineWidthRange.lowerBound,
+                min(420, availableWidth * 0.75)
+            )
+        )
+        let defaultWidth = min(
+            upperBound,
+            max(lowerBound, min(820, availableWidth * 0.86))
+        )
+
+        self.range = lowerBound ... upperBound
+        self.defaultWidth = defaultWidth
+    }
+
+    func clamped(_ width: Double) -> Double {
+        min(max(width, range.lowerBound), range.upperBound)
+    }
+}

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
@@ -31,6 +31,11 @@ public struct ReaderScreen: View {
     public var body: some View {
         content
             .background(store.appearance.backgroundColor)
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.width
+            } action: { newWidth in
+                store.send(.viewportWidthChanged(Double(newWidth)))
+            }
             // Enables WKWebView's built-in find UI (iOS 26+ / macOS 26+).
             // Binding lets us toggle from the toolbar button below; the
             // system also binds this to its own Find menu item and the
@@ -38,6 +43,11 @@ public struct ReaderScreen: View {
             // same navigator.
             .findNavigator(isPresented: $isFindNavigatorPresented)
             .navigationTitle("Reader")
+#if os(macOS)
+            .toolbar(store.isChromeHidden ? .hidden : .visible, for: .windowToolbar)
+#else
+            .toolbar(store.isChromeHidden ? .hidden : .visible, for: .navigationBar)
+#endif
             .toolbar {
                 // Group 1: mode switching. Available whenever the original
                 // source HTML is on hand so the user can flip to the full
@@ -99,6 +109,7 @@ public struct ReaderScreen: View {
                     .popover(isPresented: $isAppearancePanelPresented, arrowEdge: .top) {
                         ReaderAppearanceControls(
                             appearance: store.appearance,
+                            lineWidthPolicy: store.lineWidthPolicy,
                             onFontSizeChanged: { store.send(.fontSizeChanged($0)) },
                             onFontStyleChanged: { store.send(.fontStyleChanged($0)) },
                             onLineSpacingChanged: { store.send(.lineSpacingChanged($0)) },
@@ -138,18 +149,24 @@ public struct ReaderScreen: View {
     // MARK: - Content
 
     @ViewBuilder private var content: some View {
-        if let item = store.item, let resolvedHTML = resolvedHTML(for: item) {
+        if let item = store.item, hasRenderableContent(for: item) {
             ReaderWebView(
-                html: resolvedHTML,
+                html: { resolvedHTML(for: item) ?? "" },
                 sourceURL: item.sourceURL,
                 itemID: store.itemID,
+                contentVersion: contentReloadToken(for: item),
                 appearance: store.appearance,
+                viewportWidth: store.viewportWidth,
                 isWebViewFormat: store.effectiveRenderFormat == .webView,
                 highlightedBlockIndex: store.speech.currentBlockIndex,
-                restoreBlockIndex: item.lastReadBlockIndex
-            ) { urlString in
-                store.send(.openInlineWebEmbed(urlString))
-            }
+                restoreBlockIndex: item.lastReadBlockIndex,
+                onOpenInlineEmbed: { urlString in
+                    store.send(.openInlineWebEmbed(urlString))
+                },
+                onContentTap: {
+                    handleContentTap()
+                }
+            )
         } else if let item = store.item, item.content.isEmpty {
             downloadPrompt(item: item)
         } else if store.isLoading {
@@ -163,6 +180,13 @@ public struct ReaderScreen: View {
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+
+    private func hasRenderableContent(for item: SavedItem) -> Bool {
+        if store.effectiveRenderFormat == .webView {
+            return store.sourceHTML != nil
+        }
+        return store.document != nil
     }
 
     /// Toolbar button that flips between the interactive (archive/WebView)
@@ -201,8 +225,48 @@ public struct ReaderScreen: View {
         return ReaderDocumentHTMLBuilder.buildReaderHTML(
             item: item,
             document: document,
-            appearance: store.appearance
+            appearance: store.appearance,
+            pageWidth: CGFloat(store.viewportWidth ?? 0)
         )
+    }
+
+    private func contentReloadToken(for item: SavedItem) -> Int {
+        var hasher = Hasher()
+        hasher.combine(item.id)
+        hasher.combine(item.updatedAt)
+        hasher.combine(item.renderFormat.rawValue)
+        hasher.combine(store.effectiveRenderFormat.rawValue)
+        hasher.combine(store.sourceHTML?.count)
+
+        if let document = store.document {
+            hasher.combine(document.version)
+            hasher.combine(document.title)
+            hasher.combine(document.sourceURL)
+            hasher.combine(document.canonicalURL)
+            hasher.combine(document.blocks.count)
+        }
+
+        return hasher.finalize()
+    }
+
+    private func handleContentTap() {
+        let hasPresentedControls = isAppearancePanelPresented
+            || isListenPanelPresented
+            || isAIPanelPresented
+            || isPDFViewerPresented
+            || isFindNavigatorPresented
+
+        isAppearancePanelPresented = false
+        isListenPanelPresented = false
+        isAIPanelPresented = false
+        isPDFViewerPresented = false
+        isFindNavigatorPresented = false
+
+        guard !hasPresentedControls else { return }
+
+        _ = withAnimation(.easeInOut(duration: 0.2)) {
+            store.send(.contentAreaTapped)
+        }
     }
 
     // MARK: - Download prompt

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebPage.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebPage.swift
@@ -11,6 +11,7 @@ import WebKit
 struct ReaderNavigationDecider: WebPage.NavigationDeciding {
     var openExternalURL: @MainActor (URL) -> Void
     var openInlineEmbed: @MainActor (String) -> Void
+    var toggleChrome: @MainActor () -> Void
 
     @MainActor
     mutating func decidePolicy(
@@ -26,6 +27,12 @@ struct ReaderNavigationDecider: WebPage.NavigationDeciding {
                 .replacingOccurrences(of: "stower-embed://", with: "")
             let decoded = raw.removingPercentEncoding ?? raw
             openInlineEmbed(decoded)
+            return .cancel
+        }
+
+        if url.scheme == "stower-reader",
+           url.host(percentEncoded: false) == "toggle-chrome" {
+            toggleChrome()
             return .cancel
         }
 
@@ -53,14 +60,37 @@ enum ReaderWebPageFactory {
     @MainActor
     static func makePage(
         openExternalURL: @MainActor @escaping (URL) -> Void,
-        openInlineEmbed: @MainActor @escaping (String) -> Void = { _ in }
+        openInlineEmbed: @MainActor @escaping (String) -> Void = { _ in },
+        toggleChrome: @MainActor @escaping () -> Void = {}
     ) -> WebPage {
         let decider = ReaderNavigationDecider(
             openExternalURL: openExternalURL,
-            openInlineEmbed: openInlineEmbed
+            openInlineEmbed: openInlineEmbed,
+            toggleChrome: toggleChrome
         )
         return WebPage(navigationDecider: decider)
     }
+
+    static let contentTapScript = """
+        (function() {
+            if (window.__stowerContentTapHandlerInstalled) { return; }
+            window.__stowerContentTapHandlerInstalled = true;
+
+            var toggleURL = 'stower-reader://toggle-chrome';
+            var interactiveSelector = 'a, button, input, textarea, select, option, label, summary, details, iframe, video, audio, [contenteditable=\"true\"], .stower-yt-facade';
+
+            document.addEventListener('click', function(e) {
+                if (e.defaultPrevented) { return; }
+                if (window.getSelection && String(window.getSelection()).length > 0) { return; }
+
+                var target = e.target;
+                if (!target || !target.closest) { return; }
+                if (target.closest(interactiveSelector)) { return; }
+
+                window.location.href = toggleURL;
+            });
+        })();
+        """
 
     /// Highlights the block with the given index (or clears all highlights if nil).
     @MainActor
@@ -112,5 +142,10 @@ enum ReaderWebPageFactory {
             })();
             """
         _ = try? await page.callJavaScript(script)
+    }
+
+    @MainActor
+    static func installContentTapHandler(on page: WebPage) async {
+        _ = try? await page.callJavaScript(contentTapScript)
     }
 }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebView.swift
@@ -16,14 +16,17 @@ import WebKit
 /// `onReadingProgress`. TTS highlighting is driven by the `highlightedBlockIndex`
 /// binding and mapped through `ReaderWebPageFactory.runHighlight`.
 public struct ReaderWebView: View {
-    let html: String
+    let htmlProvider: () -> String
     let sourceURL: String?
     let itemID: UUID
+    let contentVersion: Int
     let appearance: ReaderAppearanceSettings
+    let viewportWidth: Double?
     let isWebViewFormat: Bool
     let highlightedBlockIndex: Int?
     let restoreBlockIndex: Int?
     let onOpenInlineEmbed: ((String) -> Void)?
+    let onContentTap: (() -> Void)?
 
     @State private var page: WebPage?
     @State private var archiveServer: LocalArchiveServer?
@@ -32,23 +35,29 @@ public struct ReaderWebView: View {
     private var openURL
 
     public init(
-        html: String,
+        html: @escaping () -> String,
         sourceURL: String?,
         itemID: UUID,
+        contentVersion: Int,
         appearance: ReaderAppearanceSettings,
+        viewportWidth: Double? = nil,
         isWebViewFormat: Bool = false,
         highlightedBlockIndex: Int? = nil,
         restoreBlockIndex: Int? = nil,
-        onOpenInlineEmbed: ((String) -> Void)? = nil
+        onOpenInlineEmbed: ((String) -> Void)? = nil,
+        onContentTap: (() -> Void)? = nil
     ) {
-        self.html = html
+        self.htmlProvider = html
         self.sourceURL = sourceURL
         self.itemID = itemID
+        self.contentVersion = contentVersion
         self.appearance = appearance
+        self.viewportWidth = viewportWidth
         self.isWebViewFormat = isWebViewFormat
         self.highlightedBlockIndex = highlightedBlockIndex
         self.restoreBlockIndex = restoreBlockIndex
         self.onOpenInlineEmbed = onOpenInlineEmbed
+        self.onContentTap = onContentTap
     }
 
     public var body: some View {
@@ -67,18 +76,17 @@ public struct ReaderWebView: View {
                     .webViewContentBackground(.hidden)
             }
         }
-        // Keyed on both `itemID` and the HTML byte count so that in-place
-        // document updates (e.g. re-running PDF OCR on the currently-open
-        // item) re-fire `loadContent()` and swap the WebPage for one
-        // loading the freshly-produced HTML. Without the byte-count
-        // component the task was only keyed on itemID, which never
-        // changes during an in-place update, so the WKWebView kept
-        // showing the old content.
-        .task(id: ContentReloadKey(itemID: itemID, htmlBytes: html.utf8.count)) {
+        // Keyed on item identity plus content version, not on the rendered
+        // HTML bytes. Appearance changes update CSS live; they must not tear
+        // down and recreate the whole WKWebView while the user drags a slider.
+        .task(id: ContentReloadKey(itemID: itemID, contentVersion: contentVersion)) {
             loadContent()
         }
         .onChange(of: appearance) { _, newAppearance in
             updateCSS(newAppearance)
+        }
+        .onChange(of: viewportWidth) { _, _ in
+            updateCSS(appearance)
         }
         .onChange(of: page?.isLoading) { _, isLoading in
             if isLoading == false {
@@ -90,6 +98,7 @@ public struct ReaderWebView: View {
                 // because `page.isLoading == false` is the first moment
                 // at which `stowerGetTopBlockIndex()` is guaranteed to
                 // exist on the JS side.
+                installContentTapHandler()
                 updateCSS(appearance)
                 maybeRestorePosition()
                 ReaderProgressCoordinator.shared.register(page)
@@ -105,15 +114,13 @@ public struct ReaderWebView: View {
         }
     }
 
-    /// Identity for the reload task. Changes whenever the item swaps or
-    /// the HTML content for the current item is replaced in place (e.g.
-    /// after a PDF is re-OCRed). Using `utf8.count` keeps the equality
-    /// check O(1); a collision (identical byte count after reprocessing)
-    /// would be extraordinarily unlikely given that re-extraction shifts
-    /// paragraph/table content around.
+    /// Identity for the reload task. Changes whenever the item swaps or its
+    /// underlying content changes in place (e.g. after re-extraction), but
+    /// stays stable for pure appearance tweaks so live CSS updates can handle
+    /// them without recreating the web content process.
     private struct ContentReloadKey: Hashable {
         let itemID: UUID
-        let htmlBytes: Int
+        let contentVersion: Int
     }
 
     // MARK: - Loading
@@ -130,11 +137,12 @@ public struct ReaderWebView: View {
         let hasArchive = AssetArchiver.archiveExists(for: itemID)
         let isArchive = isWebViewFormat && hasArchive
 
-        let currentHTML = html
+        let currentHTML = htmlProvider()
         let currentSourceURL = sourceURL
         let currentItemID = itemID
         let currentAppearance = appearance
         let openEmbed = onOpenInlineEmbed ?? { _ in }
+        let toggleChrome = onContentTap ?? {}
 
         Task {
             if isArchive {
@@ -148,7 +156,8 @@ public struct ReaderWebView: View {
 
                 let newPage = ReaderWebPageFactory.makePage(
                     openExternalURL: { [openURL] url in openURL(url) },
-                    openInlineEmbed: { openEmbed($0) }
+                    openInlineEmbed: { openEmbed($0) },
+                    toggleChrome: { toggleChrome() }
                 )
                 self.archiveServer = server
                 _ = newPage.load(URLRequest(url: loadURL))
@@ -174,7 +183,8 @@ public struct ReaderWebView: View {
                 ) {
                     let newPage = ReaderWebPageFactory.makePage(
                         openExternalURL: { [openURL] url in openURL(url) },
-                        openInlineEmbed: { openEmbed($0) }
+                        openInlineEmbed: { openEmbed($0) },
+                        toggleChrome: { toggleChrome() }
                     )
                     self.archiveServer = server
                     _ = newPage.load(URLRequest(url: loadURL))
@@ -187,7 +197,8 @@ public struct ReaderWebView: View {
                     let base = currentSourceURL.flatMap(URL.init(string:)) ?? URL(string: "about:blank")!
                     let newPage = ReaderWebPageFactory.makePage(
                         openExternalURL: { [openURL] url in openURL(url) },
-                        openInlineEmbed: { openEmbed($0) }
+                        openInlineEmbed: { openEmbed($0) },
+                        toggleChrome: { toggleChrome() }
                     )
                     _ = newPage.load(html: currentHTML, baseURL: base)
                     self.page = newPage
@@ -299,9 +310,17 @@ public struct ReaderWebView: View {
             return
         }
 
-        let css = appearance.readerCSS(pageWidth: 10_000)
+        let css = appearance.readerCSS(pageWidth: CGFloat(viewportWidth ?? 0))
         Task {
             await ReaderWebPageFactory.updateCSS(css, on: page)
+        }
+    }
+
+    @MainActor
+    private func installContentTapHandler() {
+        guard let page else { return }
+        Task {
+            await ReaderWebPageFactory.installContentTapHandler(on: page)
         }
     }
 

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderAppearancePolicyTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderAppearancePolicyTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+@testable import StowerData
+@testable import StowerFeature
+import Testing
+
+@Suite
+struct ReaderAppearancePolicyTests {
+    @Test
+    func lineWidthPolicy_narrowerViewportYieldsNarrowerRangeAndDefault() {
+        let narrow = ReaderLineWidthPolicy(viewportWidth: 375)
+        let wide = ReaderLineWidthPolicy(viewportWidth: 834)
+
+        #expect(narrow.range.upperBound < wide.range.upperBound)
+        #expect(narrow.defaultWidth < wide.defaultWidth)
+    }
+
+    @Test
+    func lineWidthPolicy_clampsStoredWidthIntoViewportRange() {
+        let policy = ReaderLineWidthPolicy(viewportWidth: 375)
+
+        #expect(policy.clamped(100) == policy.range.lowerBound)
+        #expect(policy.clamped(980) == policy.range.upperBound)
+    }
+
+    @Test
+    func defaultAppearance_resolvesToMeaningfulWidthOnNarrowAndWideViewports() {
+        let appearance = ReaderAppearanceSettings()
+        let narrow = ReaderLineWidthPolicy(viewportWidth: 375)
+        let wide = ReaderLineWidthPolicy(viewportWidth: 1024)
+
+        #expect(narrow.clamped(appearance.lineWidth) <= narrow.range.upperBound)
+        #expect(wide.clamped(appearance.lineWidth) <= wide.range.upperBound)
+        #expect(narrow.clamped(appearance.lineWidth) < wide.clamped(appearance.lineWidth))
+    }
+
+    @Test
+    func readerCSS_usesViewportAwareCenteredArticleWidth_andLocksHorizontalOverflow() {
+        let appearance = ReaderAppearanceSettings(lineWidth: 820)
+        let policy = ReaderLineWidthPolicy(viewportWidth: 375)
+        let css = appearance.readerCSS(pageWidth: 375)
+
+        #expect(css.contains(".stower-article"))
+        #expect(css.contains("max-width: \(policy.clamped(appearance.lineWidth))px !important;"))
+        #expect(css.contains("overflow-x: hidden"))
+        #expect(css.contains("overscroll-behavior-x: none"))
+        #expect(css.contains("touch-action: pan-y pinch-zoom"))
+        #expect(!css.contains("max-width: 820.0px !important;"))
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderDocumentHTMLBuilderTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderDocumentHTMLBuilderTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+@testable import StowerData
+@testable import StowerFeature
+import Testing
+
+@Suite
+struct ReaderDocumentHTMLBuilderTests {
+    @Test
+    func buildReaderHTML_includesHorizontalScrollLockRuntime() {
+        let item = SavedItem(
+            title: "Reader",
+            sourceURL: "https://example.com/article",
+            renderFormat: .structuredV1,
+            content: "Body"
+        )
+        let document = ReaderDocument(
+            title: "Reader",
+            blocks: [.paragraph([.text("Body")])]
+        )
+
+        let html = ReaderDocumentHTMLBuilder.buildReaderHTML(
+            item: item,
+            document: document,
+            appearance: ReaderAppearanceSettings(),
+            pageWidth: 375
+        )
+
+        #expect(html.contains("window.scrollX"))
+        #expect(html.contains("window.scrollTo(0, window.scrollY)"))
+        #expect(html.contains("requestAnimationFrame"))
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderFeatureTests.swift
@@ -8,6 +8,19 @@ import Testing
 @Suite
 struct ReaderFeatureTests {
     @Test
+    func viewportWidthChange_updatesState() async {
+        let itemID = UUID()
+
+        let store = TestStore(initialState: ReaderFeature.State(itemID: itemID)) {
+            ReaderFeature()
+        }
+
+        await store.send(.viewportWidthChanged(375)) {
+            $0.viewportWidth = 375
+        }
+    }
+
+    @Test
     func effectiveRenderFormat_defaultsToItemRenderFormat_forInteractiveArticles() {
         // Regression: previously `effectiveRenderFormat` always returned
         // `.structuredV1` when no manual override was set, which silently
@@ -186,6 +199,51 @@ struct ReaderFeatureTests {
             $0.errorMessage = SaveError.failed.localizedDescription
         }
         #expect(store.state.appearance.lineWidth == 760)
+    }
+
+    @Test
+    func lineWidthChange_clampsToViewportRange_beforeSaving() async {
+        let itemID = UUID()
+        let clock = TestClock()
+        let saved = LockIsolated<ReaderAppearanceSettings?>(nil)
+        let policy = ReaderLineWidthPolicy(viewportWidth: 375)
+
+        let store = TestStore(initialState: ReaderFeature.State(itemID: itemID)) {
+            ReaderFeature()
+        } withDependencies: {
+            $0.continuousClock = clock
+            $0.stowerRepository.saveReaderAppearanceSettings = { settings in
+                saved.withValue { $0 = settings }
+            }
+        }
+
+        await store.send(.viewportWidthChanged(375)) {
+            $0.viewportWidth = 375
+        }
+        await store.send(.lineWidthChanged(980)) {
+            $0.appearance.lineWidth = policy.range.upperBound
+        }
+        await store.receive(.saveAppearance)
+        await clock.advance(by: .milliseconds(200))
+        await store.receive(.saveAppearanceFinished)
+
+        #expect(saved.value?.lineWidth == policy.range.upperBound)
+    }
+
+    @Test
+    func contentAreaTapped_togglesChromeVisibility() async {
+        let itemID = UUID()
+
+        let store = TestStore(initialState: ReaderFeature.State(itemID: itemID)) {
+            ReaderFeature()
+        }
+
+        await store.send(.contentAreaTapped) {
+            $0.isChromeHidden = true
+        }
+        await store.send(.contentAreaTapped) {
+            $0.isChromeHidden = false
+        }
     }
 
     @Test

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderWebPageFactoryTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderWebPageFactoryTests.swift
@@ -1,0 +1,18 @@
+@testable import StowerFeature
+import Testing
+
+@Suite
+struct ReaderWebPageFactoryTests {
+    @Test
+    func contentTapScript_emitsChromeToggleURL_andSkipsInteractiveTargets() {
+        let script = ReaderWebPageFactory.contentTapScript
+
+        #expect(script.contains("stower-reader://toggle-chrome"))
+        #expect(script.contains("a, button, input, textarea, select, option, label"))
+        #expect(script.contains("iframe"))
+        #expect(script.contains("video"))
+        #expect(script.contains("audio"))
+        #expect(script.contains(".stower-yt-facade"))
+        #expect(script.contains("window.getSelection"))
+    }
+}


### PR DESCRIPTION
## Summary
- add a viewport-aware reader line width policy and use it in the reducer, controls, and live CSS updates
- keep reader appearance drags smooth by avoiding full WebView reloads and debouncing appearance saves
- lock reader scrolling horizontally in structured reader mode and add content-tap chrome toggling
- add focused tests for line width policy, HTML/runtime scroll lock, WebView tap handling, and reader reducer behavior

## Testing
- `swift test --scratch-path /tmp/stower-reader-fix-build --filter Reader`
- `swift test --scratch-path /tmp/stower-reader-fix-build`

Closes #8
Closes #9 
Closes #11 