### PR TITLE
[codex] Add text and markdown ingestion

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -183,12 +183,6 @@ custom_rules:
     severity: warning
     excluded: ".*Tests.*\\.swift$|.*Preview.*\\.swift$"
 
-  no_expect_false_pattern:
-    name: "No expect(false) Pattern"
-    regex: '#expect\\(\\s*false\\s*[,)]'
-    message: "Use Issue.record() instead of #expect(false) to avoid compiler warnings"
-    severity: error
-
   no_unused_test_variables:
     name: "No Unused Test Variables"
     regex: '(?:let|var)\s+\w+\s*=\s*(?:true|false|\"\w+\")\s*\n(?:[^=\n]*\n)*\s*(?:let|var|\#expect|\})'

--- a/Config/Shared.xcconfig
+++ b/Config/Shared.xcconfig
@@ -9,7 +9,7 @@
 PRODUCT_NAME = Stower
 PRODUCT_DISPLAY_NAME = Stower
 PRODUCT_BUNDLE_IDENTIFIER = com.ryanleewilliams.stower
-MARKETING_VERSION = 0.1.1
+MARKETING_VERSION = 0.2.0
 CURRENT_PROJECT_VERSION = 2
 
 // ==========================================

--- a/Stower.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stower.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b73f2945adf476a57465fe3cef2690ab956a297c898bdd4352e916a4909862f0",
+  "originHash" : "ed101b84463bac7e52256bb140c0eddfdc9fa6f7392be39d3271356ba0fff17a",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
         "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
