### PR TITLE
[codex] Show reading progress for document-backed articles

### DIFF
--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Helpers.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Helpers.swift
@@ -5,6 +5,18 @@ import SQLiteData
 // MARK: - Domain Mapping
 
 extension StowerRepository {
+    static func progressUnitCount(from local: SavedItemContentLocalTable?) -> Int? {
+        guard let local,
+              !local.documentJSON.isEmpty,
+              let data = local.documentJSON.data(using: .utf8),
+              let document = try? JSONDecoder().decode(ReaderDocument.self, from: data),
+              !document.blocks.isEmpty
+        else {
+            return nil
+        }
+        return document.blocks.count
+    }
+
     static func toDomain(
         sync: SavedItemSyncTable,
         local: SavedItemContentLocalTable?,
@@ -30,6 +42,7 @@ extension StowerRepository {
             createdAt: sync.createdAt,
             updatedAt: sync.updatedAt,
             lastReadBlockIndex: sync.lastReadBlockIndex,
+            progressUnitCount: progressUnitCount(from: local),
             isRead: sync.isRead,
             isStarred: sync.isStarred,
             deletedAt: sync.deletedAt,
@@ -58,6 +71,7 @@ extension StowerRepository {
             createdAt: draft.createdAt,
             updatedAt: draft.updatedAt,
             lastReadBlockIndex: draft.lastReadBlockIndex,
+            progressUnitCount: progressUnitCount(from: local),
             isRead: draft.isRead,
             isStarred: draft.isStarred,
             deletedAt: draft.deletedAt

--- a/StowerPackage/Sources/StowerData/Domain/Models.swift
+++ b/StowerPackage/Sources/StowerData/Domain/Models.swift
@@ -22,6 +22,9 @@ public struct SavedItem: Equatable, Identifiable, Sendable {
     public var updatedAt: Date
     /// Block index of the last-read position for scroll restoration. Nil means unread or at the top.
     public var lastReadBlockIndex: Int?
+    /// Total number of readable content units used to derive reading progress.
+    /// For document-backed content this is typically `ReaderDocument.blocks.count`.
+    public var progressUnitCount: Int?
     public var isRead: Bool
     public var isStarred: Bool
     /// When set, this item is in the Recently Deleted bucket and will be
@@ -51,6 +54,7 @@ public struct SavedItem: Equatable, Identifiable, Sendable {
         createdAt: Date = .now,
         updatedAt: Date = .now,
         lastReadBlockIndex: Int? = nil,
+        progressUnitCount: Int? = nil,
         isRead: Bool = false,
         isStarred: Bool = false,
         deletedAt: Date? = nil,
@@ -75,10 +79,48 @@ public struct SavedItem: Equatable, Identifiable, Sendable {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.lastReadBlockIndex = lastReadBlockIndex
+        self.progressUnitCount = progressUnitCount
         self.isRead = isRead
         self.isStarred = isStarred
         self.deletedAt = deletedAt
         self.tagIDs = tagIDs
+    }
+}
+
+public struct ReadingProgressSnapshot: Equatable, Sendable {
+    public let currentUnitIndex: Int
+    public let totalUnitCount: Int
+
+    public init?(currentUnitIndex: Int, totalUnitCount: Int) {
+        guard totalUnitCount > 1 else { return nil }
+        let clampedIndex = min(max(currentUnitIndex, 0), totalUnitCount - 1)
+        guard clampedIndex < totalUnitCount - 1 else { return nil }
+        self.currentUnitIndex = clampedIndex
+        self.totalUnitCount = totalUnitCount
+    }
+
+    public var fractionComplete: Double {
+        Double(currentUnitIndex) / Double(totalUnitCount)
+    }
+
+    public var percentComplete: Int {
+        Int((fractionComplete * 100).rounded())
+    }
+}
+
+extension SavedItem {
+    public var libraryReadingProgress: ReadingProgressSnapshot? {
+        guard renderFormat != .webView,
+              isRead,
+              let lastReadBlockIndex,
+              let progressUnitCount
+        else {
+            return nil
+        }
+        return ReadingProgressSnapshot(
+            currentUnitIndex: lastReadBlockIndex,
+            totalUnitCount: progressUnitCount
+        )
     }
 }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
@@ -119,6 +119,10 @@ public struct LibraryScreen: View {
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                             .frame(maxWidth: .infinity, alignment: .leading)
+
+                            if let progress = item.libraryReadingProgress {
+                                libraryProgressRow(progress)
+                            }
                         }
                     }
                     .contentShape(Rectangle())
@@ -449,6 +453,29 @@ public struct LibraryScreen: View {
     private func tagPillColor(_ hex: String?) -> Color {
         guard let hex, !hex.isEmpty else { return palette.secondary }
         return Color(hex: hex)
+    }
+
+    @ViewBuilder
+    private func libraryProgressRow(_ progress: ReadingProgressSnapshot) -> some View {
+        HStack(spacing: 8) {
+            GeometryReader { geometry in
+                let width = max(geometry.size.width, 0)
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(palette.ui.opacity(0.28))
+                    Capsule()
+                        .fill(palette.primaryMuted)
+                        .frame(width: width * progress.fractionComplete)
+                }
+            }
+            .frame(height: 4)
+
+            Text("\(progress.percentComplete)%")
+                .font(.caption2.weight(.medium))
+                .foregroundStyle(palette.tx2)
+                .monospacedDigit()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Tags Submenu

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderFeature.swift
@@ -13,6 +13,7 @@ public struct ReaderFeature {
         public var sourceHTML: String?
         public var appearance: ReaderAppearanceSettings
         var viewportWidth: Double?
+        var currentBlockIndex: Int?
         var isChromeHidden = false
         var speech = ReaderSpeechFeature.State()
         var ai = ReaderAIFeature.State()
@@ -52,11 +53,32 @@ public struct ReaderFeature {
             ReaderLineWidthPolicy(viewportWidth: viewportWidth)
         }
 
+        public var totalProgressUnitCount: Int? {
+            if let document, !document.blocks.isEmpty {
+                return document.blocks.count
+            }
+            return item?.progressUnitCount
+        }
+
+        public var readingProgress: ReadingProgressSnapshot? {
+            guard effectiveRenderFormat != .webView,
+                  let totalProgressUnitCount,
+                  let currentBlockIndex
+            else {
+                return nil
+            }
+            return ReadingProgressSnapshot(
+                currentUnitIndex: currentBlockIndex,
+                totalUnitCount: totalProgressUnitCount
+            )
+        }
+
         /// Initialize with a full SavedItem (preferred — instant header render).
         public init(item: SavedItem, appearance: ReaderAppearanceSettings = .init()) {
             self.itemID = item.id
             self.item = item
             self.appearance = appearance
+            self.currentBlockIndex = item.lastReadBlockIndex ?? 0
         }
 
         /// Initialize with just an ID (fallback — requires DB load).
@@ -136,6 +158,7 @@ public struct ReaderFeature {
                 if state.document != nil,
                    state.item?.id == state.itemID {
                     state.isLoading = false
+                    state.currentBlockIndex = state.item?.lastReadBlockIndex ?? 0
                     return .send(.speech(.loadPreferences))
                 }
 
@@ -167,6 +190,7 @@ public struct ReaderFeature {
                 if let item { state.item = item }
                 state.document = document
                 state.sourceHTML = sourceHTML
+                state.currentBlockIndex = state.item?.lastReadBlockIndex ?? 0
                 return .merge(
                     archiveIfNeeded(item: state.item, sourceHTML: sourceHTML),
                     startProgressPollingEffect(),
@@ -315,6 +339,7 @@ public struct ReaderFeature {
                 // Block index 0 means "at the top" — don't persist it (treat
                 // as "no restore state") so new opens don't get a false restore.
                 guard blockIndex >= 0 else { return .none }
+                state.currentBlockIndex = blockIndex
                 state.item?.lastReadBlockIndex = blockIndex > 0 ? blockIndex : nil
 
                 // Auto-mark as read the first time the user scrolls past the

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
@@ -31,6 +31,11 @@ public struct ReaderScreen: View {
     public var body: some View {
         content
             .background(store.appearance.backgroundColor)
+            .safeAreaInset(edge: .top, spacing: 0) {
+                if let progress = store.readingProgress {
+                    readerProgressHeader(progress)
+                }
+            }
             .onGeometryChange(for: CGFloat.self) { proxy in
                 proxy.size.width
             } action: { newWidth in
@@ -266,6 +271,36 @@ public struct ReaderScreen: View {
 
         _ = withAnimation(.easeInOut(duration: 0.2)) {
             store.send(.contentAreaTapped)
+        }
+    }
+
+    @ViewBuilder
+    private func readerProgressHeader(_ progress: ReadingProgressSnapshot) -> some View {
+        HStack(spacing: 10) {
+            Text("\(progress.percentComplete)%")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(palette.tx2)
+                .monospacedDigit()
+
+            GeometryReader { geometry in
+                let width = max(geometry.size.width, 0)
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(palette.ui.opacity(0.35))
+                    Capsule()
+                        .fill(palette.primary)
+                        .frame(width: width * progress.fractionComplete)
+                }
+            }
+            .frame(height: 6)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(palette.bg.opacity(0.96))
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(palette.ui.opacity(0.3))
+                .frame(height: 1)
         }
     }
 

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderFeatureTests.swift
@@ -68,6 +68,70 @@ struct ReaderFeatureTests {
     }
 
     @Test
+    func readingProgress_usesLiveBlockIndexEvenWhenTopPositionIsNotPersisted() async {
+        let itemID = UUID()
+        let clock = TestClock()
+        let item = SavedItem(id: itemID, title: "Read", content: "Body")
+        let document = ReaderDocument(
+            title: "Read",
+            blocks: [
+                .paragraph([.text("A")]),
+                .paragraph([.text("B")]),
+                .paragraph([.text("C")]),
+                .paragraph([.text("D")]),
+            ]
+        )
+
+        var initialState = ReaderFeature.State(
+            item: item,
+            appearance: ReaderAppearanceSettings()
+        )
+        initialState.document = document
+
+        let store = TestStore(initialState: initialState) {
+            ReaderFeature()
+        } withDependencies: {
+            $0.continuousClock = clock
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        #expect(store.state.readingProgress?.percentComplete == 0)
+
+        await store.send(.scrollProgressChanged(2)) {
+            $0.currentBlockIndex = 2
+            $0.item?.lastReadBlockIndex = 2
+            $0.item?.isRead = true
+        }
+
+        #expect(store.state.readingProgress?.percentComplete == 50)
+    }
+
+    @Test
+    func readingProgress_hidesForInteractiveAndCompleteContent() {
+        let webViewItem = SavedItem(
+            title: "Interactive",
+            renderFormat: .webView,
+            content: "Body",
+            progressUnitCount: 5,
+            isRead: true
+        )
+        var state = ReaderFeature.State(item: webViewItem)
+        state.currentBlockIndex = 2
+        #expect(state.readingProgress == nil)
+
+        let structured = SavedItem(
+            title: "Complete",
+            renderFormat: .structuredV1,
+            content: "Body",
+            progressUnitCount: 5,
+            isRead: true
+        )
+        state = ReaderFeature.State(item: structured)
+        state.currentBlockIndex = 4
+        #expect(state.readingProgress == nil)
+    }
+
+    @Test
     func load_populatesItemAndDocument() async {
         let itemID = UUID()
         let item = SavedItem(id: itemID, title: "Read", content: "Body")

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReadingProgressTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReadingProgressTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+@testable import StowerData
+import Testing
+
+@Suite
+struct ReadingProgressTests {
+    @Test
+    func snapshotCalculatesFractionAndPercent() {
+        let progress = ReadingProgressSnapshot(currentUnitIndex: 2, totalUnitCount: 5)
+
+        #expect(progress?.fractionComplete == 0.4)
+        #expect(progress?.percentComplete == 40)
+    }
+
+    @Test
+    func snapshotIsNilForUnreadOrCompleteExtremes() {
+        #expect(ReadingProgressSnapshot(currentUnitIndex: 4, totalUnitCount: 5) == nil)
+        #expect(ReadingProgressSnapshot(currentUnitIndex: 0, totalUnitCount: 1) == nil)
+    }
+
+    @Test
+    func libraryReadingProgressShowsOnlyForPartialNonWebItems() {
+        let partial = SavedItem(
+            title: "Partial",
+            renderFormat: .structuredV1,
+            content: "Body",
+            lastReadBlockIndex: 2,
+            progressUnitCount: 6,
+            isRead: true
+        )
+        #expect(partial.libraryReadingProgress?.percentComplete == 33)
+
+        let unread = SavedItem(
+            title: "Unread",
+            renderFormat: .structuredV1,
+            content: "Body",
+            lastReadBlockIndex: 2,
+            progressUnitCount: 6,
+            isRead: false
+        )
+        #expect(unread.libraryReadingProgress == nil)
+
+        let complete = SavedItem(
+            title: "Complete",
+            renderFormat: .structuredV1,
+            content: "Body",
+            lastReadBlockIndex: 5,
+            progressUnitCount: 6,
+            isRead: true
+        )
+        #expect(complete.libraryReadingProgress == nil)
+
+        let webView = SavedItem(
+            title: "Web",
+            renderFormat: .webView,
+            content: "Body",
+            lastReadBlockIndex: 2,
+            progressUnitCount: 6,
+            isRead: true
+        )
+        #expect(webView.libraryReadingProgress == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared reading progress model for document-backed articles and derive progress totals from the saved reader document
- show partial-reading progress in the reader chrome and in library rows while continuing to exclude interactive web view items
- add focused tests for progress calculations and reader state behavior

## Validation
- `swift test --filter 'ReadingProgressTests|ReaderFeatureTests'`
- `swift test`

## Notes
- Native original-PDF sheet progress is intentionally out of scope for this PR

Closes #12