### PR TITLE
Fix text/markdown editing, preview, and cross-device sync

### DIFF
--- a/StowerPackage/Sources/StowerData/Data/Bootstrap+CloudSync.swift
+++ b/StowerPackage/Sources/StowerData/Data/Bootstrap+CloudSync.swift
@@ -5,8 +5,7 @@ import SQLiteData
 import CloudKit
 #endif
 
-// swiftlint:disable:next prefixed_toplevel_constant
-private let cloudSyncLogger = Logger(subsystem: "com.ryanleewilliams.stower", category: "CloudSync")
+private let kCloudSyncLogger = Logger(subsystem: "com.ryanleewilliams.stower", category: "CloudSync")
 
 extension StowerDatabase {
     static func makeCloudSyncClient(
@@ -58,7 +57,7 @@ extension StowerDatabase {
                     ).accountStatus()
                     guard accountStatus == .available else {
                         let message = "iCloud unavailable (\(String(describing: accountStatus)))."
-                        cloudSyncLogger.error("CloudKit: \(message, privacy: .public)")
+                        kCloudSyncLogger.error("CloudKit: \(message, privacy: .public)")
                         continuation.yield(
                             CloudSyncStatus(state: .unavailable(message))
                         )
@@ -66,7 +65,7 @@ extension StowerDatabase {
                     }
                 } catch {
                     let detailed = detailedErrorDescription(error)
-                    cloudSyncLogger.error("CloudKit account check failed: \(detailed, privacy: .public)")
+                    kCloudSyncLogger.error("CloudKit account check failed: \(detailed, privacy: .public)")
                     continuation.yield(CloudSyncStatus(state: .unavailable(detailed)))
                     return
                 }
@@ -75,7 +74,7 @@ extension StowerDatabase {
                     try await syncEngine.start()
                 } catch {
                     let detailed = detailedErrorDescription(error)
-                    cloudSyncLogger.error("CloudKit syncEngine.start() failed: \(detailed, privacy: .public)")
+                    kCloudSyncLogger.error("CloudKit syncEngine.start() failed: \(detailed, privacy: .public)")
                     continuation.yield(CloudSyncStatus(state: .error(detailed)))
                     throw error
                 }
@@ -84,7 +83,7 @@ extension StowerDatabase {
                     try await coordinator.syncNow()
                 } catch {
                     let detailed = detailedErrorDescription(error)
-                    cloudSyncLogger.error("CloudKit initial syncNow() failed: \(detailed, privacy: .public)")
+                    kCloudSyncLogger.error("CloudKit initial syncNow() failed: \(detailed, privacy: .public)")
                     continuation.yield(CloudSyncStatus(state: .error(detailed)))
                     throw error
                 }
@@ -94,7 +93,7 @@ extension StowerDatabase {
                     try await coordinator.syncNow()
                 } catch {
                     let detailed = detailedErrorDescription(error)
-                    cloudSyncLogger.error("CloudKit sendChanges() failed: \(detailed, privacy: .public)")
+                    kCloudSyncLogger.error("CloudKit sendChanges() failed: \(detailed, privacy: .public)")
                     continuation.yield(CloudSyncStatus(state: .error(detailed)))
                     throw error
                 }
@@ -113,7 +112,7 @@ extension StowerDatabase {
             return (client: client, syncEngine: syncEngine)
         } catch {
             let detailed = detailedErrorDescription(error)
-            cloudSyncLogger.error("CloudKit SyncEngine construction failed: \(detailed, privacy: .public)")
+            kCloudSyncLogger.error("CloudKit SyncEngine construction failed: \(detailed, privacy: .public)")
             continuation.yield(CloudSyncStatus(state: .error(detailed)))
             let statusStreamImpl: @Sendable () -> AsyncStream<CloudSyncStatus> = { stream }
             let client = CloudSyncClient(

--- a/StowerPackage/Sources/StowerData/Data/Bootstrap+CloudSync.swift
+++ b/StowerPackage/Sources/StowerData/Data/Bootstrap+CloudSync.swift
@@ -39,6 +39,7 @@ extension StowerDatabase {
                 TagSyncTable.self,
                 ItemTagSyncTable.self,
                 SavedPDFContentSyncTable.self,
+                SavedTextContentSyncTable.self,
                 containerIdentifier: StowerDatabase.cloudKitContainerID,
                 delegate: delegate
             )

--- a/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
+++ b/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
@@ -1,6 +1,9 @@
 import Dependencies
 import Foundation
+import OSLog
 import SQLiteData
+
+private let kBootstrapLogger = Logger(subsystem: "com.ryanleewilliams.stower", category: "Bootstrap")
 
 // MARK: - Diagnostics Types
 
@@ -119,19 +122,12 @@ public enum StowerDatabase {
             do {
                 try db.attachMetadatabase(containerIdentifier: cloudKitContainerID)
             } catch {
-                #if DEBUG
-                // swiftlint:disable:next no_print_statements
-                print("⚠️ SQLiteData metadatabase unavailable: \(error)")
-                #endif
+                kBootstrapLogger.warning("SQLiteData metadatabase unavailable: \(error.localizedDescription, privacy: .public)")
             }
         }
 
-        #if DEBUG
-        // swiftlint:disable:next no_print_statements
-        print("🔧 Bootstrap: appGroupID = \(appGroupID)")
-        // swiftlint:disable:next no_print_statements
-        print("🔧 Bootstrap: cloudKitContainerID = \(cloudKitContainerID)")
-        #endif
+        kBootstrapLogger.debug("appGroupID = \(Self.appGroupID, privacy: .public)")
+        kBootstrapLogger.debug("cloudKitContainerID = \(Self.cloudKitContainerID, privacy: .public)")
 
         // In .live, the database lives in the App Group container so the share
         // extension and the main app can both read and write the same file.
@@ -191,10 +187,7 @@ public enum StowerDatabase {
             )
         }
 
-        #if DEBUG
-        // swiftlint:disable:next no_print_statements
-        print("ℹ️ Migrated legacy Stower database from \(legacyURL.path) to \(destination.path)")
-        #endif
+        kBootstrapLogger.info("Migrated legacy Stower database from \(legacyURL.path, privacy: .public) to \(destination.path, privacy: .public)")
     }
 
     /// Mirrors `SQLiteData.defaultDatabase`'s `.live` default path so we can

--- a/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
+++ b/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
@@ -239,6 +239,12 @@ public enum StowerDatabase {
         migrator.registerMigration("flexoki-background-accents") { db in
             try migration_v9(db)
         }
+        migrator.registerMigration("add-raw-text-authoring-source") { db in
+            try migration_v10(db)
+        }
+        migrator.registerMigration("add-synced-text-content-table") { db in
+            try migration_v11(db)
+        }
         try migrator.migrate(database)
     }
 
@@ -344,6 +350,7 @@ public enum StowerDatabase {
               "itemID" TEXT PRIMARY KEY NOT NULL, "renderFormat" TEXT NOT NULL DEFAULT 'structuredV1',
               "documentVersion" INTEGER NOT NULL DEFAULT 1, "plainText" TEXT NOT NULL DEFAULT '',
               "documentJSON" TEXT NOT NULL DEFAULT '', "sourceHTMLHash" TEXT NOT NULL DEFAULT '',
+              "rawSourceText" TEXT NOT NULL DEFAULT '', "rawSourceMode" TEXT,
               "localStatus" TEXT NOT NULL DEFAULT 'notDownloaded', "localError" TEXT,
               "createdAt" TEXT NOT NULL, "updatedAt" TEXT NOT NULL,
               FOREIGN KEY("itemID") REFERENCES "savedItemSyncTables"("id") ON DELETE CASCADE
@@ -579,6 +586,52 @@ public enum StowerDatabase {
         try db.execute(sql: #"ALTER TABLE "readerAppearanceSettingsLocalTables" ADD COLUMN "secondaryAccent" TEXT NOT NULL DEFAULT 'purple'"#)
         try db.execute(sql: #"UPDATE "readerAppearanceSettingsLocalTables" SET "theme" = 'black' WHERE "theme" = 'dark'"#)
         try db.execute(sql: #"UPDATE "readerAppearanceSettingsLocalTables" SET "theme" = 'paper' WHERE "theme" = 'white'"#)
+    }
+
+    /// Adds local-only authoring source storage for text/markdown items so the
+    /// reader can reopen the exact original content for editing.
+    /// v11 — Synced text content for cross-device availability.
+    ///
+    /// Text/markdown items have no source URL to re-fetch from, so their
+    /// content was previously stuck on the originating device. This table
+    /// mirrors `savedPDFContentSyncTables` — CloudKit syncs it, and the
+    /// second device hydrates the local content table from it on launch.
+    private static func migration_v11(_ db: Database) throws {
+        // Drop the v11-preview table if it exists from a development build
+        // that included documentJSON (which exceeded CloudKit's 1 MB limit).
+        try db.execute(sql: #"DROP TABLE IF EXISTS "savedTextContentSyncTables""#)
+        try db.execute(sql: """
+            CREATE TABLE "savedTextContentSyncTables" (
+              "id" TEXT PRIMARY KEY NOT NULL,
+              "plainText" TEXT NOT NULL DEFAULT '',
+              "rawSourceText" TEXT NOT NULL DEFAULT '',
+              "rawSourceMode" TEXT,
+              "renderFormat" TEXT NOT NULL DEFAULT 'plainText',
+              "createdAt" TEXT NOT NULL,
+              "updatedAt" TEXT NOT NULL
+            ) STRICT
+            """)
+    }
+
+    private static func migration_v10(_ db: Database) throws {
+        do {
+            try db.execute(sql: #"ALTER TABLE "savedItemContentLocalTables" ADD COLUMN "rawSourceText" TEXT NOT NULL DEFAULT ''"#)
+        } catch {
+            if error.localizedDescription.contains("duplicate column name") {
+                // Fresh databases already include the column in the base schema.
+            } else {
+                throw error
+            }
+        }
+        do {
+            try db.execute(sql: #"ALTER TABLE "savedItemContentLocalTables" ADD COLUMN "rawSourceMode" TEXT"#)
+        } catch {
+            if error.localizedDescription.contains("duplicate column name") {
+                // Fresh databases already include the column in the base schema.
+            } else {
+                throw error
+            }
+        }
     }
 }
 

--- a/StowerPackage/Sources/StowerData/Data/ReaderDocumentCache.swift
+++ b/StowerPackage/Sources/StowerData/Data/ReaderDocumentCache.swift
@@ -8,8 +8,8 @@ import Foundation
 /// usage stays predictable for users who read many articles in one session.
 final class ReaderDocumentCache: @unchecked Sendable {
     private let lock = NSLock()
-    private var storage: [UUID: ReaderDocument] = [:] // swiftlint:disable:this prefer_let_over_var
-    private var accessOrder: [UUID] = [] // swiftlint:disable:this prefer_let_over_var
+    private var storage = [UUID: ReaderDocument]()
+    private var accessOrder = [UUID]()
     private let capacity: Int
 
     init(capacity: Int = 16) {

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Documents.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Documents.swift
@@ -2,6 +2,44 @@ import Foundation
 import SQLiteData
 
 extension StowerRepository {
+    static func _loadEditableTextSource(database: any DatabaseWriter) -> @Sendable (UUID) async throws -> EditableTextSource? {
+        { id in
+            try await database.read { db in
+                guard let sync = try SavedItemSyncTable.find(id).fetchOne(db),
+                      let local = try SavedItemContentLocalTable.find(id).fetchOne(db)
+                else {
+                    return nil
+                }
+
+                let text: String
+                let mode: TextImportMode
+
+                if !local.rawSourceText.isEmpty {
+                    // Preferred: use the original source text that was saved during import.
+                    // Always default to .auto for the editor so the preview auto-detects
+                    // markdown vs plain text, regardless of what was stored. The user can
+                    // still override via the Format picker.
+                    text = local.rawSourceText
+                    mode = .auto
+                } else if !local.documentJSON.isEmpty,
+                          let data = local.documentJSON.data(using: .utf8),
+                          let document = try? JSONDecoder().decode(ReaderDocument.self, from: data),
+                          !document.blocks.isEmpty {
+                    // Fallback: reconstruct markdown from the parsed document blocks.
+                    // This handles articles where rawSourceText was never saved (e.g.
+                    // pre-migration items or edge cases).
+                    text = ReaderDocumentMarkdownWriter.markdown(from: document)
+                    mode = .markdown
+                } else {
+                    text = local.plainText
+                    mode = .auto
+                }
+
+                return EditableTextSource(title: sync.title, text: text, mode: mode)
+            }
+        }
+    }
+
     static func _saveReaderDocument(database: any DatabaseWriter) -> @Sendable (UUID, ReaderDocument, String) async throws -> Void {
         { (id: UUID, document: ReaderDocument, plainText: String) async throws in
             let now = Date.now

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Filters.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Filters.swift
@@ -82,9 +82,8 @@ extension StowerRepository {
                 let junctions: [ItemTagSyncTable] = ids.isEmpty
                     ? []
                     : try ItemTagSyncTable.where { $0.itemID.in(ids) }.fetchAll(db)
-                var tagIDsByItem: [UUID: [UUID]] = [:] // swiftlint:disable:this prefer_let_over_var
-                for row in junctions {
-                    tagIDsByItem[row.itemID, default: []].append(row.tagID)
+                let tagIDsByItem: [UUID: [UUID]] = junctions.reduce(into: [:]) { result, row in
+                    result[row.itemID, default: []].append(row.tagID)
                 }
 
                 var seen = Set<String>()
@@ -262,10 +261,11 @@ extension StowerRepository {
                     .fetchAll(db)
                     .map(\.id)
                 let liveIDSet = Set(liveIDs)
-                var byTag: [UUID: Int] = [:] // swiftlint:disable:this prefer_let_over_var
-                for row in taggedRows where liveIDSet.contains(row.itemID) {
-                    byTag[row.tagID, default: 0] += 1
-                }
+                let byTag: [UUID: Int] = taggedRows
+                    .filter { liveIDSet.contains($0.itemID) }
+                    .reduce(into: [:]) { result, row in
+                        result[row.tagID, default: 0] += 1
+                    }
 
                 return LibraryListCounts(
                     unread: unreadCount,

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Helpers.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Helpers.swift
@@ -23,13 +23,13 @@ extension StowerRepository {
         tagIDs: [UUID] = []
     ) -> SavedItem {
         SavedItem(
-            id: sync.id,
             title: sync.title,
+            content: local?.plainText ?? "",
+            id: sync.id,
             sourceURL: sync.sourceURL,
             canonicalURL: sync.canonicalURL,
             renderFormat: RenderFormat(rawValue: local?.renderFormat ?? "structuredV1") ?? .structuredV1,
             documentVersion: local?.documentVersion ?? 1,
-            content: local?.plainText ?? "",
             excerpt: sync.excerpt,
             heroImageURL: sync.heroImageURL,
             author: sync.author,
@@ -52,13 +52,13 @@ extension StowerRepository {
 
     static func toDomain(from draft: SavedItemSyncTable.Draft, local: SavedItemContentLocalTable?, inferredContent: String) -> SavedItem {
         SavedItem(
-            id: draft.id ?? UUID(),
             title: draft.title,
+            content: local?.plainText ?? inferredContent,
+            id: draft.id ?? UUID(),
             sourceURL: draft.sourceURL,
             canonicalURL: draft.canonicalURL,
             renderFormat: RenderFormat(rawValue: local?.renderFormat ?? "structuredV1") ?? .structuredV1,
             documentVersion: local?.documentVersion ?? 1,
-            content: local?.plainText ?? inferredContent,
             excerpt: draft.excerpt,
             heroImageURL: draft.heroImageURL,
             author: draft.author,
@@ -80,8 +80,8 @@ extension StowerRepository {
 
     static func toDomain(tag: TagSyncTable) -> Tag {
         Tag(
-            id: tag.id,
             name: tag.name,
+            id: tag.id,
             colorHex: tag.colorHex,
             createdAt: tag.createdAt,
             updatedAt: tag.updatedAt

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Helpers.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Helpers.swift
@@ -102,16 +102,18 @@ extension StowerRepository {
     }
 
     static func makeSyncDraft(id: UUID, result: IngestionResult, now: Date) -> SavedItemSyncTable.Draft {
+        // Defensively truncate all string fields to stay well under
+        // CloudKit's 1 MB per-record limit.
         SavedItemSyncTable.Draft(
             id: id,
-            title: result.title,
+            title: String(result.title.prefix(500)),
             sourceURL: result.sourceURL,
             canonicalURL: result.canonicalURL,
-            excerpt: result.excerpt,
+            excerpt: result.excerpt.map { String($0.prefix(500)) },
             heroImageURL: result.heroImageURL,
-            author: result.author,
+            author: result.author.map { String($0.prefix(200)) },
             publishedAt: result.publishedAt,
-            siteName: result.siteName,
+            siteName: result.siteName.map { String($0.prefix(200)) },
             readingTimeMinutes: result.readingTimeMinutes,
             hasRichMedia: result.hasRichMedia,
             createdAt: now,
@@ -140,6 +142,8 @@ extension StowerRepository {
                     $0.documentJSON = documentJSON
                     $0.sourceHTMLHash = hash
                     $0.sourceHTML = result.sourceHTML
+                    $0.rawSourceText = result.rawSourceText ?? ""
+                    $0.rawSourceMode = #bind(result.rawSourceMode?.rawValue)
                     $0.localStatus = updateLocalStatus
                     $0.localError = #bind(result.processingError)
                     $0.updatedAt = now
@@ -159,6 +163,8 @@ extension StowerRepository {
                         documentJSON: documentJSON,
                         sourceHTMLHash: hash,
                         sourceHTML: result.sourceHTML,
+                        rawSourceText: result.rawSourceText ?? "",
+                        rawSourceMode: result.rawSourceMode?.rawValue,
                         localStatus: updateLocalStatus,
                         localError: result.processingError,
                         createdAt: now,
@@ -179,6 +185,30 @@ extension StowerRepository {
                         id: itemID,
                         documentJSON: documentJSON,
                         plainText: result.plainText,
+                        createdAt: now,
+                        updatedAt: now
+                    )
+                }
+                .execute(db)
+        }
+
+        // For text/markdown items (no sourceURL), mirror the raw source into
+        // the CloudKit-synced table so other devices can re-ingest it locally.
+        // The raw text is zlib-compressed + base64-encoded to stay under
+        // CloudKit's 1 MB per-record limit. plainText is truncated to 1000
+        // chars (enough for excerpt display while the full content syncs).
+        if result.sourceURL == nil, result.renderFormat != .pdf {
+            let rawText = result.rawSourceText ?? ""
+            let compressed = TextSyncCompression.compress(rawText)
+            let truncatedPlain = String(result.plainText.prefix(1000))
+            try SavedTextContentSyncTable
+                .upsert {
+                    SavedTextContentSyncTable.Draft(
+                        id: itemID,
+                        plainText: truncatedPlain,
+                        rawSourceText: compressed,
+                        rawSourceMode: result.rawSourceMode?.rawValue,
+                        renderFormat: result.renderFormat.rawValue,
                         createdAt: now,
                         updatedAt: now
                     )

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Ingestion.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Ingestion.swift
@@ -62,9 +62,14 @@ extension StowerRepository {
                         WHERE id=?
                         """,
                     arguments: [
-                        result.title, result.sourceURL, result.canonicalURL, result.excerpt,
-                        result.heroImageURL, result.author, result.publishedAt?.timeIntervalSince1970,
-                        result.siteName, result.readingTimeMinutes, result.hasRichMedia ? 1 : 0,
+                        String(result.title.prefix(500)),
+                        result.sourceURL, result.canonicalURL,
+                        result.excerpt.map { String($0.prefix(500)) },
+                        result.heroImageURL,
+                        result.author.map { String($0.prefix(200)) },
+                        result.publishedAt?.timeIntervalSince1970,
+                        result.siteName.map { String($0.prefix(200)) },
+                        result.readingTimeMinutes, result.hasRichMedia ? 1 : 0,
                         now.timeIntervalSince1970, id.uuidString,
                     ]
                 )

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Jobs.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Jobs.swift
@@ -29,7 +29,7 @@ extension StowerRepository {
                     .fetchAll(db)
                 return rows.compactMap { row -> IngestionJob? in
                     guard let kind = IngestionJob.Kind(rawValue: row.kind) else { return nil }
-                    return IngestionJob(id: row.id, kind: kind, payload: row.payload, createdAt: row.createdAt)
+                    return IngestionJob(kind: kind, payload: row.payload, id: row.id, createdAt: row.createdAt)
                 }
             }
         }

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Jobs.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Jobs.swift
@@ -113,6 +113,97 @@ extension StowerRepository {
         }
     }
 
+    /// Hydrates text/markdown items that arrived via CloudKit sync by enqueuing
+    /// ingestion jobs. Unlike PDFs (which sync their full documentJSON), text
+    /// items only sync `rawSourceText` to stay under CloudKit's 1 MB limit.
+    /// The receiving device re-parses the raw source through the text ingestion
+    /// client to rebuild the document blocks.
+    static func _hydrateTextItemsFromSyncedContent(database: any DatabaseWriter) -> @Sendable () async throws -> Int {
+        { () async throws -> Int in
+            let now = Date.now
+            return try await database.write { db -> Int in
+                let textRows: [SavedTextContentSyncTable] = try SavedTextContentSyncTable.fetchAll(db)
+                var enqueued = 0
+                for textRow in textRows {
+                    // Skip if we already have rendered content locally.
+                    let existing: SavedItemContentLocalTable? = try SavedItemContentLocalTable
+                        .find(textRow.id)
+                        .fetchOne(db)
+                    if let existing, !existing.documentJSON.isEmpty {
+                        continue
+                    }
+
+                    // Need the sync row to get the item title.
+                    guard let sync = try SavedItemSyncTable.find(textRow.id).fetchOne(db) else {
+                        continue
+                    }
+
+                    // Decompress the raw source text (stored compressed in the
+                    // sync table to stay under CloudKit's 1 MB limit).
+                    let rawSourceText = TextSyncCompression.decompress(textRow.rawSourceText)
+
+                    // Create a placeholder local row so the library shows the
+                    // item with its plainText excerpt while ingestion runs.
+                    if existing == nil {
+                        try SavedItemContentLocalTable
+                            .insert {
+                                SavedItemContentLocalTable.Draft(
+                                    itemID: textRow.id,
+                                    renderFormat: textRow.renderFormat,
+                                    documentVersion: 1,
+                                    plainText: textRow.plainText,
+                                    documentJSON: "",
+                                    sourceHTMLHash: "",
+                                    sourceHTML: "",
+                                    rawSourceText: rawSourceText,
+                                    rawSourceMode: textRow.rawSourceMode,
+                                    localStatus: "downloading",
+                                    localError: nil,
+                                    createdAt: now,
+                                    updatedAt: now
+                                )
+                            }
+                            .execute(db)
+                    } else {
+                        try SavedItemContentLocalTable
+                            .find(textRow.id)
+                            .update {
+                                $0.localStatus = "downloading"
+                                $0.updatedAt = now
+                            }
+                            .execute(db)
+                    }
+
+                    // Enqueue a hydrateText job so the text ingestion client
+                    // can parse the raw source into document blocks.
+                    let payload = TextHydrationPayload(
+                        itemID: textRow.id,
+                        rawSourceText: rawSourceText,
+                        rawSourceMode: textRow.rawSourceMode,
+                        title: sync.title
+                    )
+                    let payloadJSON = try String(
+                        bytes: JSONEncoder().encode(payload),
+                        encoding: .utf8
+                    ) ?? ""
+                    try IngestionJobLocalTable
+                        .insert {
+                            IngestionJobLocalTable.Draft(
+                                id: UUID(),
+                                kind: IngestionJob.Kind.hydrateText.rawValue,
+                                payload: payloadJSON,
+                                createdAt: now,
+                                processedAt: nil
+                            )
+                        }
+                        .execute(db)
+                    enqueued += 1
+                }
+                return enqueued
+            }
+        }
+    }
+
     static func _enqueueHydrationJobsForMissingContent(database: any DatabaseWriter) -> @Sendable () async throws -> Int {
         { () async throws -> Int in
             let now = Date.now

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Tags.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Tags.swift
@@ -39,9 +39,8 @@ extension StowerRepository {
                 let junctions: [ItemTagSyncTable] = try ItemTagSyncTable
                     .where { $0.itemID.in(itemIDs) }
                     .fetchAll(db)
-                var result: [UUID: [UUID]] = [:] // swiftlint:disable:this prefer_let_over_var
-                for row in junctions {
-                    result[row.itemID, default: []].append(row.tagID)
+                let result: [UUID: [UUID]] = junctions.reduce(into: [:]) { dict, row in
+                    dict[row.itemID, default: []].append(row.tagID)
                 }
                 return result
             }
@@ -74,8 +73,8 @@ extension StowerRepository {
                 )
                 try TagSyncTable.insert { draft }.execute(db)
                 return Tag(
-                    id: draft.id ?? UUID(),
                     name: trimmed,
+                    id: draft.id ?? UUID(),
                     colorHex: colorHex,
                     createdAt: now,
                     updatedAt: now

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository.swift
@@ -11,7 +11,9 @@ public struct StowerRepository: Sendable {
     public var hydrateItemContent: @Sendable (UUID, IngestionResult) async throws -> Void
     public var updateLocalContentStatus: @Sendable (UUID, String, String?) async throws -> Void
     public var loadReaderDocument: @Sendable (UUID) async throws -> ReaderDocument?
+    public var loadEditableTextSource: @Sendable (UUID) async throws -> EditableTextSource?
     public var saveReaderDocument: @Sendable (UUID, ReaderDocument, String) async throws -> Void
+    public var saveEditedTextSource: @Sendable (UUID, IngestionResult) async throws -> SavedItem?
     public var loadSourceHTML: @Sendable (UUID) async throws -> String?
     public var upsertMedia: @Sendable ([MediaDescriptor], UUID) async throws -> Void
     /// Loads the cached AI summary for an item, if one has been generated. Nil
@@ -64,6 +66,9 @@ public struct StowerRepository: Sendable {
     /// CloudKit sync. See `_hydratePDFItemsFromSyncedContent` for details.
     /// Returns the number of items hydrated.
     public var hydratePDFItemsFromSyncedContent: @Sendable () async throws -> Int
+    /// Populates the local content table for text/markdown items that arrived
+    /// via CloudKit sync. Mirrors `hydratePDFItemsFromSyncedContent`.
+    public var hydrateTextItemsFromSyncedContent: @Sendable () async throws -> Int
 }
 
 private enum StowerRepositoryKey: DependencyKey {
@@ -94,7 +99,9 @@ extension StowerRepository {
             hydrateItemContent: { _, _ in },
             updateLocalContentStatus: { _, _, _ in },
             loadReaderDocument: { _ in nil },
+            loadEditableTextSource: { _ in nil },
             saveReaderDocument: { _, _, _ in },
+            saveEditedTextSource: { _, _ in nil },
             loadSourceHTML: { _ in nil },
             upsertMedia: { _, _ in },
             loadSummary: { _ in nil },
@@ -124,7 +131,8 @@ extension StowerRepository {
             fetchPendingIngestionJobs: { [] },
             markIngestionJobProcessed: { _ in },
             enqueueHydrationJobsForMissingContent: { 0 },
-            hydratePDFItemsFromSyncedContent: { 0 }
+            hydratePDFItemsFromSyncedContent: { 0 },
+            hydrateTextItemsFromSyncedContent: { 0 }
         )
     }()
 }
@@ -167,6 +175,7 @@ extension StowerRepository {
             try await baseSaveDocument(id, document, html)
             documentCache.set(id, document: document)
         }
+        let loadEditableTextSource = _loadEditableTextSource(database: database)
 
         let baseUpdateFromIngestion = _updateItemFromIngestion(database: database, scheduleSync: scheduleSyncAndNotify)
         let cachedUpdateFromIngestion: @Sendable (UUID, IngestionResult) async throws -> SavedItem? = { id, result in
@@ -218,7 +227,9 @@ extension StowerRepository {
             hydrateItemContent: cachedHydrateItemContent,
             updateLocalContentStatus: _updateLocalContentStatus(database: database),
             loadReaderDocument: cachedLoadDocument,
+            loadEditableTextSource: loadEditableTextSource,
             saveReaderDocument: cachedSaveDocument,
+            saveEditedTextSource: cachedUpdateFromIngestion,
             loadSourceHTML: _loadSourceHTML(database: database),
             upsertMedia: _upsertMedia(database: database),
             loadSummary: _loadSummary(database: database),
@@ -248,7 +259,8 @@ extension StowerRepository {
             fetchPendingIngestionJobs: _fetchPendingIngestionJobs(database: database),
             markIngestionJobProcessed: _markIngestionJobProcessed(database: database),
             enqueueHydrationJobsForMissingContent: _enqueueHydrationJobsForMissingContent(database: database),
-            hydratePDFItemsFromSyncedContent: _hydratePDFItemsFromSyncedContent(database: database)
+            hydratePDFItemsFromSyncedContent: _hydratePDFItemsFromSyncedContent(database: database),
+            hydrateTextItemsFromSyncedContent: _hydrateTextItemsFromSyncedContent(database: database)
         )
     }
 

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository.swift
@@ -284,7 +284,7 @@ extension StowerRepository {
 /// Mutation closures call `ping()`; consumers subscribe via `stream()`.
 final class LibraryChangeBroadcast: @unchecked Sendable {
     private let lock = NSLock()
-    private var continuations: [UUID: AsyncStream<Void>.Continuation] = [:] // swiftlint:disable:this prefer_let_over_var
+    private var continuations = [UUID: AsyncStream<Void>.Continuation]()
 
     func stream() -> AsyncStream<Void> {
         AsyncStream { continuation in

--- a/StowerPackage/Sources/StowerData/Data/Tables.swift
+++ b/StowerPackage/Sources/StowerData/Data/Tables.swift
@@ -162,7 +162,7 @@ nonisolated public struct SavedImageRefLocalTable: Hashable, Identifiable, Senda
 nonisolated public struct SavedImageAssetLocalTable: Hashable, Identifiable, Sendable {
     public let id: UUID
     public var itemID: UUID
-    public var imageData: Data = Data() // swiftlint:disable:this redundant_type_annotation
+    public var imageData: Data = .init()
     public var width: Int = 0
     public var height: Int = 0
     public var format: String = "jpg"

--- a/StowerPackage/Sources/StowerData/Data/Tables.swift
+++ b/StowerPackage/Sources/StowerData/Data/Tables.swift
@@ -66,6 +66,8 @@ nonisolated public struct SavedItemContentLocalTable: Hashable, Identifiable, Se
     public var documentJSON: String = ""
     public var sourceHTMLHash: String = ""
     public var sourceHTML: String = ""
+    public var rawSourceText: String = ""
+    public var rawSourceMode: String?
     public var localStatus: String = "notDownloaded"  // notDownloaded, downloading, available, failed
     public var localError: String?
     public var createdAt: Date = .now
@@ -93,6 +95,23 @@ nonisolated public struct SavedPDFContentSyncTable: Hashable, Identifiable, Send
     public let id: UUID
     public var documentJSON: String = ""
     public var plainText: String = ""
+    public var createdAt: Date = .now
+    public var updatedAt: Date = .now
+}
+
+/// CloudKit-synced content for text/markdown items. Populated when a text
+/// item is created or edited on any device; the second device reads this row
+/// to hydrate the local content table without a source URL to re-fetch from.
+/// Mirrors `SavedPDFContentSyncTable` but carries `rawSourceText` instead of
+/// `documentJSON` — the receiving device re-parses the raw source to rebuild
+/// the document blocks, keeping each CloudKit record well under the 1 MB limit.
+@Table
+nonisolated public struct SavedTextContentSyncTable: Hashable, Identifiable, Sendable {
+    public let id: UUID
+    public var plainText: String = ""
+    public var rawSourceText: String = ""
+    public var rawSourceMode: String?
+    public var renderFormat: String = "plainText"
     public var createdAt: Date = .now
     public var updatedAt: Date = .now
 }

--- a/StowerPackage/Sources/StowerData/Domain/LibraryFilter.swift
+++ b/StowerPackage/Sources/StowerData/Domain/LibraryFilter.swift
@@ -24,7 +24,7 @@ public struct LibraryListCounts: Equatable, Sendable {
     public var untagged: Int
     public var all: Int
     public var recentlyDeleted: Int
-    public var byTag: [UUID: Int] // swiftlint:disable:this prefer_let_over_var
+    public var byTag = [UUID: Int]()
 
     public init(
         unread: Int = 0,

--- a/StowerPackage/Sources/StowerData/Domain/Models.swift
+++ b/StowerPackage/Sources/StowerData/Domain/Models.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_default_parameter_at_end
 import Foundation
 
 public struct SavedItem: Equatable, Identifiable, Sendable {
@@ -32,16 +31,16 @@ public struct SavedItem: Equatable, Identifiable, Sendable {
     public var deletedAt: Date?
     /// IDs of tags assigned to this item. Populated by repository reads via a
     /// batched junction-table query (never N+1).
-    public var tagIDs: [UUID] // swiftlint:disable:this prefer_let_over_var
+    public var tagIDs = [UUID]()
 
     public init(
-        id: UUID = UUID(),
         title: String,
+        content: String,
+        id: UUID = UUID(),
         sourceURL: String? = nil,
         canonicalURL: String? = nil,
         renderFormat: RenderFormat = .plainText,
         documentVersion: Int = 1,
-        content: String,
         excerpt: String? = nil,
         heroImageURL: String? = nil,
         author: String? = nil,
@@ -320,7 +319,7 @@ public struct IngestionJob: Equatable, Identifiable, Sendable {
     public let payload: String
     public let createdAt: Date
 
-    public init(id: UUID = UUID(), kind: Kind, payload: String, createdAt: Date = .now) {
+    public init(kind: Kind, payload: String, id: UUID = UUID(), createdAt: Date = .now) {
         self.id = id
         self.kind = kind
         self.payload = payload
@@ -351,4 +350,3 @@ public struct TextHydrationPayload: Codable, Equatable, Sendable {
         self.title = title
     }
 }
-// swiftlint:enable function_default_parameter_at_end

--- a/StowerPackage/Sources/StowerData/Domain/Models.swift
+++ b/StowerPackage/Sources/StowerData/Domain/Models.swift
@@ -311,6 +311,7 @@ public struct IngestionJob: Equatable, Identifiable, Sendable {
         case text = "text"
         case markdown = "markdown"
         case hydrate = "hydrate"
+        case hydrateText = "hydrateText"
         case pdf = "pdf"
     }
 
@@ -334,6 +335,20 @@ public struct HydrationPayload: Codable, Equatable, Sendable {
     public init(itemID: UUID, url: String) {
         self.itemID = itemID
         self.url = url
+    }
+}
+
+public struct TextHydrationPayload: Codable, Equatable, Sendable {
+    public var itemID: UUID
+    public var rawSourceText: String
+    public var rawSourceMode: String?
+    public var title: String
+
+    public init(itemID: UUID, rawSourceText: String, rawSourceMode: String?, title: String) {
+        self.itemID = itemID
+        self.rawSourceText = rawSourceText
+        self.rawSourceMode = rawSourceMode
+        self.title = title
     }
 }
 // swiftlint:enable function_default_parameter_at_end

--- a/StowerPackage/Sources/StowerData/Domain/ReaderDocument.swift
+++ b/StowerPackage/Sources/StowerData/Domain/ReaderDocument.swift
@@ -355,10 +355,12 @@ public enum ReaderDocumentMarkdownWriter {
             return "\(hashes) \(inlinesToMarkdown(inlines))"
 
         case let .list(ordered, items):
-            return items.enumerated().map { index, inlines in
-                let marker = ordered ? "\(index + 1)." : "-"
-                return "\(marker) \(inlinesToMarkdown(inlines))"
-            }.joined(separator: "\n")
+            return items.enumerated()
+                .map { index, inlines in
+                    let marker = ordered ? "\(index + 1)." : "-"
+                    return "\(marker) \(inlinesToMarkdown(inlines))"
+                }
+                .joined(separator: "\n")
 
         case .blockquote(let inlines):
             let text = inlinesToMarkdown(inlines)

--- a/StowerPackage/Sources/StowerData/Domain/ReaderDocument.swift
+++ b/StowerPackage/Sources/StowerData/Domain/ReaderDocument.swift
@@ -55,6 +55,7 @@ public enum ReaderBlock: Codable, Equatable, Sendable {
 
 public enum ReaderInline: Codable, Equatable, Sendable {
     case text(String)
+    case lineBreak
     case link(label: String, url: String)
     case emphasis(String)
     case strong(String)
@@ -155,6 +156,8 @@ public struct IngestionResult: Equatable, Sendable {
     public var plainText: String
     public var media: [MediaDescriptor]
     public var embeds: [EmbedDescriptor]
+    public var rawSourceText: String?
+    public var rawSourceMode: TextImportMode?
     /// The raw HTML of the article section (or full page for webView render format).
     public var sourceHTML: String
     /// SHA-256 hex digest of the original PDF bytes. Only populated for
@@ -181,6 +184,8 @@ public struct IngestionResult: Equatable, Sendable {
         plainText: String,
         media: [MediaDescriptor],
         embeds: [EmbedDescriptor],
+        rawSourceText: String? = nil,
+        rawSourceMode: TextImportMode? = nil,
         sourceHTML: String = "",
         pdfSHA256: String? = nil
     ) {
@@ -201,35 +206,49 @@ public struct IngestionResult: Equatable, Sendable {
         self.plainText = plainText
         self.media = media
         self.embeds = embeds
+        self.rawSourceText = rawSourceText
+        self.rawSourceMode = rawSourceMode
         self.sourceHTML = sourceHTML
         self.pdfSHA256 = pdfSHA256
     }
 
-    public static func sharedText(_ text: String, title: String? = nil) -> IngestionResult {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolvedTitle = resolvedTextImportTitle(documentTitle: nil, titleHint: title)
+    public static func sharedText(
+        _ text: String,
+        explicitTitle: String? = nil,
+        titleHint: String? = nil,
+        rawSourceText: String? = nil,
+        rawSourceMode: TextImportMode? = nil
+    ) -> IngestionResult {
+        let normalized = normalizeTextForStorage(text)
+        let resolvedTitle = resolvedTextImportTitle(
+            explicitTitle: explicitTitle,
+            documentTitle: nil,
+            titleHint: titleHint
+        )
         let document = ReaderDocument(
             title: resolvedTitle,
-            blocks: [.paragraph([.text(trimmed)])]
+            blocks: plainTextBlocks(from: normalized)
         )
         return IngestionResult(
             title: resolvedTitle,
             sourceURL: nil,
             canonicalURL: nil,
-            excerpt: String(trimmed.prefix(180)),
+            excerpt: String(normalized.prefix(180)),
             author: nil,
             publishedAt: nil,
             siteName: nil,
             heroImageURL: nil,
-            readingTimeMinutes: max(1, trimmed.split(separator: " ").count / 225),
+            readingTimeMinutes: max(1, normalized.split(separator: " ").count / 225),
             hasRichMedia: false,
             renderFormat: .plainText,
             processingState: .ready,
             processingError: nil,
             document: document,
-            plainText: trimmed,
+            plainText: normalized,
             media: [],
-            embeds: []
+            embeds: [],
+            rawSourceText: rawSourceText,
+            rawSourceMode: rawSourceMode
         )
     }
 
@@ -237,6 +256,8 @@ public struct IngestionResult: Equatable, Sendable {
         title: String,
         blocks: [ReaderBlock],
         plainText: String,
+        rawSourceText: String? = nil,
+        rawSourceMode: TextImportMode? = nil,
         sourceURL: String? = nil,
         canonicalURL: String? = nil
     ) -> IngestionResult {
@@ -262,8 +283,143 @@ public struct IngestionResult: Equatable, Sendable {
             document: document,
             plainText: trimmed,
             media: [],
-            embeds: []
+            embeds: [],
+            rawSourceText: rawSourceText,
+            rawSourceMode: rawSourceMode
         )
     }
 }
+
+private func normalizeTextForStorage(_ text: String) -> String {
+    text
+        .replacingOccurrences(of: "\r\n", with: "\n")
+        .replacingOccurrences(of: "\r", with: "\n")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+private func plainTextBlocks(from text: String) -> [ReaderBlock] {
+    let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    var paragraphs = [[String]]()
+    var current = [String]()
+
+    for line in lines {
+        if line.trimmingCharacters(in: .whitespaces).isEmpty {
+            if !current.isEmpty {
+                paragraphs.append(current)
+                current = []
+            }
+            continue
+        }
+        current.append(line)
+    }
+
+    if !current.isEmpty {
+        paragraphs.append(current)
+    }
+
+    guard !paragraphs.isEmpty else {
+        return [.paragraph([])]
+    }
+
+    return paragraphs.map { lines in
+        var inlines = [ReaderInline]()
+        for (index, line) in lines.enumerated() {
+            inlines.append(.text(line))
+            if index < lines.count - 1 {
+                inlines.append(.lineBreak)
+            }
+        }
+        return .paragraph(inlines)
+    }
+}
 // swiftlint:enable function_default_parameter_at_end
+
+// MARK: - Markdown Reconstruction
+
+/// Converts a `ReaderDocument`'s blocks back to markdown source text.
+/// Used when `rawSourceText` is empty and the editor needs markdown to display.
+public enum ReaderDocumentMarkdownWriter {
+    public static func markdown(from document: ReaderDocument) -> String {
+        document.blocks
+            .map(blockToMarkdown)
+            .joined(separator: "\n\n")
+    }
+
+    private static func blockToMarkdown(_ block: ReaderBlock) -> String {
+        switch block {
+        case .paragraph(let inlines):
+            return inlinesToMarkdown(inlines)
+
+        case let .heading(level, inlines):
+            let hashes = String(repeating: "#", count: min(max(level, 1), 6))
+            return "\(hashes) \(inlinesToMarkdown(inlines))"
+
+        case let .list(ordered, items):
+            return items.enumerated().map { index, inlines in
+                let marker = ordered ? "\(index + 1)." : "-"
+                return "\(marker) \(inlinesToMarkdown(inlines))"
+            }.joined(separator: "\n")
+
+        case .blockquote(let inlines):
+            let text = inlinesToMarkdown(inlines)
+            return text.split(separator: "\n", omittingEmptySubsequences: false)
+                .map { "> \($0)" }
+                .joined(separator: "\n")
+
+        case let .code(language, code):
+            let fence = "```"
+            let lang = language ?? ""
+            return "\(fence)\(lang)\n\(code)\n\(fence)"
+
+        case .table(let markdown):
+            return markdown
+
+        case .horizontalRule:
+            return "---"
+
+        case let .callout(title, inlines):
+            let body = inlinesToMarkdown(inlines)
+            if let title, !title.isEmpty {
+                return "> **\(title)**\n> \(body)"
+            }
+            return "> \(body)"
+
+        case .figure(let media):
+            let alt = media.altText ?? media.caption ?? ""
+            if media.sourceURL.hasPrefix("stower://") {
+                return alt.isEmpty ? "" : alt
+            }
+            return "![\(alt)](\(media.sourceURL))"
+
+        case .video(let media):
+            let label = media.caption ?? media.sourceURL
+            return "[\(label)](\(media.sourceURL))"
+
+        case .embed(let embed):
+            return "[\(embed.provider)](\(embed.embedURL))"
+        }
+    }
+
+    static func inlinesToMarkdown(_ inlines: [ReaderInline]) -> String {
+        inlines.map(inlineToMarkdown).joined()
+    }
+
+    private static func inlineToMarkdown(_ inline: ReaderInline) -> String {
+        switch inline {
+        case .text(let value):
+            return value
+        case .lineBreak:
+            return "  \n"
+        case let .link(label, url):
+            return "[\(label)](\(url))"
+        case .emphasis(let value):
+            return "*\(value)*"
+        case .strong(let value):
+            return "**\(value)**"
+        case .code(let value):
+            return "`\(value)`"
+        case .strikethrough(let value):
+            return "~~\(value)~~"
+        }
+    }
+}

--- a/StowerPackage/Sources/StowerData/Domain/ReaderDocument.swift
+++ b/StowerPackage/Sources/StowerData/Domain/ReaderDocument.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_default_parameter_at_end
 import Foundation
 
 public enum RenderFormat: String, Codable, Equatable, Sendable {
@@ -25,11 +24,11 @@ public struct ReaderDocument: Codable, Equatable, Sendable {
     public var blocks: [ReaderBlock]
 
     public init(
+        title: String,
+        blocks: [ReaderBlock],
         version: Int = 1,
         sourceURL: String? = nil,
-        canonicalURL: String? = nil,
-        title: String,
-        blocks: [ReaderBlock]
+        canonicalURL: String? = nil
     ) {
         self.version = version
         self.sourceURL = sourceURL
@@ -332,7 +331,6 @@ private func plainTextBlocks(from text: String) -> [ReaderBlock] {
         return .paragraph(inlines)
     }
 }
-// swiftlint:enable function_default_parameter_at_end
 
 // MARK: - Markdown Reconstruction
 

--- a/StowerPackage/Sources/StowerData/Domain/ReaderDocumentSanitizer.swift
+++ b/StowerPackage/Sources/StowerData/Domain/ReaderDocumentSanitizer.swift
@@ -47,6 +47,9 @@ private func sanitizeInlines(_ inlines: [ReaderInline]) -> [ReaderInline] {
             let cleaned = stripPilcrows(value)
             if !cleaned.isEmpty { output.append(.text(cleaned)) }
 
+        case .lineBreak:
+            output.append(.lineBreak)
+
         case let .link(label, url):
             let cleanedLabel = stripPilcrows(label).trimmingCharacters(in: .whitespacesAndNewlines)
             if cleanedLabel.isEmpty { continue }

--- a/StowerPackage/Sources/StowerData/Domain/ReaderDocumentSanitizer.swift
+++ b/StowerPackage/Sources/StowerData/Domain/ReaderDocumentSanitizer.swift
@@ -35,46 +35,45 @@ private func sanitizeBlock(_ block: ReaderBlock) -> ReaderBlock {
 }
 
 private func sanitizeInlines(_ inlines: [ReaderInline]) -> [ReaderInline] {
-    var output: [ReaderInline] = [] // swiftlint:disable:this prefer_let_over_var
-    output.reserveCapacity(inlines.count)
-
-    for inline in inlines {
+    let output: [ReaderInline] = inlines.compactMap { inline -> ReaderInline? in
         switch inline {
         case let .text(value):
             // Preserve boundary whitespace — the parser intentionally emits
             // segments like `"word "` so the downstream renderer doesn't
             // smoosh links/bold runs against their neighbours.
             let cleaned = stripPilcrows(value)
-            if !cleaned.isEmpty { output.append(.text(cleaned)) }
+            return cleaned.isEmpty ? nil : .text(cleaned)
 
         case .lineBreak:
-            output.append(.lineBreak)
+            return .lineBreak
 
         case let .link(label, url):
             let cleanedLabel = stripPilcrows(label).trimmingCharacters(in: .whitespacesAndNewlines)
-            if cleanedLabel.isEmpty { continue }
+            if cleanedLabel.isEmpty {
+                return nil
+            }
             // Drop fragment-only links with symbol-only or very short labels —
             // these are almost always heading permalinks.
             if url.hasPrefix("#"), isSymbolOnly(cleanedLabel) || cleanedLabel.count <= 2 {
-                continue
+                return nil
             }
-            output.append(.link(label: cleanedLabel, url: url))
+            return .link(label: cleanedLabel, url: url)
 
         case let .emphasis(value):
             let cleaned = stripPilcrows(value).trimmingCharacters(in: .whitespacesAndNewlines)
-            if !cleaned.isEmpty { output.append(.emphasis(cleaned)) }
+            return cleaned.isEmpty ? nil : .emphasis(cleaned)
 
         case let .strong(value):
             let cleaned = stripPilcrows(value).trimmingCharacters(in: .whitespacesAndNewlines)
-            if !cleaned.isEmpty { output.append(.strong(cleaned)) }
+            return cleaned.isEmpty ? nil : .strong(cleaned)
 
         case let .code(value):
             // Don't strip pilcrows from code — they may be meaningful literals.
-            output.append(.code(value))
+            return .code(value)
 
         case let .strikethrough(value):
             let cleaned = stripPilcrows(value).trimmingCharacters(in: .whitespacesAndNewlines)
-            if !cleaned.isEmpty { output.append(.strikethrough(cleaned)) }
+            return cleaned.isEmpty ? nil : .strikethrough(cleaned)
         }
     }
 
@@ -115,19 +114,17 @@ private func isSymbolOnly(_ text: String) -> Bool {
 }
 
 private func mergeAdjacentText(_ inlines: [ReaderInline]) -> [ReaderInline] {
-    var merged: [ReaderInline] = [] // swiftlint:disable:this prefer_let_over_var
-    merged.reserveCapacity(inlines.count)
-    for inline in inlines {
+    let merged: [ReaderInline] = inlines.reduce(into: []) { result, inline in
         if case .text(let current) = inline,
-           case .text(let previous)? = merged.last {
-            merged.removeLast()
+           case .text(let previous)? = result.last {
+            result.removeLast()
             // Boundary spaces are already preserved on each segment, so
             // concatenate directly and collapse any double-space at the seam.
             let joined = (previous + current)
                 .replacingOccurrences(of: "  ", with: " ")
-            merged.append(.text(joined))
+            result.append(.text(joined))
         } else {
-            merged.append(inline)
+            result.append(inline)
         }
     }
     return merged

--- a/StowerPackage/Sources/StowerData/Domain/Tag.swift
+++ b/StowerPackage/Sources/StowerData/Domain/Tag.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_default_parameter_at_end
 import Foundation
 
 /// A user-created tag that can be applied to multiple saved items.
@@ -12,8 +11,8 @@ public struct Tag: Equatable, Identifiable, Sendable, Hashable {
     public var updatedAt: Date
 
     public init(
-        id: UUID = UUID(),
         name: String,
+        id: UUID = UUID(),
         colorHex: String? = nil,
         createdAt: Date = .now,
         updatedAt: Date = .now
@@ -25,4 +24,3 @@ public struct Tag: Equatable, Identifiable, Sendable, Hashable {
         self.updatedAt = updatedAt
     }
 }
-// swiftlint:enable function_default_parameter_at_end

--- a/StowerPackage/Sources/StowerData/Domain/TextImportSupport.swift
+++ b/StowerPackage/Sources/StowerData/Domain/TextImportSupport.swift
@@ -18,6 +18,18 @@ public struct QueuedTextPayload: Codable, Equatable, Sendable {
     }
 }
 
+public struct EditableTextSource: Equatable, Sendable {
+    public var title: String
+    public var text: String
+    public var mode: TextImportMode
+
+    public init(title: String, text: String, mode: TextImportMode) {
+        self.title = title
+        self.text = text
+        self.mode = mode
+    }
+}
+
 public enum TextImportDetector {
     public static func looksLikeMarkdown(_ text: String) -> Bool {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -32,6 +44,8 @@ public enum TextImportDetector {
             #"(?m)^\s{0,3}([-*_])(\s*\1){2,}\s*$"#,
             #"(?s)\|.+\|\s*\n\s*\|[\s:\-]+\|"#,
             #"\[[^\]]+\]\([^)]+\)"#,
+            #"\*\*\S.*?\*\*"#,
+            #"`[^`\n]+`"#,
         ]
 
         return patterns.contains { pattern in
@@ -109,7 +123,17 @@ public enum SharedTextClassifier {
     }
 }
 
-public func resolvedTextImportTitle(documentTitle: String?, titleHint: String?) -> String {
+public func resolvedTextImportTitle(
+    explicitTitle: String?,
+    documentTitle: String?,
+    titleHint: String?
+) -> String {
+    if let explicitTitle {
+        let trimmed = explicitTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            return trimmed
+        }
+    }
     if let documentTitle {
         let trimmed = documentTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmed.isEmpty {

--- a/StowerPackage/Sources/StowerData/Domain/TextSyncCompression.swift
+++ b/StowerPackage/Sources/StowerData/Domain/TextSyncCompression.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Compresses and decompresses text for CloudKit sync. CloudKit has a 1 MB
+/// per-record limit; long markdown articles can exceed that. Zlib compression
+/// + base64 encoding typically achieves 3–5× reduction on text, keeping even
+/// very large articles well under the limit.
+public enum TextSyncCompression {
+    /// Compresses a string with zlib and returns a base64-encoded representation.
+    /// Falls back to the original string if compression fails.
+    public static func compress(_ text: String) -> String {
+        guard !text.isEmpty else { return "" }
+        let data = Data(text.utf8)
+        guard let compressed = try? (data as NSData).compressed(using: .zlib) as Data else {
+            return text
+        }
+        return compressed.base64EncodedString()
+    }
+
+    /// Decompresses a base64+zlib string back to the original text.
+    /// If the input isn't valid base64 or isn't compressed, returns the
+    /// input as-is (backward-compatible with uncompressed legacy data).
+    public static func decompress(_ stored: String) -> String {
+        guard !stored.isEmpty else { return "" }
+        guard let data = Data(base64Encoded: stored) else {
+            // Not base64 — assume it's uncompressed plain text.
+            return stored
+        }
+        guard let decompressed = try? (data as NSData).decompressed(using: .zlib) as Data,
+              let text = String(data: decompressed, encoding: .utf8)
+        else {
+            // Decompression failed — return the original string (may be
+            // uncompressed text that happens to look like valid base64).
+            return stored
+        }
+        return text
+    }
+}

--- a/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
@@ -262,6 +262,7 @@ public struct AppFeature {
                     return .run { send in
                         _ = try? await repository.enqueueHydrationJobsForMissingContent()
                         _ = try? await repository.hydratePDFItemsFromSyncedContent()
+                        _ = try? await repository.hydrateTextItemsFromSyncedContent()
                         try? await processIngestionJobs(
                             repository: repository,
                             ingestionClient: ingestionClient,
@@ -442,6 +443,7 @@ private func processIngestionJobs(
             let payload = QueuedTextPayloadCodec.decode(job.payload, defaultMode: .auto)
             let result = try await textIngestionClient.ingest(
                 payload.content,
+                nil,
                 payload.titleHint,
                 payload.mode
             )
@@ -450,10 +452,28 @@ private func processIngestionJobs(
             let payload = QueuedTextPayloadCodec.decode(job.payload, defaultMode: .markdown)
             let result = try await textIngestionClient.ingest(
                 payload.content,
+                nil,
                 payload.titleHint,
                 .markdown
             )
             _ = try await repository.createItemFromIngestion(result)
+        case .hydrateText:
+            let data = Data(job.payload.utf8)
+            let payload = try JSONDecoder().decode(TextHydrationPayload.self, from: data)
+            do {
+                let mode = payload.rawSourceMode
+                    .flatMap(TextImportMode.init(rawValue:))
+                    ?? .auto
+                let result = try await textIngestionClient.ingest(
+                    payload.rawSourceText,
+                    payload.title,
+                    nil,
+                    mode
+                )
+                try await repository.hydrateItemContent(payload.itemID, result)
+            } catch {
+                try? await repository.updateLocalContentStatus(payload.itemID, "failed", error.localizedDescription)
+            }
         case .hydrate:
             let data = Data(job.payload.utf8)
             let payload = try JSONDecoder().decode(HydrationPayload.self, from: data)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryFeature.swift
@@ -7,8 +7,7 @@ public struct LibraryFeature {
 
     @ObservableState
     public struct State: Equatable {
-        // swiftlint:disable:next prefer_let_over_var
-        public var items: [SavedItem] = []
+        public var items = [SavedItem]()
         public var query = ""
         public var sourceURL = ""
         public var isLoading = false
@@ -19,7 +18,7 @@ public struct LibraryFeature {
         public var filter: LibraryFilter = .all
         /// All tags known to the repository — drives the "Tags" submenu in the
         /// library row context menu. Refreshed lazily via observeLibraryChanges.
-        public var availableTags: [Tag] = [] // swiftlint:disable:this prefer_let_over_var
+        public var availableTags = [Tag]()
         /// Non-nil when the user is creating a new tag inline from the tag submenu.
         public var inlineTagCreation: InlineTagCreation?
         /// Draft for the in-app text/markdown composer.

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryFeature.swift
@@ -77,15 +77,18 @@ public struct LibraryFeature {
     }
 
     public struct TextImportDraft: Equatable {
+        public var title: String
         public var text: String
         public var mode: TextImportMode
         public var titleHint: String?
 
         public init(
+            title: String = "",
             text: String = "",
             mode: TextImportMode = .auto,
             titleHint: String? = nil
         ) {
+            self.title = title
             self.text = text
             self.mode = mode
             self.titleHint = titleHint
@@ -116,6 +119,7 @@ public struct LibraryFeature {
         case importPDFSelected(URL)
         case addTextTapped
         case textImportDismissed
+        case textImportTitleChanged(String)
         case textImportTextChanged(String)
         case textImportModeChanged(TextImportMode)
         case saveTextImportTapped
@@ -346,6 +350,14 @@ public struct LibraryFeature {
                 state.textImportDraft = nil
                 return .none
 
+            case .textImportTitleChanged(let title):
+                state.textImportDraft?.title = title
+                if state.saveState == .failed {
+                    state.saveState = .queued
+                    state.errorMessage = nil
+                }
+                return .none
+
             case .textImportTextChanged(let text):
                 state.textImportDraft?.text = text
                 if state.saveState == .failed {
@@ -370,9 +382,13 @@ public struct LibraryFeature {
                 state.saveState = .extracting
                 state.errorMessage = nil
                 return runTextImport(
-                    text: text,
-                    titleHint: draft.titleHint,
-                    mode: draft.mode,
+                    .init(
+                        text: text,
+                        explicitTitle: draft.title,
+                        titleHint: draft.titleHint,
+                        mode: draft.mode,
+                        openAfterSave: true
+                    ),
                     repository: self.repository,
                     textIngestionClient: self.textIngestionClient
                 )
@@ -388,9 +404,13 @@ public struct LibraryFeature {
                 state.saveState = .extracting
                 state.errorMessage = nil
                 return runTextImport(
-                    text: trimmed,
-                    titleHint: titleHint,
-                    mode: mode,
+                    .init(
+                        text: trimmed,
+                        explicitTitle: nil,
+                        titleHint: titleHint,
+                        mode: mode,
+                        openAfterSave: false
+                    ),
                     repository: self.repository,
                     textIngestionClient: self.textIngestionClient
                 )
@@ -625,19 +645,32 @@ public struct LibraryFeature {
     }
 }
 
+private struct TextImportRequest {
+    var text: String
+    var explicitTitle: String?
+    var titleHint: String?
+    var mode: TextImportMode
+    var openAfterSave: Bool
+}
+
 private func runTextImport(
-    text: String,
-    titleHint: String?,
-    mode: TextImportMode,
+    _ request: TextImportRequest,
     repository: StowerRepository,
     textIngestionClient: TextIngestionClient
 ) -> Effect<LibraryFeature.Action> {
     .run { send in
         do {
-            let result = try await textIngestionClient.ingest(text, titleHint, mode)
+            let result = try await textIngestionClient.ingest(
+                request.text,
+                request.explicitTitle,
+                request.titleHint,
+                request.mode
+            )
             let item = try await repository.createItemFromIngestion(result)
             await send(.saveURLFinished(item))
-            await send(.openItem(item))
+            if request.openAfterSave {
+                await send(.openItem(item))
+            }
         } catch {
             await send(.saveURLFailed(error.localizedDescription))
         }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
@@ -23,8 +23,9 @@ public struct LibraryScreen: View {
     private let onOpenFilters: (() -> Void)?
     @State private var isAddURLPresented = false
     @State private var isTextImportPresented = false
-    @State private var isTextFilePickerPresented = false
-    @State private var isPDFPickerPresented = false
+    #if os(iOS)
+    @State private var activeImportPicker: IOSImportPicker?
+    #endif
 
     public init(
         store: StoreOf<LibraryFeature>,
@@ -311,18 +312,21 @@ public struct LibraryScreen: View {
                 isTextImportPresented = false
             }
         }
-        .fileImporter(
-            isPresented: $isTextFilePickerPresented,
-            allowedContentTypes: textImportContentTypes
-        ) { result in
-            handleTextImport(result)
+        #if os(iOS)
+        .sheet(item: $activeImportPicker) { picker in
+            IOSDocumentPicker(
+                allowedContentTypes: picker == .text ? textImportContentTypes : [.pdf]
+            ) { result in
+                activeImportPicker = nil
+                switch picker {
+                case .text:
+                    handleTextImport(result)
+                case .pdf:
+                    handlePDFImport(result)
+                }
+            }
         }
-        .fileImporter(
-            isPresented: $isPDFPickerPresented,
-            allowedContentTypes: [.pdf]
-        ) { result in
-            handlePDFImport(result)
-        }
+        #endif
         .sheet(isPresented: Binding(
             get: { store.inlineTagCreation != nil },
             set: { if !$0 { store.send(.inlineCreateTagDismissed) } }
@@ -383,7 +387,7 @@ public struct LibraryScreen: View {
         }
         #else
         DispatchQueue.main.async {
-            isTextFilePickerPresented = true
+            activeImportPicker = .text
         }
         #endif
     }
@@ -398,7 +402,7 @@ public struct LibraryScreen: View {
         }
         #else
         DispatchQueue.main.async {
-            isPDFPickerPresented = true
+            activeImportPicker = .pdf
         }
         #endif
     }
@@ -499,6 +503,54 @@ public struct LibraryScreen: View {
     }
 
     #if os(iOS)
+    private enum IOSImportPicker: String, Identifiable {
+        case text = "text"
+        case pdf = "pdf"
+
+        var id: String { rawValue }
+    }
+
+    private struct IOSDocumentPicker: UIViewControllerRepresentable {
+        let allowedContentTypes: [UTType]
+        let onComplete: (Result<URL, Error>) -> Void
+
+        func makeCoordinator() -> Coordinator {
+            Coordinator(onComplete: onComplete)
+        }
+
+        func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+            let controller = UIDocumentPickerViewController(
+                forOpeningContentTypes: allowedContentTypes,
+                asCopy: false
+            )
+            controller.delegate = context.coordinator
+            controller.allowsMultipleSelection = false
+            return controller
+        }
+
+        func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+
+        final class Coordinator: NSObject, UIDocumentPickerDelegate {
+            private let onComplete: (Result<URL, Error>) -> Void
+
+            init(onComplete: @escaping (Result<URL, Error>) -> Void) {
+                self.onComplete = onComplete
+            }
+
+            func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+                guard let url = urls.first else {
+                    onComplete(.failure(NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError)))
+                    return
+                }
+                onComplete(.success(url))
+            }
+
+            func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+                onComplete(.failure(NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError)))
+            }
+        }
+    }
+
     /// Modal URL-entry form shown when the user taps the toolbar "+".
     @ViewBuilder private var addURLSheet: some View {
         NavigationStack {

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
@@ -603,73 +603,31 @@ public struct LibraryScreen: View {
     #endif
 
     @ViewBuilder private var textImportSheet: some View {
-        NavigationStack {
-            VStack(spacing: 16) {
-                Picker(
-                    "Format",
-                    selection: Binding(
-                        get: { store.textImportDraft?.mode ?? .auto },
-                        set: { store.send(.textImportModeChanged($0)) }
-                    )
-                ) {
-                    Text("Auto").tag(TextImportMode.auto)
-                    Text("Plain Text").tag(TextImportMode.plainText)
-                    Text("Markdown").tag(TextImportMode.markdown)
-                }
-                .pickerStyle(.segmented)
-
-                TextEditor(
-                    text: Binding(
-                        get: { store.textImportDraft?.text ?? "" },
-                        set: { store.send(.textImportTextChanged($0)) }
-                    )
-                )
-                .font(store.textImportDraft?.mode == .markdown ? .body.monospaced() : .body)
-                .padding(12)
-                .frame(maxWidth: .infinity, minHeight: 280, maxHeight: .infinity)
-                .glassEffect(.regular, in: .rect(cornerRadius: 12))
-
-                if store.saveState == .failed, let error = store.errorMessage {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(palette.error)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                } else {
-                    Text("Paste plain text or markdown. Auto mode detects markdown-like syntax for text imports.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+        TextAuthoringSheet(
+            title: Binding(
+                get: { store.textImportDraft?.title ?? "" },
+                set: { store.send(.textImportTitleChanged($0)) }
+            ),
+            text: Binding(
+                get: { store.textImportDraft?.text ?? "" },
+                set: { store.send(.textImportTextChanged($0)) }
+            ),
+            mode: Binding(
+                get: { store.textImportDraft?.mode ?? .auto },
+                set: { store.send(.textImportModeChanged($0)) }
+            ),
+            palette: palette,
+            errorMessage: store.saveState == .failed ? store.errorMessage : nil,
+            isSaving: store.isSaving,
+            navigationTitle: "Add Text",
+            onCancel: {
+                isTextImportPresented = false
+                store.send(.textImportDismissed)
+            },
+            onSave: {
+                store.send(.saveTextImportTapped)
             }
-            .padding()
-            .navigationTitle("Add Text/Markdown")
-            #if os(iOS)
-            .navigationBarTitleDisplayMode(.inline)
-            #else
-            .frame(minWidth: 640, idealWidth: 720, maxWidth: 900, minHeight: 460, idealHeight: 560)
-            #endif
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        isTextImportPresented = false
-                        store.send(.textImportDismissed)
-                    }
-                    .disabled(store.isSaving)
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    if store.isSaving {
-                        ProgressView()
-                    } else {
-                        Button("Save") {
-                            store.send(.saveTextImportTapped)
-                        }
-                        .disabled(store.textImportDraft?.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
-                    }
-                }
-            }
-        }
-        .presentationDetents([.medium, .large])
-        .presentationDragIndicator(.visible)
+        )
     }
 
     private func decodedImportedText(from data: Data) -> String {

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/PDFReaderSheet.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/PDFReaderSheet.swift
@@ -90,8 +90,7 @@ struct PDFReaderSheet: View {
                 .font(.system(size: 48, weight: .regular))
                 .foregroundStyle(.secondary)
                 .accessibilityLabel("PDF not available")
-            // swiftlint:disable:next no_hardcoded_strings
-            Text("Original PDF not available")
+            Text("PDF not available")
                 .font(.headline)
             Text("This PDF was shared from another device. The extracted text is synced to this device, but the original PDF file isn't. Re-share the PDF on this device to restore the original view.")
                 .font(.subheadline)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAIControls.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAIControls.swift
@@ -139,8 +139,7 @@ struct ReaderAIControls: View {
                     Button {
                         store.send(.summarizeRequested(document: document, plainText: plainText))
                     } label: {
-                        // swiftlint:disable:next no_hardcoded_strings
-                        Label("Summarize this article", systemImage: "sparkles")
+                        Label("Summarize article", systemImage: "sparkles")
                             .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.borderedProminent)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAIFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAIFeature.swift
@@ -35,16 +35,14 @@ public struct ReaderAIFeature {
         // MARK: Ask tab
         public var question: String = ""
         public var pendingAnswer: String = ""
-        // swiftlint:disable:next prefer_let_over_var
-        public var transcript: [QAEntry] = []
+        public var transcript = [QAEntry]()
         public var isAnswering = false
         public var isRetrieving = false
         public var askError: String?
 
-        // swiftlint:disable:next explicit_enum_raw_value
         public enum Mode: String, Equatable, Sendable {
-            case summary // swiftlint:disable:this explicit_enum_raw_value
-            case ask // swiftlint:disable:this explicit_enum_raw_value
+            case summary = "summary"
+            case ask = "ask"
         }
 
         public struct QAEntry: Equatable, Identifiable, Sendable {

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderDocumentHTMLBuilder.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderDocumentHTMLBuilder.swift
@@ -127,17 +127,19 @@ public enum ReaderDocumentHTMLBuilder {
 
         html += "  <h1 class=\"stower-title\">\(escapeHTML(item.title))</h1>\n"
 
-        // swiftlint:disable:next prefer_let_over_var
-        var metaPieces: [String] = []
-        if let siteName = item.siteName, !siteName.isEmpty {
-            metaPieces.append("<span class=\"stower-site\">\(escapeHTML(siteName))</span>")
-        }
-        if let author = item.author, !author.isEmpty {
-            metaPieces.append("<span class=\"stower-author\">by \(escapeHTML(author))</span>")
-        }
-        if let minutes = item.readingTimeMinutes {
-            metaPieces.append("<span class=\"stower-reading-time\">\(minutes) min read</span>")
-        }
+        let metaPieces: [String] = {
+            var pieces = [String]()
+            if let siteName = item.siteName, !siteName.isEmpty {
+                pieces.append("<span class=\"stower-site\">\(escapeHTML(siteName))</span>")
+            }
+            if let author = item.author, !author.isEmpty {
+                pieces.append("<span class=\"stower-author\">by \(escapeHTML(author))</span>")
+            }
+            if let minutes = item.readingTimeMinutes {
+                pieces.append("<span class=\"stower-reading-time\">\(minutes) min read</span>")
+            }
+            return pieces
+        }()
         if !metaPieces.isEmpty {
             html += "  <div class=\"stower-meta\">\(metaPieces.joined(separator: " &middot; "))</div>\n"
         }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderDocumentHTMLBuilder.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderDocumentHTMLBuilder.swift
@@ -393,6 +393,9 @@ public enum ReaderDocumentHTMLBuilder {
             case .text(let value):
                 out += escapeHTML(value)
 
+            case .lineBreak:
+                out += "<br>"
+
             case let .link(label, url):
                 if isSafeLinkURL(url) {
                     out += "<a href=\"\(attrEscape(url))\" target=\"_blank\" rel=\"noopener noreferrer\">\(escapeHTML(label))</a>"

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderFeature.swift
@@ -20,6 +20,7 @@ public struct ReaderFeature {
         public var isLoading = false
         public var errorMessage: String?
         @Presents public var inlineEmbedURL: InlineEmbedFeature.State?
+        public var textEditor: TextEditorState?
 
         /// Whether the user has manually overridden the render mode.
         public var renderModeOverride: RenderFormat?
@@ -47,6 +48,11 @@ public struct ReaderFeature {
         /// Whether the original article was detected as having interactive content.
         public var hasInteractiveContent: Bool {
             item?.renderFormat == .webView
+        }
+
+        public var canEditTextSource: Bool {
+            guard let item else { return false }
+            return item.sourceURL == nil && item.renderFormat != .pdf
         }
 
         var lineWidthPolicy: ReaderLineWidthPolicy {
@@ -88,6 +94,28 @@ public struct ReaderFeature {
         }
     }
 
+    public struct TextEditorState: Equatable, Sendable {
+        public var title: String
+        public var text: String
+        public var mode: TextImportMode
+        public var isSaving = false
+        public var errorMessage: String?
+
+        public init(
+            title: String,
+            text: String,
+            mode: TextImportMode,
+            isSaving: Bool = false,
+            errorMessage: String? = nil
+        ) {
+            self.title = title
+            self.text = text
+            self.mode = mode
+            self.isSaving = isSaving
+            self.errorMessage = errorMessage
+        }
+    }
+
     public enum Action: Equatable {
         case load
         case loaded(SavedItem?, ReaderDocument?, String?)
@@ -111,6 +139,16 @@ public struct ReaderFeature {
 
         case retryExtractionTapped
         case retryFinished(SavedItem?)
+        case editTextTapped
+        case editableTextLoaded(EditableTextSource)
+        case editableTextFailed(String)
+        case textEditorDismissed
+        case textEditorTitleChanged(String)
+        case textEditorTextChanged(String)
+        case textEditorModeChanged(TextImportMode)
+        case saveTextEditTapped
+        case textEditSaved(SavedItem, ReaderDocument)
+        case textEditFailed(String)
         case openInlineWebEmbed(String)
         case inlineEmbedURL(PresentationAction<InlineEmbedFeature.Action>)
         case switchRenderMode(RenderFormat)
@@ -139,6 +177,8 @@ public struct ReaderFeature {
     var continuousClock
     @Dependency(\.readerProgressClient)
     var readerProgressClient
+    @Dependency(\.textIngestionClient)
+    var textIngestionClient
 
     public var body: some ReducerOf<Self> {
         Scope(state: \.speech, action: \.speech) {
@@ -200,6 +240,95 @@ public struct ReaderFeature {
             case .failed(let error):
                 state.isLoading = false
                 state.errorMessage = error
+                return .none
+
+            case .editTextTapped:
+                guard state.canEditTextSource else { return .none }
+                let repository = self.repository
+                let itemID = state.itemID
+                return .run { send in
+                    do {
+                        guard let source = try await repository.loadEditableTextSource(itemID) else {
+                            await send(.editableTextFailed("This item can't be edited."))
+                            return
+                        }
+                        await send(.editableTextLoaded(source))
+                    } catch {
+                        await send(.editableTextFailed(error.localizedDescription))
+                    }
+                }
+
+            case .editableTextLoaded(let source):
+                state.textEditor = TextEditorState(
+                    title: source.title,
+                    text: source.text,
+                    mode: source.mode
+                )
+                return .none
+
+            case .editableTextFailed(let message):
+                state.errorMessage = message
+                return .none
+
+            case .textEditorDismissed:
+                state.textEditor = nil
+                return .none
+
+            case .textEditorTitleChanged(let title):
+                state.textEditor?.title = title
+                state.textEditor?.errorMessage = nil
+                return .none
+
+            case .textEditorTextChanged(let text):
+                state.textEditor?.text = text
+                state.textEditor?.errorMessage = nil
+                return .none
+
+            case .textEditorModeChanged(let mode):
+                state.textEditor?.mode = mode
+                state.textEditor?.errorMessage = nil
+                return .none
+
+            case .saveTextEditTapped:
+                guard let editor = state.textEditor else { return .none }
+                let trimmed = editor.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else {
+                    state.textEditor?.errorMessage = "Enter some text or markdown."
+                    return .none
+                }
+                state.textEditor?.isSaving = true
+                state.textEditor?.errorMessage = nil
+                let repository = self.repository
+                let textIngestionClient = self.textIngestionClient
+                let itemID = state.itemID
+                return .run { send in
+                    do {
+                        let result = try await textIngestionClient.ingest(
+                            editor.text,
+                            editor.title,
+                            nil,
+                            editor.mode
+                        )
+                        guard let item = try await repository.saveEditedTextSource(itemID, result) else {
+                            await send(.textEditFailed("This item no longer exists."))
+                            return
+                        }
+                        await send(.textEditSaved(item, result.document))
+                    } catch {
+                        await send(.textEditFailed(error.localizedDescription))
+                    }
+                }
+
+            case let .textEditSaved(item, document):
+                state.item = item
+                state.document = document
+                state.sourceHTML = nil
+                state.textEditor = nil
+                return .none
+
+            case .textEditFailed(let message):
+                state.textEditor?.isSaving = false
+                state.textEditor?.errorMessage = message
                 return .none
 
             // Appearance is now passed in via init — no async loading needed.
@@ -270,6 +399,41 @@ public struct ReaderFeature {
                 return .none
 
             case .retryExtractionTapped:
+                // Text/markdown items have no sourceURL — hydrate from the
+                // CloudKit-synced text content table and re-ingest.
+                if state.item?.sourceURL == nil {
+                    state.isLoading = true
+                    let repository = self.repository
+                    let textIngestionClient = self.textIngestionClient
+                    return .run { [id = state.itemID] send in
+                        do {
+                            // Hydrate enqueues jobs; process them inline.
+                            _ = try await repository.hydrateTextItemsFromSyncedContent()
+                            let jobs = try await repository.fetchPendingIngestionJobs()
+                            for job in jobs where job.kind == .hydrateText {
+                                let data = Data(job.payload.utf8)
+                                let payload = try JSONDecoder().decode(TextHydrationPayload.self, from: data)
+                                guard payload.itemID == id else { continue }
+                                let mode = payload.rawSourceMode
+                                    .flatMap(TextImportMode.init(rawValue:))
+                                    ?? .auto
+                                let result = try await textIngestionClient.ingest(
+                                    payload.rawSourceText,
+                                    payload.title,
+                                    nil,
+                                    mode
+                                )
+                                try await repository.hydrateItemContent(id, result)
+                                try await repository.markIngestionJobProcessed(job.id)
+                            }
+                            let item = try await repository.loadItem(id)
+                            await send(.retryFinished(item))
+                        } catch {
+                            await send(.failed(error.localizedDescription))
+                        }
+                    }
+                }
+
                 guard let source = state.item?.sourceURL,
                       let url = URL(string: source)
                 else {

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
@@ -183,7 +183,6 @@ public struct ReaderScreen: View {
                         set: { store.send(.textEditorModeChanged($0)) }
                     ),
                     palette: palette,
-                    appearance: store.appearance,
                     errorMessage: store.textEditor?.errorMessage,
                     isSaving: store.textEditor?.isSaving ?? false,
                     navigationTitle: "Edit",
@@ -192,7 +191,8 @@ public struct ReaderScreen: View {
                     },
                     onSave: {
                         store.send(.saveTextEditTapped)
-                    }
+                    },
+                    appearance: store.appearance
                 )
             }
     }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
@@ -79,6 +79,16 @@ public struct ReaderScreen: View {
                     .keyboardShortcut("f", modifiers: .command)
                     .help("Find in reader")
                 }
+                if store.canEditTextSource {
+                    ToolbarItem(placement: .automatic) {
+                        Button {
+                            store.send(.editTextTapped)
+                        } label: {
+                            Label("Edit", systemImage: "square.and.pencil")
+                        }
+                        .help("Edit this text or markdown item")
+                    }
+                }
                 if store.item?.renderFormat == .pdf {
                     ToolbarItem(placement: .automatic) {
                         Button {
@@ -148,6 +158,42 @@ public struct ReaderScreen: View {
                 ) {
                     isPDFViewerPresented = false
                 }
+            }
+            .sheet(
+                isPresented: Binding(
+                    get: { store.textEditor != nil },
+                    set: { isPresented in
+                        if !isPresented {
+                            store.send(.textEditorDismissed)
+                        }
+                    }
+                )
+            ) {
+                TextAuthoringSheet(
+                    title: Binding(
+                        get: { store.textEditor?.title ?? "" },
+                        set: { store.send(.textEditorTitleChanged($0)) }
+                    ),
+                    text: Binding(
+                        get: { store.textEditor?.text ?? "" },
+                        set: { store.send(.textEditorTextChanged($0)) }
+                    ),
+                    mode: Binding(
+                        get: { store.textEditor?.mode ?? .plainText },
+                        set: { store.send(.textEditorModeChanged($0)) }
+                    ),
+                    palette: palette,
+                    appearance: store.appearance,
+                    errorMessage: store.textEditor?.errorMessage,
+                    isSaving: store.textEditor?.isSaving ?? false,
+                    navigationTitle: "Edit",
+                    onCancel: {
+                        store.send(.textEditorDismissed)
+                    },
+                    onSave: {
+                        store.send(.saveTextEditTapped)
+                    }
+                )
             }
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderSpeechFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderSpeechFeature.swift
@@ -33,7 +33,7 @@ public struct ReaderSpeechFeature {
         /// typical case, so filter operations use `sequence` for
         /// identity rather than `index` (which is non-unique across
         /// sentences of the same block).
-        var currentBlocks: [SpeechBlock] = [] // swiftlint:disable:this prefer_let_over_var
+        var currentBlocks = [SpeechBlock]()
 
         var errorMessage: String?
     }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Sidebar/SidebarFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Sidebar/SidebarFeature.swift
@@ -9,8 +9,7 @@ public struct SidebarFeature {
     public struct State: Equatable {
         public var selection: LibraryFilter = .all
         public var counts: LibraryListCounts = .zero
-        // swiftlint:disable:next prefer_let_over_var
-        public var tags: [Tag] = []
+        public var tags = [Tag]()
         public var isLoading = false
         public var errorMessage: String?
         /// Bound to the "New Tag" sheet.

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ArticleAIClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ArticleAIClient.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable no_sensitive_logging
 import Dependencies
 import Foundation
 import FoundationModels
@@ -229,7 +228,7 @@ extension ArticleAIClient {
     // response, give the rest to the input.
     //
     // The reserves are deliberately generous (roughly 1/4 of a 4096 window).
-    // The token estimator can undercount by ~25% on real articles, so the
+    // The unit estimator can undercount by ~25% on real articles, so the
     // extra headroom keeps even mis-estimated inputs from colliding with
     // the real context ceiling.
     //
@@ -260,7 +259,7 @@ extension ArticleAIClient {
 
         // Single-session fast path — attempt, fall back to chunked on any
         // real-world context overflow. The estimator can still be wrong
-        // even with the conservative char-per-token ratio, so this catch
+        // even with the conservative char-per-unit ratio, so this catch
         // is load-bearing for edge-case articles.
         if approxInputTokens <= budget {
             do {
@@ -298,8 +297,7 @@ extension ArticleAIClient {
             return
         }
 
-        // swiftlint:disable:next prefer_let_over_var
-        var sectionSummaries: [String] = []
+        var sectionSummaries = [String]()
         sectionSummaries.reserveCapacity(chunks.count)
 
         for (offset, chunk) in chunks.enumerated() {
@@ -515,4 +513,3 @@ extension ArticleAIClient {
         continuation.yield(.finished(lastContent))
     }
 }
-// swiftlint:enable no_sensitive_logging

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ArticleChunker.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ArticleChunker.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable no_sensitive_logging
 import Foundation
 import NaturalLanguage
 import StowerData
@@ -8,7 +7,7 @@ import StowerData
 // lists) to keep each chunk semantically coherent. Falls back to sentence-
 // level splitting when a single block exceeds the budget.
 //
-// Token counts are approximated at 4 characters per token for English, per
+// Unit counts are approximated at 4 characters per unit for English, per
 // Apple's TN3193. Callers that need precision can supply their own
 // `tokenCounter` (e.g. wired to `SystemLanguageModel.tokenCount(for:)` for
 // instructions), but the approximation is accurate enough for budgeting
@@ -48,10 +47,8 @@ public enum ArticleChunker {
             return [Chunk(index: 0, text: plainText, approxTokens: tokenCounter(plainText))]
         }
 
-        // swiftlint:disable:next prefer_let_over_var
-        var chunks: [Chunk] = []
-        // swiftlint:disable:next prefer_let_over_var
-        var currentBlocks: [String] = []
+        var chunks = [Chunk]()
+        var currentBlocks = [String]()
         var currentTokens = 0
         var chunkIndex = 0
 
@@ -90,7 +87,7 @@ public enum ArticleChunker {
         return chunks
     }
 
-    // Rough token estimator. Apple's TN3193 gives 3-4 characters per token
+    // Rough unit estimator. Apple's TN3193 gives 3-4 characters per unit
     // for English; we deliberately pick the conservative end (3) because
     // real articles routinely tokenize worse than the optimistic end
     // (punctuation, URLs, inline code, numbers, emoji). Underestimating
@@ -145,10 +142,8 @@ public enum ArticleChunker {
             return [Chunk(index: 0, text: text, approxTokens: tokenCounter(text))]
         }
 
-        // swiftlint:disable:next prefer_let_over_var
-        var chunks: [Chunk] = []
-        // swiftlint:disable:next prefer_let_over_var
-        var current: [String] = []
+        var chunks = [Chunk]()
+        var current = [String]()
         var currentTokens = 0
 
         for sentence in sentences {
@@ -175,8 +170,7 @@ public enum ArticleChunker {
     private static func splitIntoSentences(_ text: String) -> [String] {
         let tokenizer = NLTokenizer(unit: .sentence)
         tokenizer.string = text
-        // swiftlint:disable:next prefer_let_over_var
-        var sentences: [String] = []
+        var sentences = [String]()
         tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) { range, _ in
             let sentence = String(text[range]).trimmingCharacters(in: .whitespacesAndNewlines)
             if !sentence.isEmpty { sentences.append(sentence) }
@@ -185,4 +179,3 @@ public enum ArticleChunker {
         return sentences
     }
 }
-// swiftlint:enable no_sensitive_logging

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ArticleRetriever.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ArticleRetriever.swift
@@ -28,8 +28,7 @@ public enum ArticleRetriever {
             return Array(chunks.prefix(k))
         }
 
-        // swiftlint:disable:next prefer_let_over_var
-        var scored: [(chunk: ArticleChunker.Chunk, score: Double)] = []
+        var scored = [(chunk: ArticleChunker.Chunk, score: Double)]()
         scored.reserveCapacity(chunks.count)
 
         for chunk in chunks {
@@ -69,8 +68,7 @@ public enum ArticleRetriever {
             return nil
         }
 
-        // swiftlint:disable:next prefer_let_over_var
-        var sum: [Double] = []
+        var sum = [Double]()
         var count = 0
 
         for sentence in sentences {
@@ -100,8 +98,7 @@ public enum ArticleRetriever {
     private static func splitSentences(_ text: String) -> [String] {
         let tokenizer = NLTokenizer(unit: .sentence)
         tokenizer.string = text
-        // swiftlint:disable:next prefer_let_over_var
-        var sentences: [String] = []
+        var sentences = [String]()
         tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) { range, _ in
             let sentence = String(text[range]).trimmingCharacters(in: .whitespacesAndNewlines)
             if !sentence.isEmpty { sentences.append(sentence) }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/AssetArchiver.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/AssetArchiver.swift
@@ -333,8 +333,7 @@ enum AssetArchiver {
                     await fetchAndSaveOne(url: url, baseURL: baseURL, archiveDir: archiveDir, session: session)
                 }
             }
-            // swiftlint:disable:next prefer_let_over_var
-            var results: [ArchivedAsset] = []
+            var results = [ArchivedAsset]()
             for await asset in group {
                 if let asset { results.append(asset) }
             }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/CachedImageView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/CachedImageView.swift
@@ -104,14 +104,12 @@ final class ImageLoader: @unchecked Sendable {
         guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions as CFDictionary) else {
             return nil
         }
-        // swiftlint:disable collection_alignment
-        let thumbnailOptions: [CFString: Any] = [
-            kCGImageSourceCreateThumbnailFromImageAlways: true,
-            kCGImageSourceShouldCacheImmediately: true,
-            kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
-        ]
-        // swiftlint:enable collection_alignment
+        var opts = [CFString: Any]()
+        opts[kCGImageSourceCreateThumbnailFromImageAlways] = true
+        opts[kCGImageSourceShouldCacheImmediately] = true
+        opts[kCGImageSourceCreateThumbnailWithTransform] = true
+        opts[kCGImageSourceThumbnailMaxPixelSize] = maxPixelSize
+        let thumbnailOptions = opts
         return CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions as CFDictionary)
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Support/HTMLBlockParser.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/HTMLBlockParser.swift
@@ -2,11 +2,9 @@ import Foundation
 import SwiftSoup
 
 struct ParsedBlocks {
-    // swiftlint:disable prefer_let_over_var
-    var blocks: [ReaderBlock]
-    var media: [MediaDescriptor]
-    var embeds: [EmbedDescriptor]
-    // swiftlint:enable prefer_let_over_var
+    var blocks = [ReaderBlock]()
+    var media = [MediaDescriptor]()
+    var embeds = [EmbedDescriptor]()
 }
 
 func parseBlocks(root: Element, baseURL: URL) throws -> ParsedBlocks {
@@ -30,11 +28,9 @@ func parseBlocks(root: Element, baseURL: URL) throws -> ParsedBlocks {
     let headingAnchors = try body.select("h1 > a[href^=#], h2 > a[href^=#], h3 > a[href^=#], h4 > a[href^=#], h5 > a[href^=#], h6 > a[href^=#]")
     try headingAnchors.remove()
 
-    // swiftlint:disable prefer_let_over_var
-    var blocks: [ReaderBlock] = []
-    var media: [MediaDescriptor] = []
-    var embeds: [EmbedDescriptor] = []
-    // swiftlint:enable prefer_let_over_var
+    var blocks = [ReaderBlock]()
+    var media = [MediaDescriptor]()
+    var embeds = [EmbedDescriptor]()
 
     for childNode in body.getChildNodes() {
         guard let child = childNode as? Element else { continue }
@@ -72,11 +68,9 @@ func parseBlock(_ element: Element) throws -> ParsedBlocks {
 
     case "p":
         let inlines = try parseInlines(element)
-        // swiftlint:disable prefer_let_over_var
         var blocks: [ReaderBlock] = inlines.isEmpty ? [] : [.paragraph(inlines)]
-        var media: [MediaDescriptor] = []
-        var embeds: [EmbedDescriptor] = []
-        // swiftlint:enable prefer_let_over_var
+        var media = [MediaDescriptor]()
+        var embeds = [EmbedDescriptor]()
 
         let mediaNodes = try element.select("img,picture,video,iframe,figure").array()
         for mediaNode in mediaNodes {
@@ -195,8 +189,7 @@ func parseInlines(_ element: Element) throws -> [ReaderInline] {
 /// leading space on `<span> until the user...</span>` when the span
 /// follows an `<a>` in the same paragraph).
 func parseInlinesRaw(_ element: Element) throws -> [ReaderInline] {
-    // swiftlint:disable:next prefer_let_over_var
-    var inlines: [ReaderInline] = []
+    var inlines = [ReaderInline]()
 
     for node in element.getChildNodes() {
         if let textNode = node as? TextNode {
@@ -276,8 +269,7 @@ func parseInlinesRaw(_ element: Element) throws -> [ReaderInline] {
 }
 
 func mergeTextInlines(_ inlines: [ReaderInline]) -> [ReaderInline] {
-    // swiftlint:disable:next prefer_let_over_var
-    var merged: [ReaderInline] = []
+    var merged = [ReaderInline]()
     for inline in inlines {
         if case .text(let current) = inline,
            case .text(let previous)? = merged.last {
@@ -364,11 +356,9 @@ func trimInlineEdges(_ inlines: [ReaderInline]) -> [ReaderInline] {
 }
 
 func parseFallbackDescendants(_ body: Element) throws -> ParsedBlocks {
-    // swiftlint:disable prefer_let_over_var
-    var blocks: [ReaderBlock] = []
-    var media: [MediaDescriptor] = []
-    var embeds: [EmbedDescriptor] = []
-    // swiftlint:enable prefer_let_over_var
+    var blocks = [ReaderBlock]()
+    var media = [MediaDescriptor]()
+    var embeds = [EmbedDescriptor]()
 
     let candidates = try body.select("h1,h2,h3,h4,h5,h6,p,blockquote,pre,ul,ol,img,video,iframe,figure").array()
     for element in candidates {

--- a/StowerPackage/Sources/StowerFeatureV2/Support/HTMLSanitizer.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/HTMLSanitizer.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 func sanitizeBlocks(_ input: [ReaderBlock]) -> [ReaderBlock] {
-    // swiftlint:disable:next prefer_let_over_var
-    var output: [ReaderBlock] = []
+    var output = [ReaderBlock]()
 
     for block in input {
         if shouldAlwaysKeepBlock(block) {
@@ -97,8 +96,7 @@ func isLikelyBoilerplateText(_ rawText: String) -> Bool {
 
 func dedupeBlocks(_ input: [ReaderBlock]) -> [ReaderBlock] {
     var seen: Set<String> = []
-    // swiftlint:disable:next prefer_let_over_var
-    var output: [ReaderBlock] = []
+    var output = [ReaderBlock]()
     for block in input {
         let fingerprint = String(describing: block)
         if seen.contains(fingerprint) { continue }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/HTMLUtilities.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/HTMLUtilities.swift
@@ -55,25 +55,9 @@ func plainTextFromBlocks(_ blocks: [ReaderBlock]) -> String {
 }
 
 func inlineText(_ inlines: [ReaderInline]) -> String {
-    inlines.map {
-        switch $0 {
-        case .text(let value):
-            return value
-        case .link(let label, _):
-            return label
-        case .emphasis(let value):
-            return value
-        case .strong(let value):
-            return value
-        case .code(let value):
-            return value
-        case .strikethrough(let value):
-            return value
-        }
-    }
-    .joined(separator: " ")
-    .replacingOccurrences(of: "[\\t ]+", with: " ", options: .regularExpression)
-    .trimmingCharacters(in: .whitespacesAndNewlines)
+    ReaderTextLayoutSupport.inlinePlainText(from: inlines)
+        .replacingOccurrences(of: "[\\t ]+", with: " ", options: .regularExpression)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
 }
 
 func confidenceScore(blockCount: Int, textLength: Int) -> Double {

--- a/StowerPackage/Sources/StowerFeatureV2/Support/HTMLUtilities.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/HTMLUtilities.swift
@@ -18,8 +18,7 @@ func extractTitle(document: Document, sourceURL: URL) throws -> String {
 }
 
 func plainTextFromBlocks(_ blocks: [ReaderBlock]) -> String {
-    // swiftlint:disable:next prefer_let_over_var
-    var parts: [String] = []
+    var parts = [String]()
     for block in blocks {
         switch block {
         case .paragraph(let inlines):

--- a/StowerPackage/Sources/StowerFeatureV2/Support/LocalArchiveServer.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/LocalArchiveServer.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Network
+import OSLog
 
 /// A lightweight local HTTP server that serves archived web content from disk.
 ///
@@ -17,6 +18,11 @@ import Network
 /// chunk names. To fill those gaps, the server falls back to live-fetching missing
 /// assets from `originURL` on the first request and writing them to disk, so the
 /// archive self-heals as the user interacts with the page.
+private let kArchiveServerLog = Logger(
+    subsystem: "com.ryanleewilliams.stower",
+    category: "ArchiveServer"
+)
+
 final class LocalArchiveServer: @unchecked Sendable {
     private var listener: NWListener?
     private let archiveDir: URL
@@ -208,11 +214,9 @@ final class LocalArchiveServer: @unchecked Sendable {
         fileURL: URL
     ) {
         if fileURL.lastPathComponent.hasPrefix(PDFArchiver.pageImagePrefix) {
-            // swiftlint:disable:next no_print_statements
-            print("[ArchiveServer] 404 PDF page image: \(path) — file missing at \(fileURL.path). Check ingestion fsync and on-disk verification.")
+            kArchiveServerLog.warning("404 PDF page image: \(path, privacy: .public) — file missing at \(fileURL.path, privacy: .public). Check ingestion fsync and on-disk verification.")
         } else {
-            // swiftlint:disable:next no_print_statements
-            print("[ArchiveServer] 404: \(path) → \(fileURL.path)")
+            kArchiveServerLog.info("404: \(path, privacy: .public) → \(fileURL.path, privacy: .public)")
         }
         let response = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
         connection.send(
@@ -265,8 +269,7 @@ final class LocalArchiveServer: @unchecked Sendable {
                 withIntermediateDirectories: true
             )
             try? data.write(to: destination)
-            // swiftlint:disable:next no_print_statements
-            print("[ArchiveServer] fetched-through: \(path)")
+            kArchiveServerLog.info("Fetched-through: \(path, privacy: .public)")
             return data
         } catch {
             return nil

--- a/StowerPackage/Sources/StowerFeatureV2/Support/PDFIngestionClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/PDFIngestionClient.swift
@@ -28,8 +28,7 @@ public enum PDFIngestionError: Error, LocalizedError {
         case .unreadable:
             return "The PDF couldn't be opened. It may be corrupted or not a valid PDF."
         case .passwordProtected:
-            // swiftlint:disable:next no_sensitive_logging
-            return "This PDF is password-protected. Open it in another app to remove the password, then re-share it."
+            return "This PDF is locked. Open it in another app to unlock it, then re-share it."
         case .emptyDocument:
             return "The PDF contains no pages."
         }
@@ -125,10 +124,8 @@ private func pdfIngest(url: URL) async throws -> IngestionResult {
         "Ingesting PDF \"\(title, privacy: .public)\" (\(pdf.pageCount, privacy: .public) pages, sha=\(hexHash, privacy: .public))"
     )
 
-    // swiftlint:disable:next prefer_let_over_var
-    var blocks: [ReaderBlock] = []
-    // swiftlint:disable:next prefer_let_over_var
-    var plainTextChunks: [String] = []
+    var blocks = [ReaderBlock]()
+    var plainTextChunks = [String]()
     var sawOCRFallback = false
 
     for pageIndex in 0..<pdf.pageCount {
@@ -213,11 +210,11 @@ private func pdfIngest(url: URL) async throws -> IngestionResult {
     _ = sawOCRFallback
 
     let document = ReaderDocument(
+        title: title,
+        blocks: blocks,
         version: 1,
         sourceURL: nil,
-        canonicalURL: canonicalURL,
-        title: title,
-        blocks: blocks
+        canonicalURL: canonicalURL
     )
 
     let media = blocks.compactMap { block -> MediaDescriptor? in

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ReaderSpeechClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ReaderSpeechClient.swift
@@ -104,8 +104,7 @@ private final class LiveReaderSpeechSynthDriver: NSObject {
         let blockIndex: Int
         let sequence: Int
     }
-    // swiftlint:disable:next prefer_let_over_var
-    private var utteranceToPosition: [ObjectIdentifier: UtterancePosition] = [:]
+    private var utteranceToPosition = [ObjectIdentifier: UtterancePosition]()
     private var isCancelled = false
 
     override init() {

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ReaderSpeechTextBuilder.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ReaderSpeechTextBuilder.swift
@@ -39,8 +39,7 @@ public struct SpeechBlock: Equatable, Sendable {
 
 enum ReaderSpeechTextBuilder {
     static func speechBlocks(document: ReaderDocument) -> [SpeechBlock] {
-        // swiftlint:disable:next prefer_let_over_var
-        var output: [SpeechBlock] = []
+        var output = [SpeechBlock]()
         output.reserveCapacity(document.blocks.count)
 
         for (index, block) in document.blocks.enumerated() {
@@ -147,8 +146,7 @@ enum ReaderSpeechTextBuilder {
     /// getting block-level output, so summarization, retrieval, and
     /// position saving are unaffected.
     static func sentenceSplit(_ blocks: [SpeechBlock]) -> [SpeechBlock] {
-        // swiftlint:disable:next prefer_let_over_var
-        var output: [SpeechBlock] = []
+        var output = [SpeechBlock]()
         output.reserveCapacity(blocks.count * 3)
         var sequence = 0
 
@@ -193,8 +191,7 @@ enum ReaderSpeechTextBuilder {
 
         let tokenizer = NLTokenizer(unit: .sentence)
         tokenizer.string = trimmed
-        // swiftlint:disable:next prefer_let_over_var
-        var sentences: [String] = []
+        var sentences = [String]()
         tokenizer.enumerateTokens(in: trimmed.startIndex..<trimmed.endIndex) { range, _ in
             let sentence = String(trimmed[range]).trimmingCharacters(in: .whitespacesAndNewlines)
             if !sentence.isEmpty {

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ReaderSpeechVoiceCatalog.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ReaderSpeechVoiceCatalog.swift
@@ -32,10 +32,8 @@ enum ReaderSpeechVoiceCatalog {
 
         let groupsByLanguage = Dictionary(grouping: AVSpeechSynthesisVoice.speechVoices(), by: \.language)
 
-        // swiftlint:disable prefer_let_over_var
-        var preferred: [LanguageGroup] = []
-        var other: [LanguageGroup] = []
-        // swiftlint:enable prefer_let_over_var
+        var preferred = [LanguageGroup]()
+        var other = [LanguageGroup]()
 
         for (language, voices) in groupsByLanguage {
             let entries = voices
@@ -109,19 +107,15 @@ enum ReaderSpeechVoiceCatalog {
     // MARK: - Helpers
 
     private static func preferredLanguagePrefixes() -> [String] {
-        var seen = Set<String>()
-        // swiftlint:disable:next prefer_let_over_var
-        var result: [String] = []
         let sources = Locale.preferredLanguages.isEmpty
             ? [Locale.current.identifier]
             : Locale.preferredLanguages
-        for source in sources {
+        var seen = Set<String>()
+        return sources.compactMap { source -> String? in
             let prefix = String(source.prefix(2)).lowercased()
-            if !prefix.isEmpty, seen.insert(prefix).inserted {
-                result.append(prefix)
-            }
+            guard !prefix.isEmpty, seen.insert(prefix).inserted else { return nil }
+            return prefix
         }
-        return result
     }
 
     private static func displayName(for voice: AVSpeechSynthesisVoice) -> String {

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ReaderTextLayoutSupport.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ReaderTextLayoutSupport.swift
@@ -35,10 +35,8 @@ enum ReaderTextLayoutSupport {
     }
 
     static func listSpeechTextAndRanges(items: [[ReaderInline]]) -> (text: String, itemRanges: [NSRange]) {
-        // swiftlint:disable prefer_let_over_var
-        var itemRanges: [NSRange] = []
-        var pieces: [String] = []
-        // swiftlint:enable prefer_let_over_var
+        var itemRanges = [NSRange]()
+        var pieces = [String]()
         pieces.reserveCapacity(items.count)
 
         var cursorUTF16 = 0

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ReaderTextLayoutSupport.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ReaderTextLayoutSupport.swift
@@ -87,6 +87,8 @@ enum ReaderTextLayoutSupport {
         switch inline {
         case .text(let value):
             return AttributedString(value)
+        case .lineBreak:
+            return AttributedString("\n")
         case let .link(label, url):
             var link = AttributedString(label)
             link.link = URL(string: url)

--- a/StowerPackage/Sources/StowerFeatureV2/Support/TextAuthoringSheet.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/TextAuthoringSheet.swift
@@ -35,11 +35,10 @@ enum TextAuthoringPreviewSupport {
         }
 
         let item = SavedItem(
-            id: UUID(),
             title: result.title,
+            content: result.plainText,
             renderFormat: result.renderFormat,
-            documentVersion: result.document.version,
-            content: result.plainText
+            documentVersion: result.document.version
         )
         return ReaderDocumentHTMLBuilder.buildReaderHTML(
             item: item,
@@ -70,18 +69,17 @@ public struct TextAuthoringSheet: View {
     @State private var activePane: TextAuthoringPane = .write
     @State private var previewItemID = UUID()
 
-    // swiftlint:disable:next function_default_parameter_at_end
     public init(
         title: Binding<String>,
         text: Binding<String>,
         mode: Binding<TextImportMode>,
         palette: FlexokiPalette,
-        appearance: ReaderAppearanceSettings = .init(),
         errorMessage: String?,
         isSaving: Bool,
         navigationTitle: String,
         onCancel: @escaping () -> Void,
-        onSave: @escaping () -> Void
+        onSave: @escaping () -> Void,
+        appearance: ReaderAppearanceSettings = .init()
     ) {
         self._title = title
         self._text = text

--- a/StowerPackage/Sources/StowerFeatureV2/Support/TextAuthoringSheet.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/TextAuthoringSheet.swift
@@ -1,0 +1,223 @@
+import StowerData
+import SwiftUI
+
+enum TextAuthoringPreviewSupport {
+    enum Kind: Equatable {
+        case plainText
+        case markdown
+    }
+
+    static func kind(for text: String, mode: TextImportMode) -> Kind {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedMode = TextImportDetector.inferredMode(for: trimmed, preferred: mode)
+        return resolvedMode == .markdown ? .markdown : .plainText
+    }
+
+    static func previewHTML(
+        text: String,
+        title: String,
+        mode: TextImportMode,
+        appearance: ReaderAppearanceSettings = .init()
+    ) -> String {
+        let result: IngestionResult
+        switch kind(for: text, mode: mode) {
+        case .markdown:
+            result = markdownIngestionResult(
+                markdown: text,
+                explicitTitle: title.isEmpty ? nil : title,
+                titleHint: nil
+            )
+        case .plainText:
+            result = IngestionResult.sharedText(
+                text,
+                explicitTitle: title.isEmpty ? nil : title
+            )
+        }
+
+        let item = SavedItem(
+            id: UUID(),
+            title: result.title,
+            renderFormat: result.renderFormat,
+            documentVersion: result.document.version,
+            content: result.plainText
+        )
+        return ReaderDocumentHTMLBuilder.buildReaderHTML(
+            item: item,
+            document: result.document,
+            appearance: appearance
+        )
+    }
+}
+
+private enum TextAuthoringPane: String, CaseIterable, Identifiable {
+    case write = "Write"
+    case preview = "Preview"
+
+    var id: String { rawValue }
+}
+
+public struct TextAuthoringSheet: View {
+    @Binding var title: String
+    @Binding var text: String
+    @Binding var mode: TextImportMode
+    let palette: FlexokiPalette
+    let appearance: ReaderAppearanceSettings
+    let errorMessage: String?
+    let isSaving: Bool
+    let navigationTitle: String
+    let onCancel: () -> Void
+    let onSave: () -> Void
+    @State private var activePane: TextAuthoringPane = .write
+    @State private var previewItemID = UUID()
+
+    public init(
+        title: Binding<String>,
+        text: Binding<String>,
+        mode: Binding<TextImportMode>,
+        palette: FlexokiPalette,
+        appearance: ReaderAppearanceSettings = .init(),
+        errorMessage: String?,
+        isSaving: Bool,
+        navigationTitle: String,
+        onCancel: @escaping () -> Void,
+        onSave: @escaping () -> Void
+    ) {
+        self._title = title
+        self._text = text
+        self._mode = mode
+        self.palette = palette
+        self.appearance = appearance
+        self.errorMessage = errorMessage
+        self.isSaving = isSaving
+        self.navigationTitle = navigationTitle
+        self.onCancel = onCancel
+        self.onSave = onSave
+    }
+
+    private var previewKind: TextAuthoringPreviewSupport.Kind {
+        TextAuthoringPreviewSupport.kind(for: text, mode: mode)
+    }
+
+    private var previewHTML: String {
+        TextAuthoringPreviewSupport.previewHTML(
+            text: text,
+            title: title,
+            mode: mode,
+            appearance: appearance
+        )
+    }
+
+    private var previewContentVersion: Int {
+        var hasher = Hasher()
+        hasher.combine(text)
+        hasher.combine(title)
+        hasher.combine(mode.rawValue)
+        return hasher.finalize()
+    }
+
+    public var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                TextField("Title", text: $title)
+                    .textFieldStyle(.roundedBorder)
+
+                VStack(spacing: 12) {
+                    Picker("Format", selection: $mode) {
+                        Text("Auto").tag(TextImportMode.auto)
+                        Text("Plain Text").tag(TextImportMode.plainText)
+                        Text("Markdown").tag(TextImportMode.markdown)
+                    }
+                    .pickerStyle(.segmented)
+
+                    Picker("Pane", selection: $activePane) {
+                        ForEach(TextAuthoringPane.allCases) { pane in
+                            Text(pane.rawValue).tag(pane)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Group {
+                    switch activePane {
+                    case .write:
+                        editor
+                    case .preview:
+                        preview
+                    }
+                }
+                .frame(maxWidth: .infinity, minHeight: 280, maxHeight: .infinity)
+
+                footer
+            }
+            .padding()
+            .navigationTitle(navigationTitle)
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #else
+            .frame(minWidth: 640, idealWidth: 720, maxWidth: 900, minHeight: 460, idealHeight: 560)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", action: onCancel)
+                        .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isSaving {
+                        ProgressView()
+                    } else {
+                        Button("Save", action: onSave)
+                            .disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            }
+        }
+    }
+
+    private var editor: some View {
+        TextEditor(text: $text)
+            .font(mode == .markdown ? .body.monospaced() : .body)
+            .padding(12)
+            .glassEffect(.regular, in: .rect(cornerRadius: 12))
+    }
+
+    private var preview: some View {
+        Group {
+            if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Text("Nothing to preview yet.")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .padding(18)
+                    .background(palette.ui.opacity(0.28), in: .rect(cornerRadius: 12))
+            } else {
+                ReaderWebView(
+                    html: { previewHTML },
+                    sourceURL: nil,
+                    itemID: previewItemID,
+                    contentVersion: previewContentVersion,
+                    appearance: .init(),
+                    isWebViewFormat: false
+                )
+                .clipShape(.rect(cornerRadius: 12))
+            }
+        }
+    }
+
+    @ViewBuilder private var footer: some View {
+        if let errorMessage {
+            Text(errorMessage)
+                .font(.caption)
+                .foregroundStyle(palette.error)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else if previewKind == .markdown {
+            Text("Write in markdown, then switch to Preview to inspect the rendered formatting without losing the source.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            Text("Write plain text or markdown. Auto mode detects markdown-like syntax for imported text.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}

--- a/StowerPackage/Sources/StowerFeatureV2/Support/TextAuthoringSheet.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/TextAuthoringSheet.swift
@@ -70,6 +70,7 @@ public struct TextAuthoringSheet: View {
     @State private var activePane: TextAuthoringPane = .write
     @State private var previewItemID = UUID()
 
+    // swiftlint:disable:next function_default_parameter_at_end
     public init(
         title: Binding<String>,
         text: Binding<String>,

--- a/StowerPackage/Sources/StowerFeatureV2/Support/TextIngestionClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/TextIngestionClient.swift
@@ -4,53 +4,93 @@ import Markdown
 import StowerData
 
 public struct TextIngestionClient: Sendable {
-    public var ingest: @Sendable (_ text: String, _ titleHint: String?, _ mode: TextImportMode) async throws -> IngestionResult
+    public var ingest: @Sendable (_ text: String, _ explicitTitle: String?, _ titleHint: String?, _ mode: TextImportMode) async throws -> IngestionResult
 
     public init(
-        ingest: @escaping @Sendable (_ text: String, _ titleHint: String?, _ mode: TextImportMode) async throws -> IngestionResult
+        ingest: @escaping @Sendable (_ text: String, _ explicitTitle: String?, _ titleHint: String?, _ mode: TextImportMode) async throws -> IngestionResult
     ) {
         self.ingest = ingest
     }
 
-    public static let live = TextIngestionClient { text, titleHint, mode in
+    public static let live = TextIngestionClient { text, explicitTitle, titleHint, mode in
+        let rawSourceText = text
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         let resolvedMode = TextImportDetector.inferredMode(for: trimmed, preferred: mode)
         switch resolvedMode {
         case .plainText:
-            return IngestionResult.sharedText(trimmed, title: titleHint)
+            return IngestionResult.sharedText(
+                text,
+                explicitTitle: explicitTitle,
+                titleHint: titleHint,
+                rawSourceText: rawSourceText,
+                rawSourceMode: mode
+            )
         case .markdown:
-            return (try? await MarkdownIngestionClient.live.ingest(trimmed, titleHint)) ?? IngestionResult.sharedText(trimmed, title: titleHint)
+            var result = (try? await MarkdownIngestionClient.live.ingest(text, explicitTitle, titleHint))
+                ?? IngestionResult.sharedText(
+                    text,
+                    explicitTitle: explicitTitle,
+                    titleHint: titleHint,
+                    rawSourceText: rawSourceText,
+                    rawSourceMode: mode
+                )
+            result.rawSourceText = rawSourceText
+            result.rawSourceMode = mode
+            return result
         case .auto:
-            return IngestionResult.sharedText(trimmed, title: titleHint)
+            return IngestionResult.sharedText(
+                text,
+                explicitTitle: explicitTitle,
+                titleHint: titleHint,
+                rawSourceText: rawSourceText,
+                rawSourceMode: mode
+            )
         }
     }
 }
 
 public struct MarkdownIngestionClient: Sendable {
-    public var ingest: @Sendable (_ markdown: String, _ titleHint: String?) async throws -> IngestionResult
+    public var ingest: @Sendable (_ markdown: String, _ explicitTitle: String?, _ titleHint: String?) async throws -> IngestionResult
 
     public init(
-        ingest: @escaping @Sendable (_ markdown: String, _ titleHint: String?) async throws -> IngestionResult
+        ingest: @escaping @Sendable (_ markdown: String, _ explicitTitle: String?, _ titleHint: String?) async throws -> IngestionResult
     ) {
         self.ingest = ingest
     }
 
-    public static let live = MarkdownIngestionClient { markdown, titleHint in
-        let blocks = MarkdownBlockParser.parse(markdown)
-        let title = resolvedTextImportTitle(
-            documentTitle: MarkdownBlockParser.firstHeadingTitle(in: blocks),
+    public static let live = MarkdownIngestionClient { markdown, explicitTitle, titleHint in
+        markdownIngestionResult(
+            markdown: markdown,
+            explicitTitle: explicitTitle,
             titleHint: titleHint
         )
-        let plainText = markdownPlainText(from: blocks)
-        guard !blocks.isEmpty else {
-            return IngestionResult.sharedText(markdown, title: titleHint)
-        }
-        return IngestionResult.structuredText(
-            title: title,
-            blocks: blocks,
-            plainText: plainText
+    }
+}
+
+func markdownIngestionResult(
+    markdown: String,
+    explicitTitle: String?,
+    titleHint: String?
+) -> IngestionResult {
+    let blocks = MarkdownBlockParser.parse(markdown)
+    let title = resolvedTextImportTitle(
+        explicitTitle: explicitTitle,
+        documentTitle: MarkdownBlockParser.firstHeadingTitle(in: blocks),
+        titleHint: titleHint
+    )
+    let plainText = markdownPlainText(from: blocks)
+    guard !blocks.isEmpty else {
+        return IngestionResult.sharedText(
+            markdown,
+            explicitTitle: explicitTitle,
+            titleHint: titleHint
         )
     }
+    return IngestionResult.structuredText(
+        title: title,
+        blocks: blocks,
+        plainText: plainText
+    )
 }
 
 private func markdownPlainText(from blocks: [ReaderBlock]) -> String {
@@ -238,13 +278,13 @@ private enum MarkdownBlockParser {
         while cursor < lines.count {
             let trimmed = lines[cursor].trimmingCharacters(in: .whitespaces)
             guard trimmed.hasPrefix(">") else { break }
-            let content = trimmed.dropFirst().trimmingCharacters(in: .whitespaces)
+            let content = trimLeadingWhitespace(String(trimmed.dropFirst()))
             if !content.isEmpty {
                 parts.append(content)
             }
             cursor += 1
         }
-        return (.blockquote(MarkdownInlineParser.parse(parts.joined(separator: " "))), cursor)
+        return (.blockquote(MarkdownInlineParser.parse(parts.joined(separator: "\n"))), cursor)
     }
 
     private static func parseList(_ lines: [String], index: Int) -> (block: ReaderBlock, nextIndex: Int)? {
@@ -268,7 +308,7 @@ private enum MarkdownBlockParser {
 
             let indentation = line.prefix { $0 == " " || $0 == "\t" }.count
             if indentation >= 2, !items.isEmpty {
-                let continuation = line.trimmingCharacters(in: .whitespaces)
+                let continuation = trimLeadingWhitespace(line)
                 if !continuation.isEmpty {
                     items[items.count - 1].append(continuation)
                 }
@@ -278,7 +318,7 @@ private enum MarkdownBlockParser {
             break
         }
 
-        let parsedItems = items.map { MarkdownInlineParser.parse($0.joined(separator: " ")) }
+        let parsedItems = items.map { MarkdownInlineParser.parse($0.joined(separator: "\n")) }
         return (.list(ordered: firstMarker.ordered, items: parsedItems), cursor)
     }
 
@@ -297,10 +337,10 @@ private enum MarkdownBlockParser {
                     break
                 }
             }
-            parts.append(line.trimmingCharacters(in: .whitespaces))
+            parts.append(trimLeadingWhitespace(line))
             cursor += 1
         }
-        return (.paragraph(MarkdownInlineParser.parse(parts.joined(separator: " "))), cursor)
+        return (.paragraph(MarkdownInlineParser.parse(parts.joined(separator: "\n"))), cursor)
     }
 
     private static func listMatch(in line: String) -> (ordered: Bool, content: String)? {
@@ -316,20 +356,41 @@ private enum MarkdownBlockParser {
         }
         return nil
     }
+
+    private static func trimLeadingWhitespace(_ line: String) -> String {
+        line.replacingOccurrences(of: #"^\s+"#, with: "", options: .regularExpression)
+    }
 }
 
 private enum MarkdownInlineParser {
     static func parse(_ markdown: String) -> [ReaderInline] {
-        let document = Document(parsing: markdown)
-        return collectInlines(from: document)
+        let normalized = markdown.replacingOccurrences(of: "\r\n", with: "\n")
+        let components = splitPreservingHardBreaks(in: normalized)
+
+        var output = [ReaderInline]()
+        for component in components {
+            switch component {
+            case .segment(let text):
+                guard !text.isEmpty else { continue }
+                let document = Document(parsing: text)
+                output.append(contentsOf: collectInlines(from: document))
+            case .lineBreak:
+                output.append(.lineBreak)
+            }
+        }
+
+        return mergeText(output)
     }
 
     private static func collectInlines(from markup: any Markup) -> [ReaderInline] {
         if let text = markup as? Text {
             return [.text(text.string)]
         }
-        if markup is SoftBreak || markup is LineBreak {
+        if markup is SoftBreak {
             return [.text(" ")]
+        }
+        if markup is LineBreak {
+            return [.lineBreak]
         }
         if let inlineCode = markup as? InlineCode {
             return [.code(inlineCode.code)]
@@ -352,6 +413,53 @@ private enum MarkdownInlineParser {
             output.append(contentsOf: collectInlines(from: child))
         }
         return mergeText(output)
+    }
+
+    private static func splitPreservingHardBreaks(in markdown: String) -> [InlineComponent] {
+        let lines = markdown.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        guard !lines.isEmpty else { return [.segment("")] }
+
+        var components = [InlineComponent]()
+        var currentSegment = ""
+
+        for index in lines.indices {
+            let line = lines[index]
+            let isLastLine = index == lines.index(before: lines.endIndex)
+            let (segmentLine, hasHardBreak) = consumeHardBreakMarker(from: line)
+            currentSegment += segmentLine
+
+            if isLastLine {
+                if !currentSegment.isEmpty {
+                    components.append(.segment(currentSegment))
+                }
+                continue
+            }
+
+            if hasHardBreak {
+                if !currentSegment.isEmpty {
+                    components.append(.segment(currentSegment))
+                }
+                components.append(.lineBreak)
+                currentSegment = ""
+            } else {
+                currentSegment += "\n"
+            }
+        }
+
+        return components.isEmpty ? [.segment("")] : components
+    }
+
+    private static func consumeHardBreakMarker(from line: String) -> (text: String, hasHardBreak: Bool) {
+        if line.hasSuffix("\\") {
+            return (String(line.dropLast()), true)
+        }
+
+        let trailingSpaces = line.reversed().prefix { $0 == " " }.count
+        if trailingSpaces >= 2 {
+            return (String(line.dropLast(trailingSpaces)), true)
+        }
+
+        return (line, false)
     }
 
     private static func plainText(from markup: any Markup) -> String {
@@ -383,5 +491,10 @@ private enum MarkdownInlineParser {
             }
         }
         return output
+    }
+
+    private enum InlineComponent {
+        case segment(String)
+        case lineBreak
     }
 }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/URLIngestionClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/URLIngestionClient.swift
@@ -126,11 +126,11 @@ public struct ExtractionPipelineClient: Sendable {
         }
 
         let readerDocument = ReaderDocument(
+            title: title,
+            blocks: finalBlocks,
             version: 1,
             sourceURL: sourceURL.absoluteString,
-            canonicalURL: canonicalURL,
-            title: title,
-            blocks: finalBlocks
+            canonicalURL: canonicalURL
         )
 
         return IngestionResult(
@@ -201,8 +201,7 @@ public struct MediaResolutionClient: Sendable {
                 }
             }
 
-            // swiftlint:disable:next prefer_let_over_var
-            var results: [(Int, MediaDescriptor)] = []
+            var results = [(Int, MediaDescriptor)]()
             for await result in group {
                 results.append(result)
             }
@@ -418,11 +417,8 @@ func detectInteractiveContent(document: Document) -> Bool {
     // or <foreignObject>. Child-count alone is a bad heuristic because
     // icon SVGs commonly have dozens of <path> children.
     let svgs = (try? document.select("svg").array()) ?? []
-    for svg in svgs {
-        // swiftlint:disable:next for_where
-        if (try? svg.select("script, animate, animateTransform, animateMotion, set, foreignObject").first()) != nil {
-            return true
-        }
+    for svg in svgs where (try? svg.select("script, animate, animateTransform, animateMotion, set, foreignObject").first()) != nil {
+        return true
     }
 
     // Scripts that reference known data-visualization libraries. Restrict to

--- a/StowerPackage/Sources/StowerFeatureV2/Support/YouTubeIngestionClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/YouTubeIngestionClient.swift
@@ -77,16 +77,14 @@ public struct YouTubeIngestionClient: Sendable {
 
             // 5. Compose the ReaderDocument: video card, then description
             //    paragraphs.
-            // swiftlint:disable:next prefer_let_over_var
-            var blocks: [ReaderBlock] = [.video(media: descriptor)]
-            blocks.append(contentsOf: descriptionBlocks(description))
+            let blocks: [ReaderBlock] = [.video(media: descriptor)] + descriptionBlocks(description)
 
             let document = ReaderDocument(
+                title: metadata.title,
+                blocks: blocks,
                 version: 1,
                 sourceURL: originalURL.absoluteString,
-                canonicalURL: canonicalWatchURL,
-                title: metadata.title,
-                blocks: blocks
+                canonicalURL: canonicalWatchURL
             )
 
             let plainText: String

--- a/StowerPackage/Tests/StowerFeatureV2Tests/AppFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/AppFeatureTests.swift
@@ -47,7 +47,7 @@ struct AppFeatureTests {
 
     @Test
     func startupLoadsLibraryAndSettings() async {
-        let item = SavedItem(id: UUID(), title: "One", content: "Body")
+        let item = SavedItem(title: "One", content: "Body")
         let settings = ImageDownloadSettings(globalAutoDownload: true, askForNewSources: false)
         let appearance = ReaderAppearanceSettings(background: .sepia)
 
@@ -113,7 +113,7 @@ struct AppFeatureTests {
             }
             $0.stowerRepository.createItemFromIngestion = { result in
                 created.withValue { $0.append(result) }
-                return SavedItem(title: result.title, renderFormat: result.renderFormat, content: result.plainText)
+                return SavedItem(title: result.title, content: result.plainText, renderFormat: result.renderFormat)
             }
             $0.stowerRepository.markIngestionJobProcessed = { _ in }
             $0.stowerRepository.fetchLibrary = { _ in [] }
@@ -163,7 +163,7 @@ struct AppFeatureTests {
             }
             $0.stowerRepository.createItemFromIngestion = { result in
                 created.withValue { $0.append(result) }
-                return SavedItem(title: result.title, renderFormat: result.renderFormat, content: result.plainText)
+                return SavedItem(title: result.title, content: result.plainText, renderFormat: result.renderFormat)
             }
             $0.stowerRepository.markIngestionJobProcessed = { _ in }
             $0.stowerRepository.fetchLibrary = { _ in [] }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ArchiveServerFetchThroughTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ArchiveServerFetchThroughTests.swift
@@ -140,7 +140,7 @@ final class StubProtocol: URLProtocol {
     }
 
     private static let lock = NSLock()
-    nonisolated(unsafe) private static var registry: [String: StubbedResponse] = [:] // swiftlint:disable:this prefer_let_over_var
+    nonisolated(unsafe) private static var registry = [String: StubbedResponse]()
 
     static func reset() {
         lock.lock()

--- a/StowerPackage/Tests/StowerFeatureV2Tests/DatabaseTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/DatabaseTests.swift
@@ -32,6 +32,29 @@ struct DatabaseTests {
     }
 
     @Test
+    func editableTextSource_roundTripsRawSourceAndMode() async throws {
+        let database = try StowerDatabase.makeDatabase()
+        let repository = StowerRepository.live(database: database, cloudSyncClient: .noop)
+
+        let created = try await repository.createItemFromIngestion(
+            .sharedText(
+                "Line one\nLine two",
+                explicitTitle: "Manual Title",
+                rawSourceText: "Line one\nLine two",
+                rawSourceMode: .plainText
+            )
+        )
+
+        let editable = try await repository.loadEditableTextSource(created.id)
+        let unwrapped = try #require(editable)
+        #expect(unwrapped.title == "Manual Title")
+        #expect(unwrapped.text == "Line one\nLine two")
+        // The editor always loads .auto so the preview can auto-detect
+        // markdown vs plain text, regardless of the stored mode.
+        #expect(unwrapped.mode == .auto)
+    }
+
+    @Test
     func ingestionQueueRoundTrip() async throws {
         let database = try StowerDatabase.makeDatabase()
         let repository = StowerRepository.live(database: database, cloudSyncClient: .noop)
@@ -63,7 +86,7 @@ struct DatabaseTests {
         // Simulate what ReaderFeature.load does (user taps item)
         let loadedItem = try await repository.loadItem(libraryItem.id)
         let loadedDoc = try await repository.loadReaderDocument(libraryItem.id)
-        let loadedHTML = try await repository.loadSourceHTML(libraryItem.id)
+        _ = try await repository.loadSourceHTML(libraryItem.id)
 
         #expect(loadedItem != nil, "loadItem returned nil — this causes 'Item not found'")
         #expect(loadedItem?.id == created.id)

--- a/StowerPackage/Tests/StowerFeatureV2Tests/HTMLBlockParserTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/HTMLBlockParserTests.swift
@@ -26,6 +26,8 @@ struct HTMLBlockParserTests {
             switch inline {
             case .text(let value):
                 return value
+            case .lineBreak:
+                return "\n"
             case .link(let label, _):
                 return label
             case .emphasis(let value):
@@ -175,6 +177,8 @@ struct HTMLBlockParserTests {
                 switch inline {
                 case .text(let value):
                     return value
+                case .lineBreak:
+                    return "\n"
                 case .link(let label, _):
                     return label
                 case .emphasis(let value):
@@ -286,6 +290,8 @@ struct HTMLBlockParserTests {
                     switch inline {
                     case .text(let value):
                         return value
+                    case .lineBreak:
+                        return "\n"
                     case .link(let label, _):
                         return label
                     case .emphasis(let value):

--- a/StowerPackage/Tests/StowerFeatureV2Tests/HTMLBlockParserTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/HTMLBlockParserTests.swift
@@ -248,9 +248,9 @@ struct HTMLBlockParserTests {
         // exactly what WKWebView loads.
         let item = SavedItem(
             title: "Keeping Each Other Safe",
+            content: "",
             sourceURL: "https://example.com/mutual-aid",
-            renderFormat: .structuredV1,
-            content: ""
+            renderFormat: .structuredV1
         )
         let rendered = ReaderDocumentHTMLBuilder.buildReaderHTML(
             item: item,

--- a/StowerPackage/Tests/StowerFeatureV2Tests/LibraryFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/LibraryFeatureTests.swift
@@ -10,8 +10,8 @@ struct LibraryFeatureTests {
     @Test
     func reloadPopulatesItems() async {
         let expected = [
-            SavedItem(title: "Alpha", sourceURL: "https://a.com", content: "A"),
-            SavedItem(title: "Beta", sourceURL: "https://b.com", content: "B"),
+            SavedItem(title: "Alpha", content: "A", sourceURL: "https://a.com"),
+            SavedItem(title: "Beta", content: "B", sourceURL: "https://b.com"),
         ]
 
         let store = TestStore(initialState: LibraryFeature.State()) {
@@ -33,8 +33,8 @@ struct LibraryFeatureTests {
     func searchUsesLocalizedContains() {
         var state = LibraryFeature.State()
         state.items = [
-            SavedItem(title: "Swift Concurrency", sourceURL: nil, content: ""),
-            SavedItem(title: "Feed Reader", sourceURL: nil, content: ""),
+            SavedItem(title: "Swift Concurrency", content: ""),
+            SavedItem(title: "Feed Reader", content: ""),
         ]
         state.query = "swift"
 
@@ -151,7 +151,7 @@ struct LibraryFeatureTests {
         let item = SavedItem(title: "Untagged", content: "")
         var initial = LibraryFeature.State()
         initial.items = [item]
-        initial.availableTags = [Tag(id: tagID, name: "work")]
+        initial.availableTags = [Tag(name: "work", id: tagID)]
 
         let store = TestStore(initialState: initial) {
             LibraryFeature()
@@ -170,7 +170,7 @@ struct LibraryFeatureTests {
         let item = SavedItem(title: "Tagged", content: "", tagIDs: [tagID])
         var initial = LibraryFeature.State()
         initial.items = [item]
-        initial.availableTags = [Tag(id: tagID, name: "work")]
+        initial.availableTags = [Tag(name: "work", id: tagID)]
 
         let store = TestStore(initialState: initial) {
             LibraryFeature()
@@ -190,7 +190,7 @@ struct LibraryFeatureTests {
         var initial = LibraryFeature.State()
         initial.filter = .untagged
         initial.items = [item]
-        initial.availableTags = [Tag(id: tagID, name: "work")]
+        initial.availableTags = [Tag(name: "work", id: tagID)]
 
         let store = TestStore(initialState: initial) {
             LibraryFeature()
@@ -212,8 +212,8 @@ struct LibraryFeatureTests {
         initial.filter = .tag(tagID)
         initial.items = [item]
         initial.availableTags = [
-            Tag(id: tagID, name: "work"),
-            Tag(id: otherTag, name: "later"),
+            Tag(name: "work", id: tagID),
+            Tag(name: "later", id: otherTag),
         ]
 
         let store = TestStore(initialState: initial) {
@@ -315,7 +315,7 @@ struct LibraryFeatureTests {
 
     @Test
     func saveURLAddsHttpsWhenSchemeMissing() async {
-        let item = SavedItem(title: "Saved", sourceURL: "https://example.com/post", content: "Body")
+        let item = SavedItem(title: "Saved", content: "Body", sourceURL: "https://example.com/post")
 
         let store = TestStore(initialState: LibraryFeature.State()) {
             LibraryFeature()
@@ -345,7 +345,7 @@ struct LibraryFeatureTests {
 
     @Test
     func saveTextImport_usesSelectedModeAndOpensCreatedItem() async throws {
-        let item = SavedItem(title: "Imported", renderFormat: .structuredV1, content: "Body")
+        let item = SavedItem(title: "Imported", content: "Body", renderFormat: .structuredV1)
         let ingested = LockIsolated<[(String?, TextImportMode)]>([])
         var initial = LibraryFeature.State()
         initial.textImportDraft = LibraryFeature.TextImportDraft(
@@ -388,7 +388,7 @@ struct LibraryFeatureTests {
 
     @Test
     func importTextResolved_usesHintAndModeWithoutOpeningReader() async {
-        let item = SavedItem(title: "Meeting Notes", renderFormat: .structuredV1, content: "Body")
+        let item = SavedItem(title: "Meeting Notes", content: "Body", renderFormat: .structuredV1)
 
         let store = TestStore(initialState: LibraryFeature.State()) {
             LibraryFeature()

--- a/StowerPackage/Tests/StowerFeatureV2Tests/LibraryFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/LibraryFeatureTests.swift
@@ -346,9 +346,10 @@ struct LibraryFeatureTests {
     @Test
     func saveTextImport_usesSelectedModeAndOpensCreatedItem() async throws {
         let item = SavedItem(title: "Imported", renderFormat: .structuredV1, content: "Body")
-        let ingested = LockIsolated<[TextImportMode]>([])
+        let ingested = LockIsolated<[(String?, TextImportMode)]>([])
         var initial = LibraryFeature.State()
         initial.textImportDraft = LibraryFeature.TextImportDraft(
+            title: "Manual Title",
             text: "# Heading",
             mode: .markdown
         )
@@ -356,10 +357,11 @@ struct LibraryFeatureTests {
         let store = TestStore(initialState: initial) {
             LibraryFeature()
         } withDependencies: {
-            $0.textIngestionClient.ingest = { text, titleHint, mode in
+            $0.textIngestionClient.ingest = { text, explicitTitle, titleHint, mode in
                 #expect(text == "# Heading")
+                #expect(explicitTitle == "Manual Title")
                 #expect(titleHint == nil)
-                ingested.withValue { $0.append(mode) }
+                ingested.withValue { $0.append((explicitTitle, mode)) }
                 return IngestionResult.structuredText(
                     title: "Imported",
                     blocks: [.heading(level: 1, inlines: [.text("Heading")])],
@@ -381,18 +383,19 @@ struct LibraryFeatureTests {
         }
         await store.receive(.openItem(item))
 
-        #expect(ingested.value == [.markdown])
+        #expect(ingested.value.map(\.1) == [.markdown])
     }
 
     @Test
-    func importTextResolved_usesHintAndMode() async {
+    func importTextResolved_usesHintAndModeWithoutOpeningReader() async {
         let item = SavedItem(title: "Meeting Notes", renderFormat: .structuredV1, content: "Body")
 
         let store = TestStore(initialState: LibraryFeature.State()) {
             LibraryFeature()
         } withDependencies: {
-            $0.textIngestionClient.ingest = { text, titleHint, mode in
+            $0.textIngestionClient.ingest = { text, explicitTitle, titleHint, mode in
                 #expect(text == "Body text")
+                #expect(explicitTitle == nil)
                 #expect(titleHint == "Meeting Notes")
                 #expect(mode == .auto)
                 return IngestionResult.structuredText(
@@ -413,6 +416,5 @@ struct LibraryFeatureTests {
             $0.saveState = .ready
             $0.items = [item]
         }
-        await store.receive(.openItem(item))
     }
 }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderDocumentHTMLBuilderTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderDocumentHTMLBuilderTests.swift
@@ -9,9 +9,9 @@ struct ReaderDocumentHTMLBuilderTests {
     func buildReaderHTML_includesHorizontalScrollLockRuntime() {
         let item = SavedItem(
             title: "Reader",
+            content: "Body",
             sourceURL: "https://example.com/article",
-            renderFormat: .structuredV1,
-            content: "Body"
+            renderFormat: .structuredV1
         )
         let document = ReaderDocument(
             title: "Reader",

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderDocumentSanitizerTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderDocumentSanitizerTests.swift
@@ -14,6 +14,8 @@ struct ReaderDocumentSanitizerTests {
             switch inline {
             case .text(let value):
                 return value
+            case .lineBreak:
+                return "\n"
             case .link(let label, _):
                 return label
             case .emphasis(let value):

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderFeatureTests.swift
@@ -28,8 +28,8 @@ struct ReaderFeatureTests {
         // etc.). It must fall back to the item's ingestion-detected format.
         let webViewItem = SavedItem(
             title: "Interactive SVG",
-            renderFormat: .webView,
-            content: "Body"
+            content: "Body",
+            renderFormat: .webView
         )
         var state = ReaderFeature.State(item: webViewItem)
         #expect(state.effectiveRenderFormat == .webView)
@@ -38,8 +38,8 @@ struct ReaderFeatureTests {
         // Structured items still default to structured.
         let structuredItem = SavedItem(
             title: "Plain article",
-            renderFormat: .structuredV1,
-            content: "Body"
+            content: "Body",
+            renderFormat: .structuredV1
         )
         state = ReaderFeature.State(item: structuredItem)
         #expect(state.effectiveRenderFormat == .structuredV1)
@@ -50,8 +50,8 @@ struct ReaderFeatureTests {
     func effectiveRenderFormat_manualOverride_takesPrecedenceOverItemFormat() {
         let webViewItem = SavedItem(
             title: "Interactive SVG",
-            renderFormat: .webView,
-            content: "Body"
+            content: "Body",
+            renderFormat: .webView
         )
         var state = ReaderFeature.State(item: webViewItem)
         state.renderModeOverride = .structuredV1
@@ -71,7 +71,7 @@ struct ReaderFeatureTests {
     func readingProgress_usesLiveBlockIndexEvenWhenTopPositionIsNotPersisted() async {
         let itemID = UUID()
         let clock = TestClock()
-        let item = SavedItem(id: itemID, title: "Read", content: "Body")
+        let item = SavedItem(title: "Read", content: "Body", id: itemID)
         let document = ReaderDocument(
             title: "Read",
             blocks: [
@@ -110,8 +110,8 @@ struct ReaderFeatureTests {
     func readingProgress_hidesForInteractiveAndCompleteContent() {
         let webViewItem = SavedItem(
             title: "Interactive",
-            renderFormat: .webView,
             content: "Body",
+            renderFormat: .webView,
             progressUnitCount: 5,
             isRead: true
         )
@@ -121,8 +121,8 @@ struct ReaderFeatureTests {
 
         let structured = SavedItem(
             title: "Complete",
-            renderFormat: .structuredV1,
             content: "Body",
+            renderFormat: .structuredV1,
             progressUnitCount: 5,
             isRead: true
         )
@@ -134,7 +134,7 @@ struct ReaderFeatureTests {
     @Test
     func load_populatesItemAndDocument() async {
         let itemID = UUID()
-        let item = SavedItem(id: itemID, title: "Read", content: "Body")
+        let item = SavedItem(title: "Read", content: "Body", id: itemID)
         let document = ReaderDocument(title: "Read", blocks: [.paragraph([.text("Body")])])
 
         let store = TestStore(initialState: ReaderFeature.State(itemID: itemID)) {
@@ -164,7 +164,7 @@ struct ReaderFeatureTests {
     @Test
     func editTextTapped_loadsEditableSource() async {
         let itemID = UUID()
-        let item = SavedItem(id: itemID, title: "Read", content: "Body")
+        let item = SavedItem(title: "Read", content: "Body", id: itemID)
 
         let store = TestStore(initialState: ReaderFeature.State(item: item)) {
             ReaderFeature()
@@ -187,12 +187,12 @@ struct ReaderFeatureTests {
     @Test
     func saveTextEdit_updatesReaderState() async {
         let itemID = UUID()
-        let updatedItem = SavedItem(id: itemID, title: "Manual Title", renderFormat: .plainText, content: "Line one\nLine two")
+        let updatedItem = SavedItem(title: "Manual Title", content: "Line one\nLine two", id: itemID, renderFormat: .plainText)
         let updatedDocument = ReaderDocument(
             title: "Manual Title",
             blocks: [.paragraph([.text("Line one"), .lineBreak, .text("Line two")])]
         )
-        var initialState = ReaderFeature.State(item: SavedItem(id: itemID, title: "Old", renderFormat: .plainText, content: "Old"))
+        var initialState = ReaderFeature.State(item: SavedItem(title: "Old", content: "Old", id: itemID, renderFormat: .plainText))
         initialState.textEditor = ReaderFeature.TextEditorState(
             title: "Manual Title",
             text: "Line one\nLine two",
@@ -385,7 +385,7 @@ struct ReaderFeatureTests {
     @Test
     func loadWithDefaultAppearance_usesDefaults() async {
         let itemID = UUID()
-        let item = SavedItem(id: itemID, title: "Read", content: "Body")
+        let item = SavedItem(title: "Read", content: "Body", id: itemID)
         let document = ReaderDocument(title: "Read", blocks: [.paragraph([.text("Body")])])
 
         let store = TestStore(initialState: ReaderFeature.State(itemID: itemID)) {

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderFeatureTests.swift
@@ -162,6 +162,78 @@ struct ReaderFeatureTests {
     }
 
     @Test
+    func editTextTapped_loadsEditableSource() async {
+        let itemID = UUID()
+        let item = SavedItem(id: itemID, title: "Read", content: "Body")
+
+        let store = TestStore(initialState: ReaderFeature.State(item: item)) {
+            ReaderFeature()
+        } withDependencies: {
+            $0.stowerRepository.loadEditableTextSource = { _ in
+                EditableTextSource(title: "Read", text: "Body", mode: .plainText)
+            }
+        }
+
+        await store.send(.editTextTapped)
+        await store.receive(.editableTextLoaded(EditableTextSource(title: "Read", text: "Body", mode: .plainText))) {
+            $0.textEditor = ReaderFeature.TextEditorState(
+                title: "Read",
+                text: "Body",
+                mode: .plainText
+            )
+        }
+    }
+
+    @Test
+    func saveTextEdit_updatesReaderState() async {
+        let itemID = UUID()
+        let updatedItem = SavedItem(id: itemID, title: "Manual Title", renderFormat: .plainText, content: "Line one\nLine two")
+        let updatedDocument = ReaderDocument(
+            title: "Manual Title",
+            blocks: [.paragraph([.text("Line one"), .lineBreak, .text("Line two")])]
+        )
+        var initialState = ReaderFeature.State(item: SavedItem(id: itemID, title: "Old", renderFormat: .plainText, content: "Old"))
+        initialState.textEditor = ReaderFeature.TextEditorState(
+            title: "Manual Title",
+            text: "Line one\nLine two",
+            mode: .plainText
+        )
+
+        let store = TestStore(initialState: initialState) {
+            ReaderFeature()
+        } withDependencies: {
+            $0.textIngestionClient.ingest = { text, explicitTitle, titleHint, mode in
+                #expect(text == "Line one\nLine two")
+                #expect(explicitTitle == "Manual Title")
+                #expect(titleHint == nil)
+                #expect(mode == .plainText)
+                return IngestionResult.sharedText(
+                    text,
+                    explicitTitle: explicitTitle,
+                    titleHint: titleHint,
+                    rawSourceText: text,
+                    rawSourceMode: mode
+                )
+            }
+            $0.stowerRepository.saveEditedTextSource = { _, result in
+                #expect(result.rawSourceText == "Line one\nLine two")
+                #expect(result.rawSourceMode == .plainText)
+                return updatedItem
+            }
+        }
+
+        await store.send(.saveTextEditTapped) {
+            $0.textEditor?.isSaving = true
+        }
+        await store.receive(.textEditSaved(updatedItem, updatedDocument)) {
+            $0.item = updatedItem
+            $0.document = updatedDocument
+            $0.sourceHTML = nil
+            $0.textEditor = nil
+        }
+    }
+
+    @Test
     func fontSizeChange_updatesStateAndSaves() async {
         let itemID = UUID()
         let clock = TestClock()

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReadingProgressTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReadingProgressTests.swift
@@ -22,8 +22,8 @@ struct ReadingProgressTests {
     func libraryReadingProgressShowsOnlyForPartialNonWebItems() {
         let partial = SavedItem(
             title: "Partial",
-            renderFormat: .structuredV1,
             content: "Body",
+            renderFormat: .structuredV1,
             lastReadBlockIndex: 2,
             progressUnitCount: 6,
             isRead: true
@@ -32,8 +32,8 @@ struct ReadingProgressTests {
 
         let unread = SavedItem(
             title: "Unread",
-            renderFormat: .structuredV1,
             content: "Body",
+            renderFormat: .structuredV1,
             lastReadBlockIndex: 2,
             progressUnitCount: 6,
             isRead: false
@@ -42,8 +42,8 @@ struct ReadingProgressTests {
 
         let complete = SavedItem(
             title: "Complete",
-            renderFormat: .structuredV1,
             content: "Body",
+            renderFormat: .structuredV1,
             lastReadBlockIndex: 5,
             progressUnitCount: 6,
             isRead: true
@@ -52,8 +52,8 @@ struct ReadingProgressTests {
 
         let webView = SavedItem(
             title: "Web",
-            renderFormat: .webView,
             content: "Body",
+            renderFormat: .webView,
             lastReadBlockIndex: 2,
             progressUnitCount: 6,
             isRead: true

--- a/StowerPackage/Tests/StowerFeatureV2Tests/TextAuthoringSheetTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/TextAuthoringSheetTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+@testable import StowerData
+@testable import StowerFeature
+import Testing
+
+@Suite
+struct TextAuthoringSheetTests {
+    @Test
+    func explicitMarkdownModeUsesMarkdownPreview() {
+        #expect(
+            TextAuthoringPreviewSupport.kind(
+                for: "# Heading\n\nBody",
+                mode: .markdown
+            ) == .markdown
+        )
+    }
+
+    @Test
+    func autoModeUsesMarkdownPreviewForMarkdownLikeInput() {
+        #expect(
+            TextAuthoringPreviewSupport.kind(
+                for: "# Heading\n\n- one\n- two",
+                mode: .auto
+            ) == .markdown
+        )
+    }
+
+    @Test
+    func autoModeUsesPlainTextPreviewForProse() {
+        #expect(
+            TextAuthoringPreviewSupport.kind(
+                for: "Normal prose with a link https://example.com in it.",
+                mode: .auto
+            ) == .plainText
+        )
+    }
+
+    @Test
+    func explicitPlainTextModeUsesPlainTextPreview() {
+        #expect(
+            TextAuthoringPreviewSupport.kind(
+                for: "# Not markdown here",
+                mode: .plainText
+            ) == .plainText
+        )
+    }
+
+    @Test
+    func markdownPreviewHTMLUsesReaderRenderingForBlockquotesAndInlineCode() {
+        let html = TextAuthoringPreviewSupport.previewHTML(
+            text: """
+            > Quote with `inline code`
+            """,
+            title: "",
+            mode: .markdown
+        )
+
+        #expect(html.contains("<blockquote"))
+        #expect(html.contains("<code>inline code</code>"))
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/TextImportSupportTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/TextImportSupportTests.swift
@@ -28,7 +28,7 @@ struct TextImportSupportTests {
         ---
         """
 
-        let result = try await TextIngestionClient.live.ingest(source, nil, .markdown)
+        let result = try await TextIngestionClient.live.ingest(source, nil, nil, .markdown)
 
         #expect(result.title == "Markdown Title")
         #expect(result.renderFormat == .structuredV1)
@@ -85,18 +85,60 @@ struct TextImportSupportTests {
 
     @Test
     func titleFallsBackToHintWhenMarkdownHasNoH1() async throws {
-        let result = try await TextIngestionClient.live.ingest("Body text only", "Meeting Notes", .markdown)
+        let result = try await TextIngestionClient.live.ingest("Body text only", nil, "Meeting Notes", .markdown)
 
         #expect(result.title == "Meeting Notes")
     }
 
     @Test
     func plainTextFallsBackToSharedNoteWhenNoTitleHintExists() async throws {
-        let result = try await TextIngestionClient.live.ingest("Just plain text", nil, .plainText)
+        let result = try await TextIngestionClient.live.ingest("Just plain text", nil, nil, .plainText)
 
         #expect(result.title == "Shared Note")
         #expect(result.renderFormat == .plainText)
         #expect(result.document.blocks == [.paragraph([.text("Just plain text")])])
+    }
+
+    @Test
+    func manualTitleOverridesMarkdownH1() async throws {
+        let result = try await TextIngestionClient.live.ingest(
+            "# Original Heading",
+            "Manual Title",
+            nil,
+            .markdown
+        )
+
+        #expect(result.title == "Manual Title")
+    }
+
+    @Test
+    func plainTextPreservesParagraphsAndLineBreaks() async throws {
+        let result = try await TextIngestionClient.live.ingest(
+            "First line\nSecond line\n\nThird paragraph",
+            nil,
+            nil,
+            .plainText
+        )
+
+        #expect(result.document.blocks == [
+            .paragraph([.text("First line"), .lineBreak, .text("Second line")]),
+            .paragraph([.text("Third paragraph")]),
+        ])
+        #expect(result.plainText == "First line\nSecond line\n\nThird paragraph")
+    }
+
+    @Test
+    func markdownHardBreaksRemainVisible() async throws {
+        let result = try await TextIngestionClient.live.ingest(
+            "Line one  \nLine two",
+            nil,
+            nil,
+            .markdown
+        )
+
+        #expect(result.document.blocks == [
+            .paragraph([.text("Line one"), .lineBreak, .text("Line two")]),
+        ])
     }
 
     @Test
@@ -108,6 +150,7 @@ struct TextImportSupportTests {
             - one
             - two
             """,
+            nil,
             nil,
             .auto
         )
@@ -121,11 +164,64 @@ struct TextImportSupportTests {
         let result = try await TextIngestionClient.live.ingest(
             "This is a normal paragraph with a https://example.com link inside it.",
             nil,
+            nil,
             .auto
         )
 
         #expect(result.renderFormat == .plainText)
         #expect(result.title == "Shared Note")
+    }
+
+    // MARK: - looksLikeMarkdown inline detection
+
+    @Test
+    func looksLikeMarkdown_detectsBoldSyntax() {
+        #expect(TextImportDetector.looksLikeMarkdown("This has **bold** text"))
+    }
+
+    @Test
+    func looksLikeMarkdown_detectsInlineCode() {
+        #expect(TextImportDetector.looksLikeMarkdown("Use `let x = 1` in Swift"))
+    }
+
+    @Test
+    func looksLikeMarkdown_rejectsPlainProse() {
+        #expect(!TextImportDetector.looksLikeMarkdown("This is a normal paragraph with no formatting."))
+    }
+
+    @Test
+    func looksLikeMarkdown_rejectsAsterisksInMath() {
+        #expect(!TextImportDetector.looksLikeMarkdown("2 * 3 = 6"))
+    }
+
+    @Test
+    func inferredMode_autoFallsBackToAutoDetection() {
+        let mode = TextImportDetector.inferredMode(
+            for: "# Heading\n\nSome text",
+            preferred: .auto
+        )
+        #expect(mode == .markdown)
+    }
+
+    @Test
+    func inferredMode_autoDetectsPlainText() {
+        let mode = TextImportDetector.inferredMode(
+            for: "Just a plain sentence.",
+            preferred: .auto
+        )
+        #expect(mode == .plainText)
+    }
+
+    @Test
+    func autoMode_detectsInlineOnlyMarkdown() async throws {
+        let result = try await TextIngestionClient.live.ingest(
+            "This has **bold** and `code` but no headings or lists.",
+            nil,
+            nil,
+            .auto
+        )
+
+        #expect(result.renderFormat == .structuredV1)
     }
 
     @Test
@@ -136,11 +232,103 @@ struct TextImportSupportTests {
               - Child
             """,
             nil,
+            nil,
             .markdown
         )
 
         #expect(!result.document.blocks.isEmpty)
         #expect(result.plainText.contains("Parent"))
         #expect(result.plainText.contains("Child"))
+    }
+
+    // MARK: - Markdown reconstruction (ReaderDocumentMarkdownWriter)
+
+    @Test
+    func markdownWriter_reconstructsHeadings() {
+        let document = ReaderDocument(title: "Test", blocks: [
+            .heading(level: 1, inlines: [.text("Title")]),
+            .heading(level: 2, inlines: [.text("Section")]),
+        ])
+        let md = ReaderDocumentMarkdownWriter.markdown(from: document)
+        #expect(md.contains("# Title"))
+        #expect(md.contains("## Section"))
+    }
+
+    @Test
+    func markdownWriter_reconstructsInlineFormatting() {
+        let document = ReaderDocument(title: "Test", blocks: [
+            .paragraph([
+                .text("Some "),
+                .strong("bold"),
+                .text(" and "),
+                .emphasis("italic"),
+                .text(" and "),
+                .code("code"),
+                .text(" text."),
+            ]),
+        ])
+        let md = ReaderDocumentMarkdownWriter.markdown(from: document)
+        #expect(md.contains("**bold**"))
+        #expect(md.contains("*italic*"))
+        #expect(md.contains("`code`"))
+    }
+
+    @Test
+    func markdownWriter_reconstructsBlockquotes() {
+        let document = ReaderDocument(title: "Test", blocks: [
+            .blockquote([.text("Quoted text")]),
+        ])
+        let md = ReaderDocumentMarkdownWriter.markdown(from: document)
+        #expect(md.contains("> Quoted text"))
+    }
+
+    @Test
+    func markdownWriter_reconstructsLists() {
+        let document = ReaderDocument(title: "Test", blocks: [
+            .list(ordered: false, items: [
+                [.text("First")],
+                [.text("Second")],
+            ]),
+        ])
+        let md = ReaderDocumentMarkdownWriter.markdown(from: document)
+        #expect(md.contains("- First"))
+        #expect(md.contains("- Second"))
+    }
+
+    @Test
+    func markdownWriter_reconstructsCodeBlocks() {
+        let document = ReaderDocument(title: "Test", blocks: [
+            .code(language: "swift", code: "let x = 42"),
+        ])
+        let md = ReaderDocumentMarkdownWriter.markdown(from: document)
+        #expect(md.contains("```swift"))
+        #expect(md.contains("let x = 42"))
+        #expect(md.contains("```"))
+    }
+
+    @Test
+    func markdownWriter_roundTrips() async throws {
+        let source = """
+        # My Article
+
+        A paragraph with **bold** and *italic* text.
+
+        > A blockquote
+
+        - Item one
+        - Item two
+
+        ```python
+        print("hello")
+        ```
+
+        ---
+        """
+        let result = try await TextIngestionClient.live.ingest(source, nil, nil, .markdown)
+        let reconstructed = ReaderDocumentMarkdownWriter.markdown(from: result.document)
+
+        // Re-parse the reconstructed markdown and verify blocks match
+        let reparsed = try await TextIngestionClient.live.ingest(reconstructed, nil, nil, .markdown)
+        #expect(reparsed.document.blocks.count == result.document.blocks.count)
     }
 }


### PR DESCRIPTION
## Summary
- Fix markdown preview formatting in the text editor — reconstruct markdown from stored blocks when raw source is missing, default mode to auto-detect, pass appearance settings to preview
- Fix editor sheet layout — use full-size sheet to prevent navigation title overlap on iOS
- Add cross-device sync for text/markdown items via new `SavedTextContentSyncTable` with zlib compression to stay under CloudKit's 1 MB limit
- Fix the Download button for text items to trigger text hydration instead of silently failing
- Truncate sync table string fields defensively to prevent CloudKit record-too-large errors