+        "version" : "0.7.1"
       }
     },
     {
@@ -98,6 +107,15 @@
       "state" : {
         "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-markdown.git",
+      "state" : {
+        "revision" : "7d9a5ce307528578dfa777d505496bd5f544ad94",
+        "version" : "0.7.3"
       }
     },
     {

--- a/StowerPackage/Package.resolved
+++ b/StowerPackage/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b73f2945adf476a57465fe3cef2690ab956a297c898bdd4352e916a4909862f0",
+  "originHash" : "ed101b84463bac7e52256bb140c0eddfdc9fa6f7392be39d3271356ba0fff17a",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
         "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
+        "version" : "0.7.1"
       }
     },
     {
@@ -98,6 +107,15 @@
       "state" : {
         "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-markdown.git",
+      "state" : {
+        "revision" : "7d9a5ce307528578dfa777d505496bd5f544ad94",
+        "version" : "0.7.3"
       }
     },
     {

--- a/StowerPackage/Package.swift
+++ b/StowerPackage/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-dependencies.git", from: "1.11.0"),
         .package(url: "https://github.com/pointfreeco/sqlite-data.git", from: "1.5.0"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.6.0"),
+        .package(url: "https://github.com/swiftlang/swift-markdown.git", from: "0.7.0"),
     ],
     targets: [
         .target(
@@ -28,6 +29,7 @@ let package = Package(
             dependencies: [
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "Dependencies", package: "swift-dependencies"),
+                .product(name: "Markdown", package: "swift-markdown"),
                 .product(name: "SwiftSoup", package: "SwiftSoup"),
                 "StowerData",
             ],

--- a/StowerPackage/Sources/StowerData/Domain/Models.swift
+++ b/StowerPackage/Sources/StowerData/Domain/Models.swift
@@ -309,6 +309,7 @@ public struct IngestionJob: Equatable, Identifiable, Sendable {
     public enum Kind: String, Codable, Sendable {
         case url = "url"
         case text = "text"
+        case markdown = "markdown"
         case hydrate = "hydrate"
         case pdf = "pdf"
     }

--- a/StowerPackage/Sources/StowerData/Domain/ReaderDocument.swift
+++ b/StowerPackage/Sources/StowerData/Domain/ReaderDocument.swift
@@ -205,14 +205,15 @@ public struct IngestionResult: Equatable, Sendable {
         self.pdfSHA256 = pdfSHA256
     }
 
-    public static func sharedText(_ text: String) -> IngestionResult {
+    public static func sharedText(_ text: String, title: String? = nil) -> IngestionResult {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedTitle = resolvedTextImportTitle(documentTitle: nil, titleHint: title)
         let document = ReaderDocument(
-            title: "Shared Note",
+            title: resolvedTitle,
             blocks: [.paragraph([.text(trimmed)])]
         )
         return IngestionResult(
-            title: "Shared Note",
+            title: resolvedTitle,
             sourceURL: nil,
             canonicalURL: nil,
             excerpt: String(trimmed.prefix(180)),
@@ -223,6 +224,39 @@ public struct IngestionResult: Equatable, Sendable {
             readingTimeMinutes: max(1, trimmed.split(separator: " ").count / 225),
             hasRichMedia: false,
             renderFormat: .plainText,
+            processingState: .ready,
+            processingError: nil,
+            document: document,
+            plainText: trimmed,
+            media: [],
+            embeds: []
+        )
+    }
+
+    public static func structuredText(
+        title: String,
+        blocks: [ReaderBlock],
+        plainText: String,
+        sourceURL: String? = nil,
+        canonicalURL: String? = nil
+    ) -> IngestionResult {
+        let trimmed = plainText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let document = ReaderDocument(
+            title: title,
+            blocks: blocks
+        )
+        return IngestionResult(
+            title: title,
+            sourceURL: sourceURL,
+            canonicalURL: canonicalURL,
+            excerpt: String(trimmed.prefix(180)),
+            author: nil,
+            publishedAt: nil,
+            siteName: nil,
+            heroImageURL: nil,
+            readingTimeMinutes: max(1, trimmed.split(separator: " ").count / 225),
+            hasRichMedia: false,
+            renderFormat: .structuredV1,
             processingState: .ready,
             processingError: nil,
             document: document,

--- a/StowerPackage/Sources/StowerData/Domain/TextImportSupport.swift
+++ b/StowerPackage/Sources/StowerData/Domain/TextImportSupport.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+public enum TextImportMode: String, Codable, CaseIterable, Equatable, Sendable {
+    case plainText = "plainText"
+    case markdown = "markdown"
+    case auto = "auto"
+}
+
+public struct QueuedTextPayload: Codable, Equatable, Sendable {
+    public var content: String
+    public var titleHint: String?
+    public var mode: TextImportMode
+
+    public init(content: String, mode: TextImportMode, titleHint: String? = nil) {
+        self.content = content
+        self.titleHint = titleHint
+        self.mode = mode
+    }
+}
+
+public enum TextImportDetector {
+    public static func looksLikeMarkdown(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+
+        let patterns = [
+            #"(?m)^\s{0,3}#{1,6}\s+\S"#,
+            #"(?m)^\s{0,3}[-*+]\s+\S"#,
+            #"(?m)^\s{0,3}\d+\.\s+\S"#,
+            #"(?m)^\s{0,3}>\s+\S"#,
+            #"(?m)^\s{0,3}(```|~~~)"#,
+            #"(?m)^\s{0,3}([-*_])(\s*\1){2,}\s*$"#,
+            #"(?s)\|.+\|\s*\n\s*\|[\s:\-]+\|"#,
+            #"\[[^\]]+\]\([^)]+\)"#,
+        ]
+
+        return patterns.contains { pattern in
+            trimmed.range(of: pattern, options: .regularExpression) != nil
+        }
+    }
+
+    public static func inferredMode(for text: String, preferred preferredMode: TextImportMode) -> TextImportMode {
+        switch preferredMode {
+        case .plainText, .markdown:
+            return preferredMode
+        case .auto:
+            return looksLikeMarkdown(text) ? .markdown : .plainText
+        }
+    }
+
+    public static func importMode(for fileURL: URL) -> TextImportMode? {
+        switch fileURL.pathExtension.lowercased() {
+        case "md", "markdown":
+            return .markdown
+        case "txt":
+            return .auto
+        default:
+            return nil
+        }
+    }
+
+    public static func normalizedTitleHint(from fileURL: URL) -> String? {
+        let name = fileURL.deletingPathExtension().lastPathComponent
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? nil : name
+    }
+}
+
+public enum QueuedTextPayloadCodec {
+    public static func encode(_ payload: QueuedTextPayload) throws -> String {
+        let data = try JSONEncoder().encode(payload)
+        return String(bytes: data, encoding: .utf8) ?? ""
+    }
+
+    public static func decode(_ raw: String, defaultMode: TextImportMode) -> QueuedTextPayload {
+        guard let data = raw.data(using: .utf8),
+              let payload = try? JSONDecoder().decode(QueuedTextPayload.self, from: data)
+        else {
+            return QueuedTextPayload(content: raw, mode: defaultMode)
+        }
+        return payload
+    }
+}
+
+public enum SharedTextClassifier {
+    public enum Result: Equatable, Sendable {
+        case singleURL(URL)
+        case text(QueuedTextPayload)
+    }
+
+    public static func classify(_ text: String) -> Result {
+        if let url = singleURL(in: text) {
+            return .singleURL(url)
+        }
+        return .text(QueuedTextPayload(content: text, mode: .auto))
+    }
+
+    public static func singleURL(in text: String) -> URL? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        let range = NSRange(location: 0, length: trimmed.utf16.count)
+        guard let match = detector?.firstMatch(in: trimmed, options: [], range: range),
+              match.range == range
+        else {
+            return nil
+        }
+        return match.url
+    }
+}
+
+public func resolvedTextImportTitle(documentTitle: String?, titleHint: String?) -> String {
+    if let documentTitle {
+        let trimmed = documentTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            return trimmed
+        }
+    }
+    if let titleHint {
+        let trimmed = titleHint.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            return trimmed
+        }
+    }
+    return "Shared Note"
+}

--- a/StowerPackage/Sources/StowerData/Support/ShareIngestionClient.swift
+++ b/StowerPackage/Sources/StowerData/Support/ShareIngestionClient.swift
@@ -25,15 +25,44 @@ public enum ShareIngestionClient {
         }
     }
 
-    public static func enqueueText(_ text: String) throws {
+    public static func enqueueText(
+        _ text: String,
+        titleHint: String? = nil,
+        mode: TextImportMode = .auto
+    ) throws {
         try prepareDependencies {
             // Share extension should avoid CloudKit work.
             try $0.bootstrapStowerDatabase(enableSync: false)
         }
         @Dependency(\.stowerRepository)
         var repository
+        let payload = try QueuedTextPayloadCodec.encode(
+            QueuedTextPayload(
+                content: text,
+                mode: mode,
+                titleHint: titleHint
+            )
+        )
         Task {
-            try? await repository.enqueueIngestionJob(.text, text)
+            try? await repository.enqueueIngestionJob(.text, payload)
+        }
+    }
+
+    public static func enqueueMarkdown(_ markdown: String, titleHint: String? = nil) throws {
+        try prepareDependencies {
+            try $0.bootstrapStowerDatabase(enableSync: false)
+        }
+        @Dependency(\.stowerRepository)
+        var repository
+        let payload = try QueuedTextPayloadCodec.encode(
+            QueuedTextPayload(
+                content: markdown,
+                mode: .markdown,
+                titleHint: titleHint
+            )
+        )
+        Task {
+            try? await repository.enqueueIngestionJob(.markdown, payload)
         }
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
@@ -100,6 +100,8 @@ public struct AppFeature {
     var ingestionClient
     @Dependency(\.pdfIngestionClient)
     var pdfIngestionClient
+    @Dependency(\.textIngestionClient)
+    var textIngestionClient
     @Dependency(\.defaultDatabase)
     var database
     @Dependency(\.defaultSyncEngine)
@@ -130,6 +132,7 @@ public struct AppFeature {
                 let repository = self.repository
                 let ingestionClient = self.ingestionClient
                 let pdfIngestionClient = self.pdfIngestionClient
+                let textIngestionClient = self.textIngestionClient
                 let clock = self.clock
                 let periodicSync: Effect<Action> =
                     context == .live
@@ -173,7 +176,8 @@ public struct AppFeature {
                             try await processIngestionJobs(
                                 repository: repository,
                                 ingestionClient: ingestionClient,
-                                pdfIngestionClient: pdfIngestionClient
+                                pdfIngestionClient: pdfIngestionClient,
+                                textIngestionClient: textIngestionClient
                             )
                             try await cloudSyncClient.sendChanges()
                             await send(.startupFinished)
@@ -210,11 +214,13 @@ public struct AppFeature {
                 let repository = self.repository
                 let ingestionClient = self.ingestionClient
                 let pdfIngestionClient = self.pdfIngestionClient
+                let textIngestionClient = self.textIngestionClient
                 return .run { send in
                     try? await processIngestionJobs(
                         repository: repository,
                         ingestionClient: ingestionClient,
-                        pdfIngestionClient: pdfIngestionClient
+                        pdfIngestionClient: pdfIngestionClient,
+                        textIngestionClient: textIngestionClient
                     )
                     await send(.library(.reload))
                     await send(.sidebar(.reload))
@@ -252,13 +258,15 @@ public struct AppFeature {
                     let repository = self.repository
                     let ingestionClient = self.ingestionClient
                     let pdfIngestionClient = self.pdfIngestionClient
+                    let textIngestionClient = self.textIngestionClient
                     return .run { send in
                         _ = try? await repository.enqueueHydrationJobsForMissingContent()
                         _ = try? await repository.hydratePDFItemsFromSyncedContent()
                         try? await processIngestionJobs(
                             repository: repository,
                             ingestionClient: ingestionClient,
-                            pdfIngestionClient: pdfIngestionClient
+                            pdfIngestionClient: pdfIngestionClient,
+                            textIngestionClient: textIngestionClient
                         )
                         await send(.library(.reload))
                         await send(.sidebar(.reload))
@@ -362,7 +370,8 @@ public struct AppFeature {
 private func processIngestionJobs(
     repository: StowerRepository,
     ingestionClient: URLIngestionClient,
-    pdfIngestionClient: PDFIngestionClient
+    pdfIngestionClient: PDFIngestionClient,
+    textIngestionClient: TextIngestionClient
 ) async throws {
     let jobs = try await repository.fetchPendingIngestionJobs()
     for job in jobs {
@@ -430,7 +439,21 @@ private func processIngestionJobs(
                 try? FileManager.default.removeItem(at: scratchDir)
             }
         case .text:
-            _ = try await repository.createItemFromIngestion(.sharedText(job.payload))
+            let payload = QueuedTextPayloadCodec.decode(job.payload, defaultMode: .auto)
+            let result = try await textIngestionClient.ingest(
+                payload.content,
+                payload.titleHint,
+                payload.mode
+            )
+            _ = try await repository.createItemFromIngestion(result)
+        case .markdown:
+            let payload = QueuedTextPayloadCodec.decode(job.payload, defaultMode: .markdown)
+            let result = try await textIngestionClient.ingest(
+                payload.content,
+                payload.titleHint,
+                .markdown
+            )
+            _ = try await repository.createItemFromIngestion(result)
         case .hydrate:
             let data = Data(job.payload.utf8)
             let payload = try JSONDecoder().decode(HydrationPayload.self, from: data)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryFeature.swift
@@ -22,6 +22,8 @@ public struct LibraryFeature {
         public var availableTags: [Tag] = [] // swiftlint:disable:this prefer_let_over_var
         /// Non-nil when the user is creating a new tag inline from the tag submenu.
         public var inlineTagCreation: InlineTagCreation?
+        /// Draft for the in-app text/markdown composer.
+        public var textImportDraft: TextImportDraft?
 
         /// Library search matches against title, URL, site name, author,
         /// excerpt, AND full body text (`item.content`). The body-text
@@ -74,6 +76,22 @@ public struct LibraryFeature {
         }
     }
 
+    public struct TextImportDraft: Equatable {
+        public var text: String
+        public var mode: TextImportMode
+        public var titleHint: String?
+
+        public init(
+            text: String = "",
+            mode: TextImportMode = .auto,
+            titleHint: String? = nil
+        ) {
+            self.text = text
+            self.mode = mode
+            self.titleHint = titleHint
+        }
+    }
+
     public enum Action: Equatable {
         case onAppear
         case reload
@@ -96,6 +114,12 @@ public struct LibraryFeature {
         case saveURLFinished(SavedItem)
         case saveURLFailed(String)
         case importPDFSelected(URL)
+        case addTextTapped
+        case textImportDismissed
+        case textImportTextChanged(String)
+        case textImportModeChanged(TextImportMode)
+        case saveTextImportTapped
+        case importTextResolved(String, String?, TextImportMode)
 
         // Tag assignment
         case reloadTags
@@ -124,6 +148,8 @@ public struct LibraryFeature {
     var ingestionClient
     @Dependency(\.pdfIngestionClient)
     var pdfIngestionClient
+    @Dependency(\.textIngestionClient)
+    var textIngestionClient
 
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -308,6 +334,67 @@ public struct LibraryFeature {
                 }
                 return .none
 
+            case .addTextTapped:
+                state.textImportDraft = TextImportDraft()
+                if state.saveState == .failed {
+                    state.saveState = .queued
+                    state.errorMessage = nil
+                }
+                return .none
+
+            case .textImportDismissed:
+                state.textImportDraft = nil
+                return .none
+
+            case .textImportTextChanged(let text):
+                state.textImportDraft?.text = text
+                if state.saveState == .failed {
+                    state.saveState = .queued
+                    state.errorMessage = nil
+                }
+                return .none
+
+            case .textImportModeChanged(let mode):
+                state.textImportDraft?.mode = mode
+                return .none
+
+            case .saveTextImportTapped:
+                guard let draft = state.textImportDraft else { return .none }
+                let text = draft.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !text.isEmpty else {
+                    state.errorMessage = "Enter some text or markdown."
+                    state.saveState = .failed
+                    return .none
+                }
+                state.isSaving = true
+                state.saveState = .extracting
+                state.errorMessage = nil
+                return runTextImport(
+                    text: text,
+                    titleHint: draft.titleHint,
+                    mode: draft.mode,
+                    repository: self.repository,
+                    textIngestionClient: self.textIngestionClient
+                )
+
+            case let .importTextResolved(text, titleHint, mode):
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else {
+                    state.errorMessage = "The selected file is empty."
+                    state.saveState = .failed
+                    return .none
+                }
+                state.isSaving = true
+                state.saveState = .extracting
+                state.errorMessage = nil
+                return runTextImport(
+                    text: trimmed,
+                    titleHint: titleHint,
+                    mode: mode,
+                    repository: self.repository,
+                    textIngestionClient: self.textIngestionClient
+                )
+
             case .saveURLTapped:
                 let sourceURL = state.sourceURL.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard let normalizedURL = normalizeSourceURL(sourceURL),
@@ -351,6 +438,7 @@ public struct LibraryFeature {
                 state.isSaving = false
                 state.saveState = .ready
                 state.sourceURL = ""
+                state.textImportDraft = nil
                 // Only pre-insert if the current filter would include the new
                 // item. Otherwise the subsequent sidebar reload will
                 // surface it in the correct bucket.
@@ -533,6 +621,25 @@ public struct LibraryFeature {
             case .deleteFinished, .openItem:
                 return .none
             }
+        }
+    }
+}
+
+private func runTextImport(
+    text: String,
+    titleHint: String?,
+    mode: TextImportMode,
+    repository: StowerRepository,
+    textIngestionClient: TextIngestionClient
+) -> Effect<LibraryFeature.Action> {
+    .run { send in
+        do {
+            let result = try await textIngestionClient.ingest(text, titleHint, mode)
+            let item = try await repository.createItemFromIngestion(result)
+            await send(.saveURLFinished(item))
+            await send(.openItem(item))
+        } catch {
+            await send(.saveURLFailed(error.localizedDescription))
         }
     }
 }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
@@ -22,6 +22,8 @@ public struct LibraryScreen: View {
     /// visible. Set on iPhone compact to surface the filter sheet.
     private let onOpenFilters: (() -> Void)?
     @State private var isAddURLPresented = false
+    @State private var isTextImportPresented = false
+    @State private var isTextFilePickerPresented = false
     @State private var isPDFPickerPresented = false
 
     public init(
@@ -255,15 +257,22 @@ public struct LibraryScreen: View {
             ToolbarItem(placement: .primaryAction) {
                 Menu {
                     Button {
-                        if store.saveState == .failed {
-                            store.send(.sourceURLChanged(""))
-                        }
-                        isAddURLPresented = true
+                        presentAddURLSheet()
                     } label: {
                         Label("Add URL…", systemImage: "link")
                     }
                     Button {
-                        isPDFPickerPresented = true
+                        presentTextImportSheet()
+                    } label: {
+                        Label("Add Text/Markdown…", systemImage: "square.and.pencil")
+                    }
+                    Button {
+                        presentTextFileImporter()
+                    } label: {
+                        Label("Import Text/Markdown…", systemImage: "doc.text")
+                    }
+                    Button {
+                        presentPDFImporter()
                     } label: {
                         Label("Import PDF…", systemImage: "doc.richtext")
                     }
@@ -284,6 +293,30 @@ public struct LibraryScreen: View {
             }
         }
         #endif
+        .sheet(
+            isPresented: Binding(
+                get: { isTextImportPresented && store.textImportDraft != nil },
+                set: {
+                    isTextImportPresented = $0
+                    if !$0 {
+                        store.send(.textImportDismissed)
+                    }
+                }
+            )
+        ) {
+            textImportSheet
+        }
+        .onChange(of: store.saveState) { _, newValue in
+            if isTextImportPresented, newValue == .ready, store.textImportDraft == nil {
+                isTextImportPresented = false
+            }
+        }
+        .fileImporter(
+            isPresented: $isTextFilePickerPresented,
+            allowedContentTypes: textImportContentTypes
+        ) { result in
+            handleTextImport(result)
+        }
         .fileImporter(
             isPresented: $isPDFPickerPresented,
             allowedContentTypes: [.pdf]
@@ -324,6 +357,79 @@ public struct LibraryScreen: View {
         #endif
     }
 
+    private func presentAddURLSheet() {
+        if store.saveState == .failed {
+            store.send(.sourceURLChanged(""))
+        }
+        DispatchQueue.main.async {
+            isAddURLPresented = true
+        }
+    }
+
+    private func presentTextImportSheet() {
+        store.send(.addTextTapped)
+        DispatchQueue.main.async {
+            isTextImportPresented = true
+        }
+    }
+
+    private func presentTextFileImporter() {
+        #if os(macOS)
+        presentOpenPanel(
+            allowedContentTypes: textImportContentTypes,
+            title: "Import Text or Markdown"
+        ) { url in
+            handleTextImport(.success(url))
+        }
+        #else
+        DispatchQueue.main.async {
+            isTextFilePickerPresented = true
+        }
+        #endif
+    }
+
+    private func presentPDFImporter() {
+        #if os(macOS)
+        presentOpenPanel(
+            allowedContentTypes: [.pdf],
+            title: "Import PDF"
+        ) { url in
+            handlePDFImport(.success(url))
+        }
+        #else
+        DispatchQueue.main.async {
+            isPDFPickerPresented = true
+        }
+        #endif
+    }
+
+    #if os(macOS)
+    private func presentOpenPanel(
+        allowedContentTypes: [UTType],
+        title: String,
+        onSelect: @escaping (URL) -> Void
+    ) {
+        let panel = NSOpenPanel()
+        panel.title = title
+        panel.allowedContentTypes = allowedContentTypes
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            onSelect(url)
+        }
+    }
+    #endif
+
+    private var textImportContentTypes: [UTType] {
+        let markdownTypes = [
+            UTType(filenameExtension: "md"),
+            UTType(filenameExtension: "markdown"),
+        ].compactMap { $0 }
+        return [.plainText] + markdownTypes
+    }
+
     /// Handles the result of the SwiftUI `.fileImporter` PDF picker. The
     /// picked URL is security-scoped — we must start/stop access around the
     /// copy, and we copy to a plain temp file so the reducer can consume a
@@ -361,6 +467,33 @@ public struct LibraryScreen: View {
             let ns = error as NSError
             if ns.code != NSUserCancelledError {
                 store.send(.saveURLFailed("PDF import failed: \(error.localizedDescription)"))
+            }
+        }
+    }
+
+    private func handleTextImport(_ result: Result<URL, Error>) {
+        switch result {
+        case .success(let pickedURL):
+            let accessed = pickedURL.startAccessingSecurityScopedResource()
+            defer {
+                if accessed { pickedURL.stopAccessingSecurityScopedResource() }
+            }
+            guard let mode = TextImportDetector.importMode(for: pickedURL) else {
+                store.send(.saveURLFailed("Unsupported text file type."))
+                return
+            }
+            do {
+                let data = try Data(contentsOf: pickedURL)
+                let text = decodedImportedText(from: data)
+                let titleHint = TextImportDetector.normalizedTitleHint(from: pickedURL)
+                store.send(.importTextResolved(text, titleHint, mode))
+            } catch {
+                store.send(.saveURLFailed("Couldn't read text file: \(error.localizedDescription)"))
+            }
+        case .failure(let error):
+            let ns = error as NSError
+            if ns.code != NSUserCancelledError {
+                store.send(.saveURLFailed("Text import failed: \(error.localizedDescription)"))
             }
         }
     }
@@ -416,6 +549,92 @@ public struct LibraryScreen: View {
         .presentationDragIndicator(.visible)
     }
     #endif
+
+    @ViewBuilder private var textImportSheet: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                Picker(
+                    "Format",
+                    selection: Binding(
+                        get: { store.textImportDraft?.mode ?? .auto },
+                        set: { store.send(.textImportModeChanged($0)) }
+                    )
+                ) {
+                    Text("Auto").tag(TextImportMode.auto)
+                    Text("Plain Text").tag(TextImportMode.plainText)
+                    Text("Markdown").tag(TextImportMode.markdown)
+                }
+                .pickerStyle(.segmented)
+
+                TextEditor(
+                    text: Binding(
+                        get: { store.textImportDraft?.text ?? "" },
+                        set: { store.send(.textImportTextChanged($0)) }
+                    )
+                )
+                .font(store.textImportDraft?.mode == .markdown ? .body.monospaced() : .body)
+                .padding(12)
+                .frame(maxWidth: .infinity, minHeight: 280, maxHeight: .infinity)
+                .glassEffect(.regular, in: .rect(cornerRadius: 12))
+
+                if store.saveState == .failed, let error = store.errorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(palette.error)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    Text("Paste plain text or markdown. Auto mode detects markdown-like syntax for text imports.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .padding()
+            .navigationTitle("Add Text/Markdown")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #else
+            .frame(minWidth: 640, idealWidth: 720, maxWidth: 900, minHeight: 460, idealHeight: 560)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        isTextImportPresented = false
+                        store.send(.textImportDismissed)
+                    }
+                    .disabled(store.isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if store.isSaving {
+                        ProgressView()
+                    } else {
+                        Button("Save") {
+                            store.send(.saveTextImportTapped)
+                        }
+                        .disabled(store.textImportDraft?.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+
+    private func decodedImportedText(from data: Data) -> String {
+        if let text = String(data: data, encoding: .utf8) {
+            return text
+        }
+        if let text = String(data: data, encoding: .utf16) {
+            return text
+        }
+        if let text = String(data: data, encoding: .utf16LittleEndian) {
+            return text
+        }
+        if let text = String(data: data, encoding: .utf16BigEndian) {
+            return text
+        }
+        return String(bytes: data, encoding: .utf8) ?? ""
+    }
 
     // MARK: - Tag Pills
 
@@ -526,7 +745,7 @@ public struct LibraryScreen: View {
 
     @ViewBuilder private var urlComposer: some View {
         HStack(spacing: 10) {
-            TextField("Paste Source URL", text: $store.sourceURL.sending(\.sourceURLChanged))
+            TextField("Paste article URL", text: $store.sourceURL.sending(\.sourceURLChanged))
                 .autocorrectionDisabled()
                 #if os(iOS)
                 // iOS TextField defaults to `.sentences` which capitalizes
@@ -544,6 +763,48 @@ public struct LibraryScreen: View {
                 .glassEffect(.regular, in: .rect(cornerRadius: 6))
                 .onSubmit { store.send(.saveURLTapped) }
 
+            #if os(macOS)
+            Button {
+                store.send(.saveURLTapped)
+            } label: {
+                if store.isSaving {
+                    ProgressView()
+                } else {
+                    Label("Add", systemImage: "plus.circle.fill")
+                }
+            }
+            .disabled(store.isSaving)
+            .buttonStyle(.glassProminent)
+            .fixedSize()
+
+            Menu {
+                Section("Text") {
+                    Button {
+                        presentTextImportSheet()
+                    } label: {
+                        Label("Write or Paste Text…", systemImage: "square.and.pencil")
+                    }
+                }
+
+                Section("Import") {
+                    Button {
+                        presentTextFileImporter()
+                    } label: {
+                        Label("Import Text/Markdown…", systemImage: "doc.text")
+                    }
+
+                    Button {
+                        presentPDFImporter()
+                    } label: {
+                        Label("Import PDF…", systemImage: "doc.richtext")
+                    }
+                }
+            } label: {
+                Label("More", systemImage: "ellipsis.circle")
+            }
+            .fixedSize()
+            .disabled(store.isSaving)
+            #else
             Button {
                 store.send(.saveURLTapped)
             } label: {
@@ -554,16 +815,7 @@ public struct LibraryScreen: View {
                 }
             }
             .disabled(store.isSaving)
-            #if os(macOS)
-            .buttonStyle(.glassProminent)
             #endif
-
-            Button {
-                isPDFPickerPresented = true
-            } label: {
-                Label("Import PDF", systemImage: "doc.richtext")
-            }
-            .disabled(store.isSaving)
         }
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Support/TextIngestionClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/TextIngestionClient.swift
@@ -1,0 +1,387 @@
+import Dependencies
+import Foundation
+import Markdown
+import StowerData
+
+public struct TextIngestionClient: Sendable {
+    public var ingest: @Sendable (_ text: String, _ titleHint: String?, _ mode: TextImportMode) async throws -> IngestionResult
+
+    public init(
+        ingest: @escaping @Sendable (_ text: String, _ titleHint: String?, _ mode: TextImportMode) async throws -> IngestionResult
+    ) {
+        self.ingest = ingest
+    }
+
+    public static let live = TextIngestionClient { text, titleHint, mode in
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedMode = TextImportDetector.inferredMode(for: trimmed, preferred: mode)
+        switch resolvedMode {
+        case .plainText:
+            return IngestionResult.sharedText(trimmed, title: titleHint)
+        case .markdown:
+            return (try? await MarkdownIngestionClient.live.ingest(trimmed, titleHint)) ?? IngestionResult.sharedText(trimmed, title: titleHint)
+        case .auto:
+            return IngestionResult.sharedText(trimmed, title: titleHint)
+        }
+    }
+}
+
+public struct MarkdownIngestionClient: Sendable {
+    public var ingest: @Sendable (_ markdown: String, _ titleHint: String?) async throws -> IngestionResult
+
+    public init(
+        ingest: @escaping @Sendable (_ markdown: String, _ titleHint: String?) async throws -> IngestionResult
+    ) {
+        self.ingest = ingest
+    }
+
+    public static let live = MarkdownIngestionClient { markdown, titleHint in
+        let blocks = MarkdownBlockParser.parse(markdown)
+        let title = resolvedTextImportTitle(
+            documentTitle: MarkdownBlockParser.firstHeadingTitle(in: blocks),
+            titleHint: titleHint
+        )
+        let plainText = markdownPlainText(from: blocks)
+        guard !blocks.isEmpty else {
+            return IngestionResult.sharedText(markdown, title: titleHint)
+        }
+        return IngestionResult.structuredText(
+            title: title,
+            blocks: blocks,
+            plainText: plainText
+        )
+    }
+}
+
+private func markdownPlainText(from blocks: [ReaderBlock]) -> String {
+    let parts = blocks.compactMap { block -> String? in
+        switch block {
+        case .paragraph(let inlines), .heading(_, let inlines), .blockquote(let inlines):
+            return ReaderTextLayoutSupport.inlinePlainText(from: inlines)
+        case .list(_, let items):
+            return items.map { ReaderTextLayoutSupport.inlinePlainText(from: $0) }.joined(separator: "\n")
+        case .code(_, let code):
+            return code
+        case .table(let markdown):
+            return markdown
+        case let .callout(title, inlines):
+            let calloutBody = ReaderTextLayoutSupport.inlinePlainText(from: inlines)
+            if let title, !title.isEmpty {
+                return [title, calloutBody].joined(separator: "\n")
+            }
+            return calloutBody
+        case .figure(let media), .video(let media):
+            return media.caption?.isEmpty == false ? media.caption : nil
+        case .embed, .horizontalRule:
+            return nil
+        }
+    }
+
+    return parts
+        .joined(separator: "\n\n")
+        .replacingOccurrences(of: "\n{3,}", with: "\n\n", options: .regularExpression)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+private enum TextIngestionClientKey: DependencyKey {
+    static let liveValue = TextIngestionClient.live
+    static let testValue = TextIngestionClient.live
+}
+
+extension DependencyValues {
+    public var textIngestionClient: TextIngestionClient {
+        get { self[TextIngestionClientKey.self] }
+        set { self[TextIngestionClientKey.self] = newValue }
+    }
+}
+
+private enum MarkdownBlockParser {
+    static func parse(_ markdown: String) -> [ReaderBlock] {
+        let normalized = markdown.replacingOccurrences(of: "\r\n", with: "\n")
+        let lines = normalized.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        var blocks = [ReaderBlock]()
+        var index = 0
+
+        while index < lines.count {
+            let line = lines[index]
+            if line.trimmingCharacters(in: .whitespaces).isEmpty {
+                index += 1
+                continue
+            }
+
+            if let block = parseHeading(line) {
+                blocks.append(block)
+                index += 1
+                continue
+            }
+
+            if let parsed = parseFencedCode(lines, index: index) {
+                blocks.append(parsed.block)
+                index = parsed.nextIndex
+                continue
+            }
+
+            if let parsed = parseTable(lines, index: index) {
+                blocks.append(parsed.block)
+                index = parsed.nextIndex
+                continue
+            }
+
+            if isHorizontalRule(line) {
+                blocks.append(.horizontalRule)
+                index += 1
+                continue
+            }
+
+            if let parsed = parseBlockquote(lines, index: index) {
+                blocks.append(parsed.block)
+                index = parsed.nextIndex
+                continue
+            }
+
+            if let parsed = parseList(lines, index: index) {
+                blocks.append(parsed.block)
+                index = parsed.nextIndex
+                continue
+            }
+
+            let parsed = parseParagraph(lines, index: index)
+            blocks.append(parsed.block)
+            index = parsed.nextIndex
+        }
+
+        return blocks
+    }
+
+    static func firstHeadingTitle(in blocks: [ReaderBlock]) -> String? {
+        for block in blocks {
+            if case .heading(level: 1, inlines: let inlines) = block {
+                let text = inlineText(inlines).trimmingCharacters(in: .whitespacesAndNewlines)
+                if !text.isEmpty {
+                    return text
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func parseHeading(_ line: String) -> ReaderBlock? {
+        guard let range = line.range(of: #"^\s{0,3}(#{1,6})\s+(.+?)\s*$"#, options: .regularExpression) else {
+            return nil
+        }
+        let match = String(line[range])
+        let hashes = match.prefix { $0 == "#" }
+        let content = match.drop { $0 == "#" || $0.isWhitespace }
+        return .heading(level: hashes.count, inlines: MarkdownInlineParser.parse(String(content)))
+    }
+
+    private static func parseFencedCode(_ lines: [String], index: Int) -> (block: ReaderBlock, nextIndex: Int)? {
+        let line = lines[index]
+        guard let range = line.range(of: #"^\s{0,3}(```|~~~)(.*)$"#, options: .regularExpression) else {
+            return nil
+        }
+        let opener = String(line[range]).trimmingCharacters(in: .whitespaces)
+        let fence = opener.hasPrefix("```") ? "```" : "~~~"
+        let language = opener.dropFirst(3).trimmingCharacters(in: .whitespaces)
+        var body = [String]()
+        var cursor = index + 1
+        while cursor < lines.count {
+            let candidate = lines[cursor].trimmingCharacters(in: .whitespaces)
+            if candidate.hasPrefix(fence) {
+                return (
+                    .code(language: language.isEmpty ? nil : language, code: body.joined(separator: "\n")),
+                    cursor + 1
+                )
+            }
+            body.append(lines[cursor])
+            cursor += 1
+        }
+        return (
+            .code(language: language.isEmpty ? nil : language, code: body.joined(separator: "\n")),
+            cursor
+        )
+    }
+
+    private static func parseTable(_ lines: [String], index: Int) -> (block: ReaderBlock, nextIndex: Int)? {
+        guard index + 1 < lines.count else { return nil }
+        let header = lines[index].trimmingCharacters(in: .whitespaces)
+        let separator = lines[index + 1].trimmingCharacters(in: .whitespaces)
+        guard header.contains("|"),
+              separator.range(of: #"^\|?[\s:\-|\t]+\|?\s*$"#, options: .regularExpression) != nil,
+              separator.contains("-")
+        else {
+            return nil
+        }
+
+        var collected = [String]()
+        collected.append(contentsOf: [header, separator])
+        var cursor = index + 2
+        while cursor < lines.count {
+            let line = lines[cursor].trimmingCharacters(in: .whitespaces)
+            guard !line.isEmpty, line.contains("|") else { break }
+            collected.append(line)
+            cursor += 1
+        }
+        return (.table(markdown: collected.joined(separator: "\n")), cursor)
+    }
+
+    private static func isHorizontalRule(_ line: String) -> Bool {
+        line.range(of: #"^\s{0,3}([-*_])(\s*\1){2,}\s*$"#, options: .regularExpression) != nil
+    }
+
+    private static func parseBlockquote(_ lines: [String], index: Int) -> (block: ReaderBlock, nextIndex: Int)? {
+        guard lines[index].trimmingCharacters(in: .whitespaces).hasPrefix(">") else {
+            return nil
+        }
+        var parts = [String]()
+        var cursor = index
+        while cursor < lines.count {
+            let trimmed = lines[cursor].trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix(">") else { break }
+            let content = trimmed.dropFirst().trimmingCharacters(in: .whitespaces)
+            if !content.isEmpty {
+                parts.append(content)
+            }
+            cursor += 1
+        }
+        return (.blockquote(MarkdownInlineParser.parse(parts.joined(separator: " "))), cursor)
+    }
+
+    private static func parseList(_ lines: [String], index: Int) -> (block: ReaderBlock, nextIndex: Int)? {
+        let first = lines[index]
+        guard let firstMarker = listMatch(in: first) else { return nil }
+
+        var items = [[String]]()
+        items.append([firstMarker.content])
+        var cursor = index + 1
+
+        while cursor < lines.count {
+            let line = lines[cursor]
+            if line.trimmingCharacters(in: .whitespaces).isEmpty {
+                break
+            }
+            if let marker = listMatch(in: line), marker.ordered == firstMarker.ordered {
+                items.append([marker.content])
+                cursor += 1
+                continue
+            }
+
+            let indentation = line.prefix { $0 == " " || $0 == "\t" }.count
+            if indentation >= 2, !items.isEmpty {
+                let continuation = line.trimmingCharacters(in: .whitespaces)
+                if !continuation.isEmpty {
+                    items[items.count - 1].append(continuation)
+                }
+                cursor += 1
+                continue
+            }
+            break
+        }
+
+        let parsedItems = items.map { MarkdownInlineParser.parse($0.joined(separator: " ")) }
+        return (.list(ordered: firstMarker.ordered, items: parsedItems), cursor)
+    }
+
+    private static func parseParagraph(_ lines: [String], index: Int) -> (block: ReaderBlock, nextIndex: Int) {
+        var parts = [String]()
+        var cursor = index
+        while cursor < lines.count {
+            let line = lines[cursor]
+            if line.trimmingCharacters(in: .whitespaces).isEmpty {
+                break
+            }
+            if cursor != index {
+                if parseHeading(line) != nil || parseFencedCode(lines, index: cursor) != nil ||
+                    parseTable(lines, index: cursor) != nil || isHorizontalRule(line) ||
+                    parseBlockquote(lines, index: cursor) != nil || parseList(lines, index: cursor) != nil {
+                    break
+                }
+            }
+            parts.append(line.trimmingCharacters(in: .whitespaces))
+            cursor += 1
+        }
+        return (.paragraph(MarkdownInlineParser.parse(parts.joined(separator: " "))), cursor)
+    }
+
+    private static func listMatch(in line: String) -> (ordered: Bool, content: String)? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        if let range = trimmed.range(of: #"^[-*+]\s+.+$"#, options: .regularExpression) {
+            let content = String(trimmed[range]).dropFirst().trimmingCharacters(in: .whitespaces)
+            return (false, content)
+        }
+        if trimmed.range(of: #"^\d+\.\s+.+$"#, options: .regularExpression) != nil,
+           let dot = trimmed.firstIndex(of: ".") {
+            let content = trimmed[trimmed.index(after: dot)...].trimmingCharacters(in: .whitespaces)
+            return (true, content)
+        }
+        return nil
+    }
+}
+
+private enum MarkdownInlineParser {
+    static func parse(_ markdown: String) -> [ReaderInline] {
+        let document = Document(parsing: markdown)
+        return collectInlines(from: document)
+    }
+
+    private static func collectInlines(from markup: any Markup) -> [ReaderInline] {
+        if let text = markup as? Text {
+            return [.text(text.string)]
+        }
+        if markup is SoftBreak || markup is LineBreak {
+            return [.text(" ")]
+        }
+        if let inlineCode = markup as? InlineCode {
+            return [.code(inlineCode.code)]
+        }
+        if let emphasis = markup as? Emphasis {
+            return [.emphasis(plainText(from: emphasis))]
+        }
+        if let strong = markup as? Strong {
+            return [.strong(plainText(from: strong))]
+        }
+        if let strikethrough = markup as? Strikethrough {
+            return [.strikethrough(plainText(from: strikethrough))]
+        }
+        if let link = markup as? Link {
+            return [.link(label: plainText(from: link), url: link.destination ?? "")]
+        }
+
+        var output = [ReaderInline]()
+        for child in markup.children {
+            output.append(contentsOf: collectInlines(from: child))
+        }
+        return mergeText(output)
+    }
+
+    private static func plainText(from markup: any Markup) -> String {
+        if let text = markup as? Text {
+            return text.string
+        }
+        if markup is SoftBreak || markup is LineBreak {
+            return " "
+        }
+        if let inlineCode = markup as? InlineCode {
+            return inlineCode.code
+        }
+        return markup.children.map(plainText(from:)).joined()
+    }
+
+    private static func mergeText(_ inlines: [ReaderInline]) -> [ReaderInline] {
+        var output = [ReaderInline]()
+        for inline in inlines {
+            switch inline {
+            case .text(let value):
+                guard !value.isEmpty else { continue }
+                if case .text(let current)? = output.last {
+                    output[output.count - 1] = .text(current + value)
+                } else {
+                    output.append(.text(value))
+                }
+            default:
+                output.append(inline)
+            }
+        }
+        return output
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/AppFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/AppFeatureTests.swift
@@ -87,4 +87,105 @@ struct AppFeatureTests {
 
         await store.finish()
     }
+
+    @Test
+    func startupProcessesQueuedMarkdownJob() async throws {
+        let created = LockIsolated<[IngestionResult]>([])
+        let payload = try QueuedTextPayloadCodec.encode(
+            QueuedTextPayload(
+                content: "Just a note body",
+                mode: .markdown,
+                titleHint: "Meeting Notes"
+            )
+        )
+
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.cloudSyncClient = CloudSyncClient(
+                start: {},
+                sendChanges: {},
+                scheduleSendChanges: {},
+                statusStream: { AsyncStream { continuation in continuation.finish() } }
+            )
+            $0.stowerRepository.fetchPendingIngestionJobs = {
+                [IngestionJob(kind: .markdown, payload: payload)]
+            }
+            $0.stowerRepository.createItemFromIngestion = { result in
+                created.withValue { $0.append(result) }
+                return SavedItem(title: result.title, renderFormat: result.renderFormat, content: result.plainText)
+            }
+            $0.stowerRepository.markIngestionJobProcessed = { _ in }
+            $0.stowerRepository.fetchLibrary = { _ in [] }
+            $0.stowerRepository.fetchListCounts = { .zero }
+            $0.stowerRepository.fetchTags = { [] }
+            $0.stowerRepository.observeLibraryChanges = { AsyncStream { $0.finish() } }
+            $0.stowerRepository.purgeOldTrash = { [] }
+            $0.stowerRepository.enqueueHydrationJobsForMissingContent = { 0 }
+            $0.continuousClock = ImmediateClock()
+            $0.syncDiagnosticsClient = .noop
+        }
+
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(AppFeature.Action.onAppear)
+        await store.receive(AppFeature.Action.startupFinished) {
+            $0.startupFinished = true
+        }
+
+        let results = created.value
+        #expect(results.count == 1)
+        #expect(results[0].title == "Meeting Notes")
+        #expect(results[0].renderFormat == .structuredV1)
+    }
+
+    @Test
+    func startupProcessesLegacyRawTextJobUsingAutoDetection() async {
+        let created = LockIsolated<[IngestionResult]>([])
+        let markdown = """
+        # Queued Heading
+
+        - one
+        - two
+        """
+
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.cloudSyncClient = CloudSyncClient(
+                start: {},
+                sendChanges: {},
+                scheduleSendChanges: {},
+                statusStream: { AsyncStream { continuation in continuation.finish() } }
+            )
+            $0.stowerRepository.fetchPendingIngestionJobs = {
+                [IngestionJob(kind: .text, payload: markdown)]
+            }
+            $0.stowerRepository.createItemFromIngestion = { result in
+                created.withValue { $0.append(result) }
+                return SavedItem(title: result.title, renderFormat: result.renderFormat, content: result.plainText)
+            }
+            $0.stowerRepository.markIngestionJobProcessed = { _ in }
+            $0.stowerRepository.fetchLibrary = { _ in [] }
+            $0.stowerRepository.fetchListCounts = { .zero }
+            $0.stowerRepository.fetchTags = { [] }
+            $0.stowerRepository.observeLibraryChanges = { AsyncStream { $0.finish() } }
+            $0.stowerRepository.purgeOldTrash = { [] }
+            $0.stowerRepository.enqueueHydrationJobsForMissingContent = { 0 }
+            $0.continuousClock = ImmediateClock()
+            $0.syncDiagnosticsClient = .noop
+        }
+
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(AppFeature.Action.onAppear)
+        await store.receive(AppFeature.Action.startupFinished) {
+            $0.startupFinished = true
+        }
+
+        let results = created.value
+        #expect(results.count == 1)
+        #expect(results[0].title == "Queued Heading")
+        #expect(results[0].renderFormat == .structuredV1)
+    }
 }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/LibraryFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/LibraryFeatureTests.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+@testable import StowerData
 @testable import StowerFeature
 import Testing
 
@@ -337,6 +338,79 @@ struct LibraryFeatureTests {
             $0.isSaving = false
             $0.saveState = .ready
             $0.sourceURL = ""
+            $0.items = [item]
+        }
+        await store.receive(.openItem(item))
+    }
+
+    @Test
+    func saveTextImport_usesSelectedModeAndOpensCreatedItem() async throws {
+        let item = SavedItem(title: "Imported", renderFormat: .structuredV1, content: "Body")
+        let ingested = LockIsolated<[TextImportMode]>([])
+        var initial = LibraryFeature.State()
+        initial.textImportDraft = LibraryFeature.TextImportDraft(
+            text: "# Heading",
+            mode: .markdown
+        )
+
+        let store = TestStore(initialState: initial) {
+            LibraryFeature()
+        } withDependencies: {
+            $0.textIngestionClient.ingest = { text, titleHint, mode in
+                #expect(text == "# Heading")
+                #expect(titleHint == nil)
+                ingested.withValue { $0.append(mode) }
+                return IngestionResult.structuredText(
+                    title: "Imported",
+                    blocks: [.heading(level: 1, inlines: [.text("Heading")])],
+                    plainText: "Heading"
+                )
+            }
+            $0.stowerRepository.createItemFromIngestion = { _ in item }
+        }
+
+        await store.send(.saveTextImportTapped) {
+            $0.isSaving = true
+            $0.saveState = .extracting
+        }
+        await store.receive(.saveURLFinished(item)) {
+            $0.isSaving = false
+            $0.saveState = .ready
+            $0.textImportDraft = nil
+            $0.items = [item]
+        }
+        await store.receive(.openItem(item))
+
+        #expect(ingested.value == [.markdown])
+    }
+
+    @Test
+    func importTextResolved_usesHintAndMode() async {
+        let item = SavedItem(title: "Meeting Notes", renderFormat: .structuredV1, content: "Body")
+
+        let store = TestStore(initialState: LibraryFeature.State()) {
+            LibraryFeature()
+        } withDependencies: {
+            $0.textIngestionClient.ingest = { text, titleHint, mode in
+                #expect(text == "Body text")
+                #expect(titleHint == "Meeting Notes")
+                #expect(mode == .auto)
+                return IngestionResult.structuredText(
+                    title: "Meeting Notes",
+                    blocks: [.paragraph([.text("Body text")])],
+                    plainText: "Body text"
+                )
+            }
+            $0.stowerRepository.createItemFromIngestion = { _ in item }
+        }
+
+        await store.send(.importTextResolved("Body text", "Meeting Notes", .auto)) {
+            $0.isSaving = true
+            $0.saveState = .extracting
+        }
+        await store.receive(.saveURLFinished(item)) {
+            $0.isSaving = false
+            $0.saveState = .ready
             $0.items = [item]
         }
         await store.receive(.openItem(item))

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ShareImportClassifierTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ShareImportClassifierTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+@testable import StowerData
+import Testing
+
+@Suite
+struct ShareImportClassifierTests {
+    @Test
+    func classifyTreatsSingleURLAsURLImport() {
+        let result = SharedTextClassifier.classify("https://example.com/article")
+
+        switch result {
+        case .singleURL(let url):
+            #expect(url.absoluteString == "https://example.com/article")
+        case .text:
+            Issue.record("Expected a single URL classification.")
+        }
+    }
+
+    @Test
+    func classifyKeepsProseWithIncidentalLinksAsText() {
+        let result = SharedTextClassifier.classify(
+            "Here is a note about https://example.com/article that should stay as text."
+        )
+
+        switch result {
+        case .singleURL:
+            Issue.record("Expected prose with an incidental URL to stay text.")
+        case .text(let payload):
+            #expect(payload.mode == .auto)
+            #expect(payload.content.contains("Here is a note"))
+        }
+    }
+
+    @Test
+    func importModeUsesMarkdownForMarkdownFilesAndAutoForTxt() {
+        #expect(TextImportDetector.importMode(for: URL(fileURLWithPath: "/tmp/notes.md")) == .markdown)
+        #expect(TextImportDetector.importMode(for: URL(fileURLWithPath: "/tmp/notes.markdown")) == .markdown)
+        #expect(TextImportDetector.importMode(for: URL(fileURLWithPath: "/tmp/notes.txt")) == .auto)
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/TextImportSupportTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/TextImportSupportTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+@testable import StowerData
+@testable import StowerFeature
+import Testing
+
+@Suite
+struct TextImportSupportTests {
+    @Test
+    func markdownMode_buildsStructuredDocumentWithSupportedBlocks() async throws {
+        let source = """
+        # Markdown Title
+
+        Lead paragraph with *emphasis*, **strong text**, `inline code`, ~~strike~~, and [a link](https://example.com).
+
+        > Quoted line
+
+        - First item
+        - Second item
+
+        ```swift
+        let value = 42
+        ```
+
+        | Name | Value |
+        | --- | --- |
+        | One | 1 |
+
+        ---
+        """
+
+        let result = try await TextIngestionClient.live.ingest(source, nil, .markdown)
+
+        #expect(result.title == "Markdown Title")
+        #expect(result.renderFormat == .structuredV1)
+        #expect(result.document.blocks.contains { block in
+            if case .heading(level: 1, inlines: let inlines) = block {
+                return inlines == [ReaderInline.text("Markdown Title")]
+            }
+            return false
+        })
+        #expect(result.document.blocks.contains { block in
+            if case .paragraph(let inlines) = block {
+                return inlines.contains(.emphasis("emphasis"))
+                    && inlines.contains(.strong("strong text"))
+                    && inlines.contains(.code("inline code"))
+                    && inlines.contains(.strikethrough("strike"))
+                    && inlines.contains(.link(label: "a link", url: "https://example.com"))
+            }
+            return false
+        })
+        #expect(result.document.blocks.contains { block in
+            if case .blockquote(let inlines) = block {
+                return inlines == [.text("Quoted line")]
+            }
+            return false
+        })
+        #expect(result.document.blocks.contains { block in
+            if case .list(ordered: false, items: let items) = block {
+                return items.count == 2
+                    && items[0] == [.text("First item")]
+                    && items[1] == [.text("Second item")]
+            }
+            return false
+        })
+        #expect(result.document.blocks.contains { block in
+            if case .code(language: "swift", code: let code) = block {
+                return code == "let value = 42"
+            }
+            return false
+        })
+        #expect(result.document.blocks.contains { block in
+            if case .table(let markdown) = block {
+                return markdown.contains("| Name | Value |")
+            }
+            return false
+        })
+        #expect(result.document.blocks.contains { block in
+            if case .horizontalRule = block {
+                return true
+            }
+            return false
+        })
+        #expect(result.plainText.contains("Lead paragraph with emphasis, strong text, inline code, strike, and a link."))
+    }
+
+    @Test
+    func titleFallsBackToHintWhenMarkdownHasNoH1() async throws {
+        let result = try await TextIngestionClient.live.ingest("Body text only", "Meeting Notes", .markdown)
+
+        #expect(result.title == "Meeting Notes")
+    }
+
+    @Test
+    func plainTextFallsBackToSharedNoteWhenNoTitleHintExists() async throws {
+        let result = try await TextIngestionClient.live.ingest("Just plain text", nil, .plainText)
+
+        #expect(result.title == "Shared Note")
+        #expect(result.renderFormat == .plainText)
+        #expect(result.document.blocks == [.paragraph([.text("Just plain text")])])
+    }
+
+    @Test
+    func autoMode_detectsMarkdownLikeContent() async throws {
+        let result = try await TextIngestionClient.live.ingest(
+            """
+            # Heading
+
+            - one
+            - two
+            """,
+            nil,
+            .auto
+        )
+
+        #expect(result.renderFormat == .structuredV1)
+        #expect(result.title == "Heading")
+    }
+
+    @Test
+    func autoMode_keepsPlainProseAsPlainText() async throws {
+        let result = try await TextIngestionClient.live.ingest(
+            "This is a normal paragraph with a https://example.com link inside it.",
+            nil,
+            .auto
+        )
+
+        #expect(result.renderFormat == .plainText)
+        #expect(result.title == "Shared Note")
+    }
+
+    @Test
+    func unsupportedNestedMarkdown_degradesToReadableText() async throws {
+        let result = try await TextIngestionClient.live.ingest(
+            """
+            - Parent
+              - Child
+            """,
+            nil,
+            .markdown
+        )
+
+        #expect(!result.document.blocks.isEmpty)
+        #expect(result.plainText.contains("Parent"))
+        #expect(result.plainText.contains("Child"))
+    }
+}

--- a/StowerShare/ShareViewController.swift
+++ b/StowerShare/ShareViewController.swift
@@ -145,6 +145,10 @@ final class ShareViewController: UIViewController {
                     processPDFAttachment(attachment)
                     return
                 }
+                if attachment.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+                    processPotentialTextFileAttachment(attachment)
+                    return
+                }
                 if attachment.hasItemConformingToTypeIdentifier(UTType.url.identifier) {
                     processURLAttachment(attachment)
                     return
@@ -156,7 +160,7 @@ final class ShareViewController: UIViewController {
             }
         }
 
-        finish(with: .failure("No URL, text, or PDF in the share."))
+        finish(with: .failure("No URL, text, markdown, or PDF in the share."))
     }
 
     /// Share extensions have a ~120 MB memory ceiling. `loadItem` can return
@@ -207,6 +211,39 @@ final class ShareViewController: UIViewController {
         }
     }
 
+    private func processPotentialTextFileAttachment(_ attachment: NSItemProvider) {
+        attachment.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { [weak self] item, error in
+            guard let self else { return }
+            if let error {
+                self.reportFailureOnMain("Share load failed: \(error.localizedDescription)")
+                return
+            }
+            guard let url = item as? URL else {
+                self.reportFailureOnMain("Shared file isn't readable.")
+                return
+            }
+            guard let mode = TextImportDetector.importMode(for: url) else {
+                self.reportFailureOnMain("Unsupported shared file type.")
+                return
+            }
+            do {
+                let data = try Data(contentsOf: url)
+                let text = self.decodedImportedText(from: data)
+                let titleHint = TextImportDetector.normalizedTitleHint(from: url)
+                self.enqueueOnBackground {
+                    switch mode {
+                    case .markdown:
+                        try ShareIngestionClient.enqueueMarkdown(text, titleHint: titleHint)
+                    case .auto, .plainText:
+                        try ShareIngestionClient.enqueueText(text, titleHint: titleHint, mode: mode)
+                    }
+                }
+            } catch {
+                self.reportFailureOnMain("Couldn't read shared text file: \(error.localizedDescription)")
+            }
+        }
+    }
+
     private func processTextAttachment(_ attachment: NSItemProvider) {
         attachment.loadItem(forTypeIdentifier: UTType.text.identifier, options: nil) { [weak self] item, error in
             guard let self else { return }
@@ -218,12 +255,16 @@ final class ShareViewController: UIViewController {
                 self.reportFailureOnMain("Shared item isn't text.")
                 return
             }
-            let extractedURL = self.extractURL(from: text)
             self.enqueueOnBackground {
-                if let extractedURL {
-                    try ShareIngestionClient.enqueueURL(extractedURL)
-                } else {
-                    try ShareIngestionClient.enqueueText(text)
+                switch SharedTextClassifier.classify(text) {
+                case .singleURL(let url):
+                    try ShareIngestionClient.enqueueURL(url)
+                case .text(let payload):
+                    try ShareIngestionClient.enqueueText(
+                        payload.content,
+                        titleHint: payload.titleHint,
+                        mode: payload.mode
+                    )
                 }
             }
         }
@@ -265,10 +306,20 @@ final class ShareViewController: UIViewController {
         }
     }
 
-    private func extractURL(from text: String) -> URL? {
-        let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
-        let matches = detector?.matches(in: text, options: [], range: NSRange(location: 0, length: text.utf16.count))
-        return matches?.first?.url
+    private func decodedImportedText(from data: Data) -> String {
+        if let text = String(data: data, encoding: .utf8) {
+            return text
+        }
+        if let text = String(data: data, encoding: .utf16) {
+            return text
+        }
+        if let text = String(data: data, encoding: .utf16LittleEndian) {
+            return text
+        }
+        if let text = String(data: data, encoding: .utf16BigEndian) {
+            return text
+        }
+        return String(bytes: data, encoding: .utf8) ?? ""
     }
 
     // MARK: - Timeout + completion


### PR DESCRIPTION
## Summary
- add text and markdown ingestion support using `swift-markdown`
- add in-app text/markdown compose and import flows, plus share-extension support for markdown/text payloads
- tighten the library composer UX on macOS and fix the text/import presentation bugs on both macOS and iOS
- bump the app version to `0.2.0`
- clean up the touched SwiftLint issues and remove the broken custom-rule config entry so `swiftlint lint` runs cleanly

## Why
Issue #19 needed text and markdown ingestion end to end, but the initial UI wiring still had broken presentation paths and the repo still had remaining lint warnings. This folds the feature work and the follow-up fixes into one shippable change.

## Validation
- `swiftlint lint`
- `swift test --filter 'AppFeatureTests|LibraryFeatureTests|ShareImportClassifierTests|TextImportSupportTests'`
