### PR TITLE
Import interactive website archives (.zip) + bump to 0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,12 @@ jobs:
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: ${{ runner.os }}-spm-
 
+      - name: Install xcbeautify
+        run: brew install xcbeautify
+
       - name: Test
         run: |
+          set -o pipefail
           xcodebuild test \
             -workspace Stower.xcworkspace \
             -scheme Stower \
@@ -100,5 +104,34 @@ jobs:
             -skip-testing:StowerUITests \
             -skipMacroValidation \
             -skipPackagePluginValidation \
+            -resultBundlePath TestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO \
-            -quiet
+          | xcbeautify --renderer github-actions --disable-logging
+
+      - name: Summarize test failures
+        if: failure()
+        run: |
+          # Print every test failure with file/line context so the job log
+          # actually tells us which tests broke, even when xcbeautify
+          # suppresses passes for readability.
+          xcrun xcresulttool get test-results tests \
+            --path TestResults.xcresult \
+            --format json \
+            | jq -r '
+              .. | objects
+              | select(.testStatus == "Failure" or .result == "Failure")
+              | "\(.name // .identifier // "unknown")"
+            ' \
+            | sort -u || true
+
+          xcrun xcresulttool get log \
+            --path TestResults.xcresult \
+            --type action 2>/dev/null | tail -200 || true
+
+      - name: Upload xcresult bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: TestResults
+          path: TestResults.xcresult
+          if-no-files-found: ignore

--- a/Config/Shared.xcconfig
+++ b/Config/Shared.xcconfig
@@ -9,8 +9,8 @@
 PRODUCT_NAME = Stower
 PRODUCT_DISPLAY_NAME = Stower
 PRODUCT_BUNDLE_IDENTIFIER = com.ryanleewilliams.stower
-MARKETING_VERSION = 0.2.1
-CURRENT_PROJECT_VERSION = 2
+MARKETING_VERSION = 0.3.0
+CURRENT_PROJECT_VERSION = 3
 
 // ==========================================
 // Platform Configuration

--- a/Stower.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stower.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ed101b84463bac7e52256bb140c0eddfdc9fa6f7392be39d3271356ba0fff17a",
+  "originHash" : "7c491e3972a0c7d842a25e3802c5dc5d34327af1ccd9ff67a9f45e671de0407e",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -188,6 +188,15 @@
       "state" : {
         "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
         "version" : "1.9.0"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation.git",
+      "state" : {
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
       }
     }
   ],

--- a/StowerPackage/Package.resolved
+++ b/StowerPackage/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ed101b84463bac7e52256bb140c0eddfdc9fa6f7392be39d3271356ba0fff17a",
+  "originHash" : "7c491e3972a0c7d842a25e3802c5dc5d34327af1ccd9ff67a9f45e671de0407e",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -188,6 +188,15 @@
       "state" : {
         "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
         "version" : "1.9.0"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation.git",
+      "state" : {
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
       }
     }
   ],

--- a/StowerPackage/Package.swift
+++ b/StowerPackage/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/sqlite-data.git", from: "1.5.0"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.6.0"),
         .package(url: "https://github.com/swiftlang/swift-markdown.git", from: "0.7.0"),
+        .package(url: "https://github.com/weichsel/ZIPFoundation.git", from: "0.9.19"),
     ],
     targets: [
         .target(
@@ -31,13 +32,18 @@ let package = Package(
                 .product(name: "Dependencies", package: "swift-dependencies"),
                 .product(name: "Markdown", package: "swift-markdown"),
                 .product(name: "SwiftSoup", package: "SwiftSoup"),
+                .product(name: "ZIPFoundation", package: "ZIPFoundation"),
                 "StowerData",
             ],
             path: "Sources/StowerFeatureV2"
         ),
         .testTarget(
             name: "StowerFeatureTests",
-            dependencies: ["StowerFeature", "StowerData"],
+            dependencies: [
+                "StowerFeature",
+                "StowerData",
+                .product(name: "ZIPFoundation", package: "ZIPFoundation"),
+            ],
             path: "Tests/StowerFeatureV2Tests"
         ),
     ]

--- a/StowerPackage/Sources/StowerData/Data/Bootstrap+CloudSync.swift
+++ b/StowerPackage/Sources/StowerData/Data/Bootstrap+CloudSync.swift
@@ -39,6 +39,7 @@ extension StowerDatabase {
                 ItemTagSyncTable.self,
                 SavedPDFContentSyncTable.self,
                 SavedTextContentSyncTable.self,
+                SavedWebsiteArchiveSyncTable.self,
                 containerIdentifier: StowerDatabase.cloudKitContainerID,
                 delegate: delegate
             )

--- a/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
+++ b/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
@@ -238,6 +238,12 @@ public enum StowerDatabase {
         migrator.registerMigration("add-synced-text-content-table") { db in
             try migration_v11(db)
         }
+        migrator.registerMigration("add-website-archive-sync-table") { db in
+            try migration_v12(db)
+        }
+        migrator.registerMigration("purge-mistargeted-text-sync-rows") { db in
+            try migration_v13(db)
+        }
         try migrator.migrate(database)
     }
 
@@ -614,6 +620,46 @@ public enum StowerDatabase {
         } catch {
             // Column doesn't exist — table was created with the current schema.
         }
+    }
+
+    /// v12 — Synced user-imported website archives.
+    ///
+    /// Interactive static websites (e.g. ebook companion guides) are imported
+    /// as a `.zip` file. The original zip bytes are persisted here so that
+    /// SQLiteData's CloudKit bridge can promote the BLOB to a CKAsset and the
+    /// archive appears on every signed-in device. The second device runs a
+    /// `hydrateWebsite` job that unpacks the zip into `StowerArchive/{itemID}/`
+    /// on first open.
+    ///
+    /// Never DROP this table — its CloudKit change tokens live alongside it.
+    private static func migration_v12(_ db: Database) throws {
+        try db.execute(sql: """
+            CREATE TABLE IF NOT EXISTS "savedWebsiteArchiveSyncTables" (
+              "id" TEXT PRIMARY KEY NOT NULL,
+              "zipData" BLOB NOT NULL DEFAULT x'',
+              "sha256" TEXT NOT NULL DEFAULT '',
+              "originalFilename" TEXT NOT NULL DEFAULT '',
+              "byteCount" INTEGER NOT NULL DEFAULT 0,
+              "createdAt" TEXT NOT NULL,
+              "updatedAt" TEXT NOT NULL
+            ) STRICT
+            """)
+    }
+
+    /// v13 — Purge `savedTextContentSyncTables` rows that were written for
+    /// non-text render formats. A now-fixed helper in
+    /// `persistLocalContentAndCaches` mirrored every item without a
+    /// `sourceURL` into this table, which meant imported `.webView`
+    /// websites (and any `.pdf` items that slipped through an older guard)
+    /// got an empty row here. CloudKit then echoed those empty rows back
+    /// on every update, pinning the sync engine in a churn loop. Deleting
+    /// the rows here propagates as a CloudKit delete on first launch, so
+    /// every paired device stops the churn too.
+    private static func migration_v13(_ db: Database) throws {
+        try db.execute(sql: """
+            DELETE FROM "savedTextContentSyncTables"
+            WHERE "renderFormat" NOT IN ('plainText', 'structuredV1', 'htmlFallback')
+            """)
     }
 
     private static func migration_v10(_ db: Database) throws {

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Helpers.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Helpers.swift
@@ -197,7 +197,19 @@ extension StowerRepository {
         // The raw text is zlib-compressed + base64-encoded to stay under
         // CloudKit's 1 MB per-record limit. plainText is truncated to 1000
         // chars (enough for excerpt display while the full content syncs).
-        if result.sourceURL == nil, result.renderFormat != .pdf {
+        //
+        // Scoped to text-oriented render formats only. Other formats that
+        // happen to have a nil sourceURL (e.g. `.webView` from a user-
+        // imported `.zip`) have their own sync tables — mirroring them here
+        // would write empty rows every time the item updates, and the
+        // resulting CloudKit echo floods the sync engine.
+        let isTextAuthoredItem = result.sourceURL == nil
+            && (
+                result.renderFormat == .plainText
+                || result.renderFormat == .structuredV1
+                || result.renderFormat == .htmlFallback
+            )
+        if isTextAuthoredItem {
             let rawText = result.rawSourceText ?? ""
             let compressed = TextSyncCompression.compress(rawText)
             let truncatedPlain = String(result.plainText.prefix(1000))

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Website.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Website.swift
@@ -1,0 +1,163 @@
+import Foundation
+import SQLiteData
+
+/// Repository helpers for user-imported website archives (`.webView` items
+/// that originated from a `.zip` import rather than a live URL fetch).
+///
+/// The original zip bytes are persisted in `SavedWebsiteArchiveSyncTable` so
+/// SQLiteData's CloudKit bridge can promote them to a CKAsset and every
+/// signed-in device sees the item. The unpacked site lives under the
+/// per-item `StowerArchive/{itemID}/` directory and is reconstructed on the
+/// receiving device by a `hydrateWebsite` ingestion job.
+extension StowerRepository {
+    static func _saveWebsiteArchive(
+        database: any DatabaseWriter,
+        scheduleSync: @escaping @Sendable () -> Void
+    ) -> @Sendable (UUID, Data, String, String) async throws -> Void {
+        { (itemID: UUID, zipData: Data, sha256: String, originalFilename: String) in
+            let now = Date.now
+            try await database.write { db in
+                try SavedWebsiteArchiveSyncTable
+                    .upsert {
+                        SavedWebsiteArchiveSyncTable.Draft(
+                            id: itemID,
+                            zipData: zipData,
+                            sha256: sha256,
+                            originalFilename: originalFilename,
+                            byteCount: zipData.count,
+                            createdAt: now,
+                            updatedAt: now
+                        )
+                    }
+                    .execute(db)
+            }
+            scheduleSync()
+        }
+    }
+
+    static func _loadWebsiteArchive(
+        database: any DatabaseWriter
+    ) -> @Sendable (UUID) async throws -> WebsiteArchiveBytes? {
+        { itemID in
+            try await database.read { db in
+                guard
+                    let row: SavedWebsiteArchiveSyncTable = try SavedWebsiteArchiveSyncTable
+                        .find(itemID)
+                        .fetchOne(db),
+                    !row.zipData.isEmpty
+                else {
+                    return nil
+                }
+                return WebsiteArchiveBytes(
+                    zipData: row.zipData,
+                    originalFilename: row.originalFilename,
+                    sha256: row.sha256
+                )
+            }
+        }
+    }
+
+    /// Scans the website sync table for rows whose local item has no
+    /// unpacked archive on disk and enqueues a `hydrateWebsite` job for
+    /// each. Returns the number of jobs enqueued.
+    static func _hydrateWebsiteItemsFromSyncedContent(
+        database: any DatabaseWriter,
+        archiveExists: @escaping @Sendable (UUID) -> Bool
+    ) -> @Sendable () async throws -> Int {
+        { () async throws -> Int in
+            let now = Date.now
+            return try await database.write { db -> Int in
+                let archiveRows: [SavedWebsiteArchiveSyncTable] =
+                    try SavedWebsiteArchiveSyncTable.fetchAll(db)
+                var enqueued = 0
+                for row in archiveRows {
+                    guard row.byteCount > 0 else { continue }
+                    // Only enqueue when the item exists and the local archive is missing.
+                    guard try SavedItemSyncTable.find(row.id).fetchOne(db) != nil else { continue }
+                    if archiveExists(row.id) { continue }
+
+                    let payload = try String(
+                        bytes: JSONEncoder().encode(WebsiteHydrationPayload(itemID: row.id)),
+                        encoding: .utf8
+                    ) ?? ""
+                    try IngestionJobLocalTable
+                        .insert {
+                            IngestionJobLocalTable.Draft(
+                                id: UUID(),
+                                kind: IngestionJob.Kind.hydrateWebsite.rawValue,
+                                payload: payload,
+                                createdAt: now,
+                                processedAt: nil
+                            )
+                        }
+                        .execute(db)
+                    enqueued += 1
+                }
+                return enqueued
+            }
+        }
+    }
+}
+
+/// Return type for `StowerRepository.loadWebsiteArchive`. Carries the raw zip
+/// bytes and the original filename so the unpacker can use the latter as a
+/// title fallback before parsing `<title>` out of the extracted index.html.
+public struct WebsiteArchiveBytes: Sendable, Equatable {
+    public let zipData: Data
+    public let originalFilename: String
+    public let sha256: String
+
+    public init(zipData: Data, originalFilename: String, sha256: String) {
+        self.zipData = zipData
+        self.originalFilename = originalFilename
+        self.sha256 = sha256
+    }
+}
+
+/// Checks whether an unpacked website archive exists on disk for the given
+/// item. URL-ingested archives and zip imports with root `index.html` hit
+/// the cheap check first; zip imports with a nested entry (e.g.
+/// `guide/index.html`) fall through to a bounded BFS.
+///
+/// Lives in `StowerData` because the CloudKit hydration path is wired from
+/// here and can't reach the feature module's `AssetArchiver` directly. The
+/// BFS intentionally mirrors `WebsiteArchiveUnpacker.findEntryURL` so the
+/// two places agree on what "archive exists" means.
+func websiteArchiveExists(itemID: UUID) -> Bool {
+    let docs = FileManager.default.urls(
+        for: .documentDirectory,
+        in: .userDomainMask
+    ).first!
+    let archiveDir = docs
+        .appendingPathComponent("StowerArchive", isDirectory: true)
+        .appendingPathComponent(itemID.uuidString, isDirectory: true)
+
+    let rootIndex = archiveDir.appendingPathComponent("index.html")
+    if FileManager.default.fileExists(atPath: rootIndex.path) {
+        return true
+    }
+
+    // BFS up to 4 directory levels for `index.html`/`index.htm`.
+    var queue: [(URL, Int)] = [(archiveDir, 0)]
+    while !queue.isEmpty {
+        let (dir, depth) = queue.removeFirst()
+        let children = (try? FileManager.default.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        for child in children {
+            let name = child.lastPathComponent.lowercased()
+            if name == "index.html" || name == "index.htm" {
+                let isDir = (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+                if !isDir { return true }
+            }
+        }
+        if depth >= 4 { continue }
+        for child in children {
+            let isDir = (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            if isDir { queue.append((child, depth + 1)) }
+        }
+    }
+    return false
+}

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Website.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Website.swift
@@ -138,7 +138,7 @@ func websiteArchiveExists(itemID: UUID) -> Bool {
     }
 
     // BFS up to 4 directory levels for `index.html`/`index.htm`.
-    var queue: [(URL, Int)] = [(archiveDir, 0)]
+    var queue = [(dir: archiveDir, depth: 0)]
     while !queue.isEmpty {
         let (dir, depth) = queue.removeFirst()
         let children = (try? FileManager.default.contentsOfDirectory(
@@ -150,13 +150,19 @@ func websiteArchiveExists(itemID: UUID) -> Bool {
             let name = child.lastPathComponent.lowercased()
             if name == "index.html" || name == "index.htm" {
                 let isDir = (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
-                if !isDir { return true }
+                if !isDir {
+                    return true
+                }
             }
         }
-        if depth >= 4 { continue }
+        if depth >= 4 {
+            continue
+        }
         for child in children {
             let isDir = (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
-            if isDir { queue.append((child, depth + 1)) }
+            if isDir {
+                queue.append((child, depth + 1))
+            }
         }
     }
     return false

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository.swift
@@ -295,9 +295,7 @@ extension StowerRepository {
             loadWebsiteArchive: _loadWebsiteArchive(database: database),
             hydrateWebsiteItemsFromSyncedContent: _hydrateWebsiteItemsFromSyncedContent(
                 database: database,
-                archiveExists: { itemID in
-                    websiteArchiveExists(itemID: itemID)
-                }
+                archiveExists: websiteArchiveExists(itemID:)
             )
         )
     }

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository.swift
@@ -73,6 +73,24 @@ public struct StowerRepository: Sendable {
     /// text items missing a sync row. Recovers from dropped tables and
     /// backfills items created before the sync table existed.
     public var backfillTextSyncTable: @Sendable () async throws -> Int
+
+    // MARK: - Website archives
+
+    /// Persists the original zip bytes for an imported website into the
+    /// CloudKit-synced archive table. SQLiteData promotes the blob column to
+    /// a CKAsset so the other device receives the full archive.
+    public var saveWebsiteArchive: @Sendable (
+        _ itemID: UUID,
+        _ zipData: Data,
+        _ sha256: String,
+        _ originalFilename: String
+    ) async throws -> Void
+    /// Loads the zip bytes for an imported website. Returns nil when the row
+    /// is absent or the blob has not yet been populated by sync.
+    public var loadWebsiteArchive: @Sendable (UUID) async throws -> WebsiteArchiveBytes?
+    /// Enqueues `hydrateWebsite` jobs for synced website rows whose local
+    /// archive directory is missing. Returns the number of jobs enqueued.
+    public var hydrateWebsiteItemsFromSyncedContent: @Sendable () async throws -> Int
 }
 
 private enum StowerRepositoryKey: DependencyKey {
@@ -137,7 +155,10 @@ extension StowerRepository {
             enqueueHydrationJobsForMissingContent: { 0 },
             hydratePDFItemsFromSyncedContent: { 0 },
             hydrateTextItemsFromSyncedContent: { 0 },
-            backfillTextSyncTable: { 0 }
+            backfillTextSyncTable: { 0 },
+            saveWebsiteArchive: { _, _, _, _ in },
+            loadWebsiteArchive: { _ in nil },
+            hydrateWebsiteItemsFromSyncedContent: { 0 }
         )
     }()
 }
@@ -266,7 +287,18 @@ extension StowerRepository {
             enqueueHydrationJobsForMissingContent: _enqueueHydrationJobsForMissingContent(database: database),
             hydratePDFItemsFromSyncedContent: _hydratePDFItemsFromSyncedContent(database: database),
             hydrateTextItemsFromSyncedContent: _hydrateTextItemsFromSyncedContent(database: database),
-            backfillTextSyncTable: _backfillTextSyncTable(database: database)
+            backfillTextSyncTable: _backfillTextSyncTable(database: database),
+            saveWebsiteArchive: _saveWebsiteArchive(
+                database: database,
+                scheduleSync: scheduleSyncAndNotify
+            ),
+            loadWebsiteArchive: _loadWebsiteArchive(database: database),
+            hydrateWebsiteItemsFromSyncedContent: _hydrateWebsiteItemsFromSyncedContent(
+                database: database,
+                archiveExists: { itemID in
+                    websiteArchiveExists(itemID: itemID)
+                }
+            )
         )
     }
 

--- a/StowerPackage/Sources/StowerData/Data/Tables.swift
+++ b/StowerPackage/Sources/StowerData/Data/Tables.swift
@@ -116,6 +116,23 @@ nonisolated public struct SavedTextContentSyncTable: Hashable, Identifiable, Sen
     public var updatedAt: Date = .now
 }
 
+/// CloudKit-synced original zip bytes for user-imported interactive website
+/// archives. The column `zipData` is a SQLite BLOB; SQLiteData's CloudKit
+/// bridge promotes blob columns to `CKAsset` automatically, so sites up to a
+/// few hundred MB sync within the user's iCloud quota. The second device runs
+/// a `.hydrateWebsite` job that unpacks the bytes into the item's archive
+/// directory on first open.
+@Table
+nonisolated public struct SavedWebsiteArchiveSyncTable: Hashable, Identifiable, Sendable {
+    public let id: UUID
+    public var zipData: Data = Data()
+    public var sha256: String = ""
+    public var originalFilename: String = ""
+    public var byteCount: Int = 0
+    public var createdAt: Date = .now
+    public var updatedAt: Date = .now
+}
+
 @Table
 nonisolated public struct SavedMediaLocalTable: Hashable, Identifiable, Sendable {
     public let id: UUID

--- a/StowerPackage/Sources/StowerData/Data/Tables.swift
+++ b/StowerPackage/Sources/StowerData/Data/Tables.swift
@@ -125,7 +125,10 @@ nonisolated public struct SavedTextContentSyncTable: Hashable, Identifiable, Sen
 @Table
 nonisolated public struct SavedWebsiteArchiveSyncTable: Hashable, Identifiable, Sendable {
     public let id: UUID
-    public var zipData: Data = Data()
+    // `@Table` macro requires an explicit type annotation so the
+    // generated memberwise initializer and row bindings know this column
+    // is a BLOB rather than having its type inferred at the call site.
+    public var zipData: Data = .init()
     public var sha256: String = ""
     public var originalFilename: String = ""
     public var byteCount: Int = 0

--- a/StowerPackage/Sources/StowerData/Domain/Models.swift
+++ b/StowerPackage/Sources/StowerData/Domain/Models.swift
@@ -312,6 +312,8 @@ public struct IngestionJob: Equatable, Identifiable, Sendable {
         case hydrate = "hydrate"
         case hydrateText = "hydrateText"
         case pdf = "pdf"
+        case website = "website"
+        case hydrateWebsite = "hydrateWebsite"
     }
 
     public let id: UUID
@@ -348,5 +350,13 @@ public struct TextHydrationPayload: Codable, Equatable, Sendable {
         self.rawSourceText = rawSourceText
         self.rawSourceMode = rawSourceMode
         self.title = title
+    }
+}
+
+public struct WebsiteHydrationPayload: Codable, Equatable, Sendable {
+    public var itemID: UUID
+
+    public init(itemID: UUID) {
+        self.itemID = itemID
     }
 }

--- a/StowerPackage/Sources/StowerData/Domain/ReaderDocument.swift
+++ b/StowerPackage/Sources/StowerData/Domain/ReaderDocument.swift
@@ -251,6 +251,38 @@ public struct IngestionResult: Equatable, Sendable {
         )
     }
 
+    /// Builds an `IngestionResult` for a user-imported interactive website
+    /// archive. Produces a minimal `.webView` item — the reader renders from
+    /// the unpacked files on disk, not from `document`/`plainText`, so those
+    /// stay empty. `excerpt` carries the original filename so the library
+    /// card has something readable before the `<title>` tag is parsed.
+    public static func importedWebsite(
+        title: String,
+        filename: String,
+        heroImageURL: String? = nil
+    ) -> IngestionResult {
+        IngestionResult(
+            title: title,
+            sourceURL: nil,
+            canonicalURL: nil,
+            excerpt: filename.isEmpty ? nil : filename,
+            author: nil,
+            publishedAt: nil,
+            siteName: nil,
+            heroImageURL: heroImageURL,
+            readingTimeMinutes: nil,
+            hasRichMedia: true,
+            renderFormat: .webView,
+            processingState: .ready,
+            processingError: nil,
+            document: ReaderDocument(title: title, blocks: []),
+            plainText: "",
+            media: [],
+            embeds: [],
+            sourceHTML: ""
+        )
+    }
+
     public static func structuredText(
         title: String,
         blocks: [ReaderBlock],

--- a/StowerPackage/Sources/StowerData/Support/ShareIngestionClient.swift
+++ b/StowerPackage/Sources/StowerData/Support/ShareIngestionClient.swift
@@ -109,4 +109,41 @@ public enum ShareIngestionClient {
             try? await repository.enqueueIngestionJob(.pdf, path)
         }
     }
+
+    /// Copies a `.zip` website archive at `sourceURL` into the shared App
+    /// Group container under `PendingWebsites/{uuid}/` and enqueues a
+    /// `.website` ingestion job whose payload is the absolute destination
+    /// path. Mirrors `enqueuePDF` so the main-app ingester can rely on the
+    /// original filename for the title fallback before the `<title>` tag has
+    /// been parsed out of index.html.
+    public static func enqueueWebsiteZip(_ sourceURL: URL) throws {
+        try prepareDependencies {
+            try $0.bootstrapStowerDatabase(enableSync: false)
+        }
+
+        guard let container = FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: StowerDatabase.appGroupID)
+        else {
+            throw Error.appGroupUnavailable
+        }
+
+        let pendingRoot = container.appendingPathComponent("PendingWebsites", isDirectory: true)
+        let pendingDir = pendingRoot.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: pendingDir,
+            withIntermediateDirectories: true
+        )
+        let filename = sourceURL.lastPathComponent.isEmpty
+            ? "website.zip"
+            : sourceURL.lastPathComponent
+        let destination = pendingDir.appendingPathComponent(filename)
+        try FileManager.default.copyItem(at: sourceURL, to: destination)
+
+        @Dependency(\.stowerRepository)
+        var repository
+        let path = destination.path
+        Task {
+            try? await repository.enqueueIngestionJob(.website, path)
+        }
+    }
 }

--- a/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
@@ -268,6 +268,7 @@ public struct AppFeature {
                         _ = try? await repository.enqueueHydrationJobsForMissingContent()
                         _ = try? await repository.hydratePDFItemsFromSyncedContent()
                         _ = try? await repository.hydrateTextItemsFromSyncedContent()
+                        _ = try? await repository.hydrateWebsiteItemsFromSyncedContent()
                         try? await processIngestionJobs(
                             repository: repository,
                             ingestionClient: ingestionClient,
@@ -503,7 +504,52 @@ private func processIngestionJobs(
                     try? await repository.updateLocalContentStatus(payload.itemID, "failed", error.localizedDescription)
                 }
             }
+        case .website:
+            // Payload is the absolute path of a .zip file the share extension
+            // (or another background enqueuer) copied into the shared App
+            // Group container (PendingWebsites/{uuid}/). The in-app picker
+            // path imports inline via WebsiteImportService without touching
+            // this queue.
+            let zipURL = URL(fileURLWithPath: job.payload)
+            let scratchDir = zipURL.deletingLastPathComponent()
+            do {
+                _ = try await WebsiteImportService.importWebsite(
+                    zipURL: zipURL,
+                    repository: repository
+                )
+                try? FileManager.default.removeItem(at: scratchDir)
+            } catch {
+                let fallback = zipURL.deletingPathExtension().lastPathComponent
+                _ = try? await repository.createItemFromIngestion(
+                    .sharedText("Failed to import website: \(fallback)\n\n\(error.localizedDescription)")
+                )
+                try? FileManager.default.removeItem(at: scratchDir)
+            }
+        case .hydrateWebsite:
+            // Receive-side: the website archive arrived via CloudKit sync but
+            // the site isn't unpacked locally yet. Pull the zip bytes out of
+            // the sync table and run the same unpack logic we use on the
+            // originating device.
+            let data = Data(job.payload.utf8)
+            let payload = try JSONDecoder().decode(WebsiteHydrationPayload.self, from: data)
+            do {
+                guard
+                    let archive = try await repository.loadWebsiteArchive(payload.itemID)
+                else { break }
+                try await WebsiteImportService.hydrateWebsite(
+                    itemID: payload.itemID,
+                    archive: archive,
+                    repository: repository
+                )
+            } catch {
+                try? await repository.updateLocalContentStatus(
+                    payload.itemID,
+                    "failed",
+                    error.localizedDescription
+                )
+            }
         }
         try await repository.markIngestionJobProcessed(job.id)
     }
 }
+

--- a/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
@@ -552,4 +552,3 @@ private func processIngestionJobs(
         try await repository.markIngestionJobProcessed(job.id)
     }
 }
-

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryFeature.swift
@@ -116,6 +116,7 @@ public struct LibraryFeature {
         case saveURLFinished(SavedItem)
         case saveURLFailed(String)
         case importPDFSelected(URL)
+        case importWebsiteSelected(URL)
         case addTextTapped
         case textImportDismissed
         case textImportTitleChanged(String)
@@ -504,6 +505,38 @@ public struct LibraryFeature {
                         let result = try await pdfIngestionClient.ingest(pickedURL)
                         let item = try await repository.createItemFromIngestion(result)
                         try? PDFArchiver.archivePDF(from: pickedURL, itemID: item.id)
+                        await send(.saveURLFinished(item))
+                        await send(.openItem(item))
+                    } catch {
+                        await send(.saveURLFailed(error.localizedDescription))
+                    }
+                }
+
+            case .importWebsiteSelected(let pickedURL):
+                // Foreground import via `UIDocumentPicker` / `NSOpenPanel`.
+                // The screen copies the picked .zip into a UUID-named scratch
+                // subdirectory before dispatching this action so we own the
+                // file and security-scoped access has already been released.
+                // Mirrors `.importPDFSelected` — we run inline to open the
+                // site as soon as the unpack finishes.
+                state.isSaving = true
+                state.saveState = .extracting
+                state.errorMessage = nil
+                let repository = self.repository
+                return .run { send in
+                    defer {
+                        let parent = pickedURL.deletingLastPathComponent()
+                        if parent.path != FileManager.default.temporaryDirectory.path {
+                            try? FileManager.default.removeItem(at: parent)
+                        } else {
+                            try? FileManager.default.removeItem(at: pickedURL)
+                        }
+                    }
+                    do {
+                        let item = try await WebsiteImportService.importWebsite(
+                            zipURL: pickedURL,
+                            repository: repository
+                        )
                         await send(.saveURLFinished(item))
                         await send(.openItem(item))
                     } catch {

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
@@ -566,9 +566,12 @@ public struct LibraryScreen: View {
 
     private func contentTypes(for picker: IOSImportPicker) -> [UTType] {
         switch picker {
-        case .text: return textImportContentTypes
-        case .pdf: return [.pdf]
-        case .website: return [.zip]
+        case .text:
+            return textImportContentTypes
+        case .pdf:
+            return [.pdf]
+        case .website:
+            return [.zip]
         }
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
@@ -277,6 +277,11 @@ public struct LibraryScreen: View {
                     } label: {
                         Label("Import PDF…", systemImage: "doc.richtext")
                     }
+                    Button {
+                        presentWebsiteImporter()
+                    } label: {
+                        Label("Import Website Archive…", systemImage: "globe")
+                    }
                 } label: {
                     Label("Add", systemImage: "plus")
                 }
@@ -315,7 +320,7 @@ public struct LibraryScreen: View {
         #if os(iOS)
         .sheet(item: $activeImportPicker) { picker in
             IOSDocumentPicker(
-                allowedContentTypes: picker == .text ? textImportContentTypes : [.pdf]
+                allowedContentTypes: contentTypes(for: picker)
             ) { result in
                 activeImportPicker = nil
                 switch picker {
@@ -323,6 +328,8 @@ public struct LibraryScreen: View {
                     handleTextImport(result)
                 case .pdf:
                     handlePDFImport(result)
+                case .website:
+                    handleWebsiteImport(result)
                 }
             }
         }
@@ -407,6 +414,21 @@ public struct LibraryScreen: View {
         #endif
     }
 
+    private func presentWebsiteImporter() {
+        #if os(macOS)
+        presentOpenPanel(
+            allowedContentTypes: [.zip],
+            title: "Import Website Archive"
+        ) { url in
+            handleWebsiteImport(.success(url))
+        }
+        #else
+        DispatchQueue.main.async {
+            activeImportPicker = .website
+        }
+        #endif
+    }
+
     #if os(macOS)
     private func presentOpenPanel(
         allowedContentTypes: [UTType],
@@ -438,6 +460,37 @@ public struct LibraryScreen: View {
     /// picked URL is security-scoped — we must start/stop access around the
     /// copy, and we copy to a plain temp file so the reducer can consume a
     /// URL with no lifetime restrictions.
+    /// Handles the result of a `.zip` website archive picker. Uses the same
+    /// security-scoped + scratch-copy dance as `handlePDFImport` so the
+    /// reducer consumes a plain temp URL with no lifetime restrictions.
+    private func handleWebsiteImport(_ result: Result<URL, Error>) {
+        switch result {
+        case .success(let pickedURL):
+            let accessed = pickedURL.startAccessingSecurityScopedResource()
+            defer {
+                if accessed { pickedURL.stopAccessingSecurityScopedResource() }
+            }
+            do {
+                let scratchDir = FileManager.default.temporaryDirectory
+                    .appendingPathComponent(UUID().uuidString, isDirectory: true)
+                try FileManager.default.createDirectory(
+                    at: scratchDir,
+                    withIntermediateDirectories: true
+                )
+                let scratch = scratchDir.appendingPathComponent(pickedURL.lastPathComponent)
+                try FileManager.default.copyItem(at: pickedURL, to: scratch)
+                store.send(.importWebsiteSelected(scratch))
+            } catch {
+                store.send(.saveURLFailed("Couldn't read zip: \(error.localizedDescription)"))
+            }
+        case .failure(let error):
+            let ns = error as NSError
+            if ns.code != NSUserCancelledError {
+                store.send(.saveURLFailed("Website import failed: \(error.localizedDescription)"))
+            }
+        }
+    }
+
     private func handlePDFImport(_ result: Result<URL, Error>) {
         switch result {
         case .success(let pickedURL):
@@ -506,8 +559,17 @@ public struct LibraryScreen: View {
     private enum IOSImportPicker: String, Identifiable {
         case text = "text"
         case pdf = "pdf"
+        case website = "website"
 
         var id: String { rawValue }
+    }
+
+    private func contentTypes(for picker: IOSImportPicker) -> [UTType] {
+        switch picker {
+        case .text: return textImportContentTypes
+        case .pdf: return [.pdf]
+        case .website: return [.zip]
+        }
     }
 
     private struct IOSDocumentPicker: UIViewControllerRepresentable {
@@ -808,6 +870,12 @@ public struct LibraryScreen: View {
                     } label: {
                         Label("Import PDF…", systemImage: "doc.richtext")
                     }
+
+                    Button {
+                        presentWebsiteImporter()
+                    } label: {
+                        Label("Import Website Archive…", systemImage: "globe")
+                    }
                 }
             } label: {
                 Label("More", systemImage: "ellipsis.circle")
@@ -941,6 +1009,22 @@ private struct LibraryItemThumbnail: View {
     private var resolvedImageURL: URL? {
         guard let heroURLString = item.heroImageURL, !heroURLString.isEmpty else {
             return nil
+        }
+        // `stower-archive:<relative-path>` is produced by the website-archive
+        // importer: each device resolves it against its own local archive
+        // directory so the field can sync cross-device without pinning a
+        // file URL. Fall through to regular URL parsing for every other
+        // scheme (http/https/data/etc.).
+        let scheme = WebsiteArchiveUnpacker.heroArchiveURLScheme + ":"
+        if heroURLString.hasPrefix(scheme) {
+            let relative = String(heroURLString.dropFirst(scheme.count))
+            guard !relative.isEmpty else { return nil }
+            let fileURL = AssetArchiver.archiveDirectory(for: item.id)
+                .appendingPathComponent(relative)
+            guard FileManager.default.fileExists(atPath: fileURL.path) else {
+                return nil
+            }
+            return fileURL
         }
         return URL(string: heroURLString)
     }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderFeature.swift
@@ -177,6 +177,9 @@ public struct ReaderFeature {
     var continuousClock
     @Dependency(\.readerProgressClient)
     var readerProgressClient
+    @Dependency(\.cloudSyncClient)
+    var cloudSyncClient
+
     @Dependency(\.textIngestionClient)
     var textIngestionClient
 
@@ -399,17 +402,41 @@ public struct ReaderFeature {
                 return .none
 
             case .retryExtractionTapped:
-                // Text/markdown items have no sourceURL — hydrate from the
-                // CloudKit-synced text content table and re-ingest.
+                // Items without a source URL come from one of two paths:
+                // imported websites (zip bytes live in the archive sync
+                // table) or text/markdown (raw source in the text sync
+                // table). The item's renderFormat only survives in the
+                // LOCAL content table, which doesn't exist on the device
+                // that synced the item down — so we can't use it as a
+                // discriminator here. Instead, peek at the archive sync
+                // table first: if a row exists for this ID, treat it as a
+                // website regardless of what renderFormat the domain model
+                // is currently reporting.
                 if state.item?.sourceURL == nil {
                     state.isLoading = true
+                    state.errorMessage = nil
                     let repository = self.repository
                     let textIngestionClient = self.textIngestionClient
+                    let cloudSyncClient = self.cloudSyncClient
                     return .run { [id = state.itemID] send in
                         do {
-                            // Hydrate enqueues jobs; process them inline.
+                            try? await cloudSyncClient.sendChanges()
+
+                            if let archive = try await repository.loadWebsiteArchive(id) {
+                                try await WebsiteImportService.hydrateWebsite(
+                                    itemID: id,
+                                    archive: archive,
+                                    repository: repository
+                                )
+                                let item = try await repository.loadItem(id)
+                                await send(.retryFinished(item))
+                                return
+                            }
+
+                            // Fall back to the text/markdown hydration path.
                             _ = try await repository.hydrateTextItemsFromSyncedContent()
                             let jobs = try await repository.fetchPendingIngestionJobs()
+                            var hydratedTextItem = false
                             for job in jobs where job.kind == .hydrateText {
                                 let data = Data(job.payload.utf8)
                                 let payload = try JSONDecoder().decode(TextHydrationPayload.self, from: data)
@@ -425,9 +452,25 @@ public struct ReaderFeature {
                                 )
                                 try await repository.hydrateItemContent(id, result)
                                 try await repository.markIngestionJobProcessed(job.id)
+                                hydratedTextItem = true
+                            }
+
+                            if !hydratedTextItem {
+                                await send(.failed(
+                                    "The full content hasn't finished syncing from iCloud yet. Try again in a moment."
+                                ))
+                                return
                             }
                             let item = try await repository.loadItem(id)
                             await send(.retryFinished(item))
+                        } catch let error as WebsiteImportService.ImportError {
+                            if case .incompleteAsset = error {
+                                await send(.failed(
+                                    "Still downloading the website archive from iCloud. Try again in a moment."
+                                ))
+                            } else {
+                                await send(.failed(error.localizedDescription))
+                            }
                         } catch {
                             await send(.failed(error.localizedDescription))
                         }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
@@ -235,7 +235,12 @@ public struct ReaderScreen: View {
 
     private func hasRenderableContent(for item: SavedItem) -> Bool {
         if store.effectiveRenderFormat == .webView {
-            return store.sourceHTML != nil
+            // URL-ingested archives carry their captured HTML in
+            // `sourceHTML`. User-imported website zips don't — they unpack
+            // straight to disk and leave sourceHTML empty, so also accept an
+            // on-disk archive directory as evidence the site is renderable.
+            if store.sourceHTML != nil { return true }
+            return AssetArchiver.archiveExists(for: item.id)
         }
         return store.document != nil
     }
@@ -376,6 +381,13 @@ public struct ReaderScreen: View {
                 Button("Improve Formatting") {
                     store.send(.retryExtractionTapped)
                 }
+            }
+
+            if let error = store.errorMessage {
+                Text(error)
+                    .font(.footnote)
+                    .foregroundStyle(store.appearance.palette.error)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .padding(20)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
@@ -239,7 +239,9 @@ public struct ReaderScreen: View {
             // `sourceHTML`. User-imported website zips don't — they unpack
             // straight to disk and leave sourceHTML empty, so also accept an
             // on-disk archive directory as evidence the site is renderable.
-            if store.sourceHTML != nil { return true }
+            if store.sourceHTML != nil {
+                return true
+            }
             return AssetArchiver.archiveExists(for: item.id)
         }
         return store.document != nil

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebPage.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebPage.swift
@@ -108,13 +108,28 @@ enum ReaderWebPageFactory {
     @MainActor
     static func scrollToBlock(_ index: Int, on page: WebPage) async {
         guard index > 0 else { return }
-        _ = try? await page.callJavaScript("window.stowerScrollToBlock(\(index));")
+        let script = """
+        if (typeof window.stowerScrollToBlock === 'function') {
+            window.stowerScrollToBlock(\(index));
+        }
+        """
+        _ = try? await page.callJavaScript(script)
     }
 
     /// Returns the data-block-index of the topmost visible block, or nil on failure.
+    ///
+    /// Guards the call with `typeof` so pages that don't expose
+    /// `stowerGetTopBlockIndex()` (e.g. user-imported website archives that
+    /// Stower didn't author) return a clean nil instead of spewing JS
+    /// exceptions into the WebContent log each poll tick.
     @MainActor
     static func fetchTopBlockIndex(on page: WebPage) async -> Int? {
-        let result = try? await page.callJavaScript("return window.stowerGetTopBlockIndex();")
+        let script = """
+        return typeof window.stowerGetTopBlockIndex === 'function'
+            ? window.stowerGetTopBlockIndex()
+            : null;
+        """
+        let result = try? await page.callJavaScript(script)
         guard let number = result as? Int else { return nil }
         return number >= 0 ? number : nil
     }
@@ -147,5 +162,56 @@ enum ReaderWebPageFactory {
     @MainActor
     static func installContentTapHandler(on page: WebPage) async {
         _ = try? await page.callJavaScript(contentTapScript)
+    }
+
+    /// For user-imported website archives, when the rendered document
+    /// already fits within the viewport we want the WebView to stop
+    /// interpreting horizontal swipes as scroll-the-page gestures — those
+    /// gestures should reach interactive widgets (carousels, draggable
+    /// cards, swipe menus) inside the page instead of being eaten by the
+    /// outer scroll view's bounce.
+    ///
+    /// The script watches for `resize` / DOM mutations and toggles
+    /// `overflow-x` and `touch-action` on `<html>`/`<body>` depending on
+    /// whether the document actually overflows. When it doesn't, vertical
+    /// pan + pinch-zoom stay enabled but horizontal pans are released to
+    /// the page's own handlers. Sites wider than the viewport keep their
+    /// normal horizontal scroll.
+    static let horizontalScrollLockScript = """
+        (function() {
+            if (window.__stowerHorizontalLockInstalled) { return; }
+            window.__stowerHorizontalLockInstalled = true;
+
+            var root = document.documentElement;
+            var body = document.body;
+
+            function apply() {
+                if (!body) { body = document.body; }
+                if (!body) { return; }
+                var fits = root.scrollWidth <= window.innerWidth + 1;
+                if (fits) {
+                    root.style.overflowX = 'hidden';
+                    body.style.overflowX = 'hidden';
+                    body.style.touchAction = 'pan-y pinch-zoom';
+                } else {
+                    root.style.overflowX = '';
+                    body.style.overflowX = '';
+                    body.style.touchAction = '';
+                }
+            }
+
+            apply();
+            window.addEventListener('resize', apply);
+            window.addEventListener('orientationchange', apply);
+            if (window.ResizeObserver) {
+                var ro = new ResizeObserver(apply);
+                ro.observe(root);
+            }
+        })();
+        """
+
+    @MainActor
+    static func installHorizontalScrollLock(on page: WebPage) async {
+        _ = try? await page.callJavaScript(horizontalScrollLockScript)
     }
 }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebView.swift
@@ -99,6 +99,9 @@ public struct ReaderWebView: View {
                 // at which `stowerGetTopBlockIndex()` is guaranteed to
                 // exist on the JS side.
                 installContentTapHandler()
+                if isWebViewFormat {
+                    installHorizontalScrollLock()
+                }
                 updateCSS(appearance)
                 maybeRestorePosition()
                 ReaderProgressCoordinator.shared.register(page)
@@ -267,7 +270,34 @@ public struct ReaderWebView: View {
 
         let archiveDir = AssetArchiver.archiveDirectory(for: itemID)
         let sourceURLValue = sourceURL.flatMap(URL.init(string:))
-        let articlePath = sourceURLValue?.path ?? "/"
+
+        // For URL-ingested archives `index.html` sits at the archive root,
+        // and the server's article-path shortcut maps the original URL path
+        // to that root index. Zip-imported archives can instead have a
+        // nested entry (e.g. `guide/index.html` referencing sibling folders
+        // via `../`), and promoting those contents would silently break
+        // those references. When the root index is missing, serve the
+        // nested entry directly — `articlePath` is set to a sentinel that
+        // matches nothing so the server's shortcut stays out of the way.
+        let rootIndexExists = FileManager.default.fileExists(
+            atPath: archiveDir.appendingPathComponent("index.html").path
+        )
+
+        let articlePath: String
+        let loadURLPath: String
+        if rootIndexExists {
+            let path = sourceURLValue?.path ?? "/"
+            articlePath = path
+            loadURLPath = path
+        } else if let nested = WebsiteArchiveUnpacker.findEntryURL(in: archiveDir),
+                  let relative = WebsiteArchiveUnpacker.relativePath(of: nested, in: archiveDir) {
+            articlePath = ""
+            loadURLPath = "/\(relative)"
+        } else {
+            let path = sourceURLValue?.path ?? "/"
+            articlePath = path
+            loadURLPath = path
+        }
 
         // Resolve the origin used by the local server's fetch-through.
         // Prefer the fresh `sourceURL` from the caller; fall back to the
@@ -294,7 +324,7 @@ public struct ReaderWebView: View {
         )
         guard let port = try? await server.start() else { return (nil, nil) }
 
-        let loadURL = URL(string: "http://localhost:\(port)\(articlePath)")!
+        let loadURL = URL(string: "http://localhost:\(port)\(loadURLPath)")!
         return (loadURL, server)
     }
 
@@ -321,6 +351,14 @@ public struct ReaderWebView: View {
         guard let page else { return }
         Task {
             await ReaderWebPageFactory.installContentTapHandler(on: page)
+        }
+    }
+
+    @MainActor
+    private func installHorizontalScrollLock() {
+        guard let page else { return }
+        Task {
+            await ReaderWebPageFactory.installHorizontalScrollLock(on: page)
         }
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Support/AssetArchiver.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/AssetArchiver.swift
@@ -130,11 +130,18 @@ enum AssetArchiver {
             .appendingPathComponent(itemID.uuidString, isDirectory: true)
     }
 
-    /// Checks whether an archive exists for the given item.
+    /// Checks whether an archive exists for the given item. URL-ingested
+    /// archives keep `index.html` at the root (fast path). User-imported
+    /// website zips can land their index nested (e.g. `guide/index.html`);
+    /// in that case fall back to the unpacker's entry-point search so the
+    /// reader treats the archive as renderable.
     static func archiveExists(for itemID: UUID) -> Bool {
         let dir = archiveDirectory(for: itemID)
         let indexPath = dir.appendingPathComponent("index.html")
-        return FileManager.default.fileExists(atPath: indexPath.path)
+        if FileManager.default.fileExists(atPath: indexPath.path) {
+            return true
+        }
+        return WebsiteArchiveUnpacker.findEntryURL(in: dir) != nil
     }
 
     /// Re-generates index.html from the original source HTML using the current patching logic.

--- a/StowerPackage/Sources/StowerFeatureV2/Support/WebsiteArchiveUnpacker.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/WebsiteArchiveUnpacker.swift
@@ -52,14 +52,14 @@ enum WebsiteArchiveUnpacker {
         var description: String {
             switch self {
             case .cannotOpenArchive:
-                return "The zip file could not be opened. It may be corrupt or password-protected."
+                return "The zip file could not be opened. It may be corrupt or encrypted."
             case .pathTraversal(let path):
                 return "The zip contains an unsafe entry path (\(path)). Import aborted."
             case .uncompressedSizeExceeded(let cap):
                 return "The zip's contents exceed the \(cap / 1_048_576) MB uncompressed limit."
             case .noIndexHTML:
                 return "The zip does not contain an index.html at its root or one folder deep."
-            case .writeFailed(let entryPath, let underlying):
+            case let .writeFailed(entryPath, underlying):
                 return "Failed to unpack \"\(entryPath)\": \(underlying.localizedDescription)"
             }
         }
@@ -354,7 +354,7 @@ enum WebsiteArchiveUnpacker {
     /// directory levels.
     private static func breadthFirstSearchIndex(in root: URL, maxDepth: Int) -> URL? {
         let fileManager = FileManager.default
-        var queue: [(url: URL, depth: Int)] = [(root, 0)]
+        var queue = [(url: root, depth: 0)]
         while !queue.isEmpty {
             let (dir, depth) = queue.removeFirst()
             let children = (try? fileManager.contentsOfDirectory(
@@ -368,7 +368,9 @@ enum WebsiteArchiveUnpacker {
                 let name = child.lastPathComponent.lowercased()
                 if name == "index.html" || name == "index.htm" {
                     let isDir = (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
-                    if !isDir { return child }
+                    if !isDir {
+                        return child
+                    }
                 }
             }
 
@@ -376,7 +378,9 @@ enum WebsiteArchiveUnpacker {
 
             for child in children {
                 let isDir = (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
-                if isDir { queue.append((child, depth + 1)) }
+                if isDir {
+                    queue.append((child, depth + 1))
+                }
             }
         }
         return nil

--- a/StowerPackage/Sources/StowerFeatureV2/Support/WebsiteArchiveUnpacker.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/WebsiteArchiveUnpacker.swift
@@ -1,0 +1,488 @@
+import Foundation
+import OSLog
+import ZIPFoundation
+
+private let kUnpackerLog = Logger(
+    subsystem: "com.ryanleewilliams.stower",
+    category: "WebsiteArchiveUnpacker"
+)
+
+/// Unpacks a user-supplied `.zip` containing a static website into the given
+/// archive directory. Produces the same on-disk layout the reader already
+/// understands (`index.html` + sibling assets at the archive root), so the
+/// existing `.webView` + `LocalArchiveServer` path renders the site without
+/// any reader-side changes.
+///
+/// Security properties:
+///   * Rejects the whole archive if any entry would write outside the
+///     destination directory after path resolution (Zip Slip defense).
+///   * Skips symlinks entirely — the archive is served by
+///     `LocalArchiveServer` via absolute file paths, so symlink semantics
+///     are not needed and would only widen the attack surface.
+///   * Caps cumulative uncompressed bytes so a zip bomb can't exhaust disk
+///     or memory before being aborted.
+enum WebsiteArchiveUnpacker {
+    struct UnpackResult {
+        let indexURL: URL
+        let title: String?
+        /// Archive-relative POSIX path to a hero image resolved from the
+        /// unpacked index (e.g. `"images/cover.jpg"`). Nil when no usable
+        /// candidate is found. Callers that want a URL for this image should
+        /// prefix with `stower-archive:` for sync storage, or resolve against
+        /// `AssetArchiver.archiveDirectory(for:)` for local rendering.
+        let heroImageRelativePath: String?
+        let entryCount: Int
+        let uncompressedBytes: Int64
+    }
+
+    /// Scheme prefix used by the library thumbnail resolver to route a
+    /// hero-image reference back to a file on disk. The remainder of the URL
+    /// is a path relative to the item's archive root, so the same value
+    /// syncs across devices without pinning to any single device's Documents
+    /// directory.
+    static let heroArchiveURLScheme = "stower-archive"
+
+    enum UnpackError: Error, LocalizedError, CustomStringConvertible {
+        case cannotOpenArchive
+        case pathTraversal(String)
+        case uncompressedSizeExceeded(Int64)
+        case noIndexHTML
+        case writeFailed(entryPath: String, underlying: Error)
+
+        var description: String {
+            switch self {
+            case .cannotOpenArchive:
+                return "The zip file could not be opened. It may be corrupt or password-protected."
+            case .pathTraversal(let path):
+                return "The zip contains an unsafe entry path (\(path)). Import aborted."
+            case .uncompressedSizeExceeded(let cap):
+                return "The zip's contents exceed the \(cap / 1_048_576) MB uncompressed limit."
+            case .noIndexHTML:
+                return "The zip does not contain an index.html at its root or one folder deep."
+            case .writeFailed(let entryPath, let underlying):
+                return "Failed to unpack \"\(entryPath)\": \(underlying.localizedDescription)"
+            }
+        }
+
+        var errorDescription: String? { description }
+    }
+
+    /// Unpacks `zipURL` into `destination`, which must be an empty directory
+    /// (or a path that does not yet exist). On any error, the destination is
+    /// removed so the caller sees a clean slate.
+    ///
+    /// - Parameters:
+    ///   - zipURL: Local file URL of the zip to unpack.
+    ///   - destination: Target directory for the archive root. Will be
+    ///     created if missing and wiped on any failure.
+    ///   - maxUncompressedBytes: Hard ceiling on total uncompressed bytes.
+    ///     Typical values: 400 MB for a 200 MB compressed cap.
+    static func unpack(
+        zipAt zipURL: URL,
+        into destination: URL,
+        maxUncompressedBytes: Int64 = 400 * 1_048_576
+    ) throws -> UnpackResult {
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: destination.path) {
+            try fileManager.removeItem(at: destination)
+        }
+        try fileManager.createDirectory(at: destination, withIntermediateDirectories: true)
+
+        let archive: Archive
+        do {
+            archive = try Archive(url: zipURL, accessMode: .read)
+        } catch {
+            try? fileManager.removeItem(at: destination)
+            throw UnpackError.cannotOpenArchive
+        }
+
+        var uncompressedTotal: Int64 = 0
+        var entryCount = 0
+
+        var currentEntryPath = ""
+        do {
+            for entry in archive {
+                currentEntryPath = entry.path
+
+                // Skip macOS Finder "Compress" metadata — these entries are
+                // never needed by the site itself and often have quirky paths
+                // (AppleDouble `._` files, nested `__MACOSX/` mirrors) that
+                // can trip extraction on case-sensitive or sandboxed volumes.
+                if entry.path.hasPrefix("__MACOSX/")
+                    || entry.path.split(separator: "/").last?.hasPrefix("._") == true {
+                    continue
+                }
+
+                // Traversal defense: the only ways a zip entry can write
+                // outside `destination` are via `..` segments or an
+                // absolute path. Reject both here before we touch the
+                // filesystem. String-based prefix comparisons against
+                // `standardizedFileURL.path` aren't reliable — macOS and
+                // iOS resolve `/var` ↔ `/private/var` symlinks
+                // inconsistently depending on whether the URL points at an
+                // existing path, so a check that passes on one platform
+                // flags a legitimate `guide/` entry on the other.
+                let segments = entry.path.split(separator: "/", omittingEmptySubsequences: true)
+                if entry.path.hasPrefix("/") || segments.contains(where: { $0 == ".." }) {
+                    throw UnpackError.pathTraversal(entry.path)
+                }
+                let resolvedURL = resolvedEntryURL(entry: entry.path, in: destination)
+
+                switch entry.type {
+                case .directory:
+                    try fileManager.createDirectory(
+                        at: resolvedURL,
+                        withIntermediateDirectories: true
+                    )
+                case .symlink:
+                    // Silently skipped. Logged for post-mortems.
+                    kUnpackerLog.info("Skipping symlink entry: \(entry.path, privacy: .public)")
+                case .file:
+                    let projectedSize = uncompressedTotal + Int64(entry.uncompressedSize)
+                    if projectedSize > maxUncompressedBytes {
+                        throw UnpackError.uncompressedSizeExceeded(maxUncompressedBytes)
+                    }
+                    try fileManager.createDirectory(
+                        at: resolvedURL.deletingLastPathComponent(),
+                        withIntermediateDirectories: true
+                    )
+                    _ = try archive.extract(entry, to: resolvedURL)
+                    uncompressedTotal += Int64(entry.uncompressedSize)
+                    entryCount += 1
+                }
+            }
+        } catch let error as UnpackError {
+            try? fileManager.removeItem(at: destination)
+            throw error
+        } catch {
+            kUnpackerLog.error(
+                "Unpack failed on entry \(currentEntryPath, privacy: .public): \(String(reflecting: error), privacy: .public)"
+            )
+            try? fileManager.removeItem(at: destination)
+            throw UnpackError.writeFailed(entryPath: currentEntryPath, underlying: error)
+        }
+
+        // Resolve the entry point without moving files around. The reader
+        // serves the archive directly through `LocalArchiveServer`, so a
+        // nested `guide/index.html` is loaded from `http://localhost/guide/`
+        // and the HTML's own relative paths (including `../sibling/...`
+        // references) resolve against that base URL exactly the way they
+        // did in the browser the author tested in.
+        let indexURL: URL
+        do {
+            indexURL = try locateIndex(in: destination)
+        } catch {
+            try? fileManager.removeItem(at: destination)
+            throw error
+        }
+
+        let title = extractTitle(from: indexURL)
+        let heroRelativePath = extractHeroImageRelativePath(
+            indexURL: indexURL,
+            archiveRoot: destination
+        )
+
+        return UnpackResult(
+            indexURL: indexURL,
+            title: title,
+            heroImageRelativePath: heroRelativePath,
+            entryCount: entryCount,
+            uncompressedBytes: uncompressedTotal
+        )
+    }
+
+    /// Scans the given index HTML for a hero image and returns its path
+    /// relative to `archiveRoot`. Only references that resolve to a file
+    /// already unpacked inside the archive are returned — absolute `https://`
+    /// URLs, protocol-relative `//…` URLs, and `data:` URIs are skipped
+    /// because they defeat the whole point of offline archival.
+    ///
+    /// Detection order:
+    ///   1. `<meta property="og:image">`
+    ///   2. `<meta name="twitter:image">`
+    ///   3. `<link rel="apple-touch-icon">` (usually 180×180)
+    ///   4. First `<img>` tag's `src`
+    static func extractHeroImageRelativePath(
+        indexURL: URL,
+        archiveRoot: URL
+    ) -> String? {
+        guard let html = try? String(contentsOf: indexURL, encoding: .utf8) else {
+            return nil
+        }
+        return extractHeroImageRelativePath(
+            fromHTML: html,
+            indexURL: indexURL,
+            archiveRoot: archiveRoot
+        )
+    }
+
+    /// Pure-string variant exposed for testing. `indexURL` is used as the
+    /// base when resolving relative `src`/`content` values, so it should
+    /// point at where the HTML lives inside `archiveRoot`.
+    static func extractHeroImageRelativePath(
+        fromHTML html: String,
+        indexURL: URL,
+        archiveRoot: URL
+    ) -> String? {
+        let scrubbed = stripSVGBlocks(in: html)
+        let candidates: [String?] = [
+            firstMatch(
+                in: scrubbed,
+                pattern: #"<meta[^>]+property\s*=\s*["']og:image["'][^>]*content\s*=\s*["']([^"']+)["'][^>]*>"#
+            ),
+            firstMatch(
+                in: scrubbed,
+                pattern: #"<meta[^>]+content\s*=\s*["']([^"']+)["'][^>]*property\s*=\s*["']og:image["'][^>]*>"#
+            ),
+            firstMatch(
+                in: scrubbed,
+                pattern: #"<meta[^>]+name\s*=\s*["']twitter:image["'][^>]*content\s*=\s*["']([^"']+)["'][^>]*>"#
+            ),
+            firstMatch(
+                in: scrubbed,
+                pattern: #"<link[^>]+rel\s*=\s*["']apple-touch-icon["'][^>]*href\s*=\s*["']([^"']+)["'][^>]*>"#
+            ),
+            firstMatch(
+                in: scrubbed,
+                pattern: #"<img[^>]+src\s*=\s*["']([^"']+)["'][^>]*>"#
+            ),
+        ]
+
+        for candidate in candidates {
+            guard let raw = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !raw.isEmpty
+            else { continue }
+
+            // Reject anything that can't resolve to a local file.
+            if raw.hasPrefix("data:") { continue }
+            if raw.hasPrefix("//") { continue }
+            if raw.lowercased().hasPrefix("http://") { continue }
+            if raw.lowercased().hasPrefix("https://") { continue }
+
+            // Drop any query/fragment — they're irrelevant for file lookup
+            // and often carry cache-busting hashes that would never match
+            // what's actually on disk.
+            let withoutQuery = raw
+                .components(separatedBy: "?").first ?? raw
+            let pathOnly = withoutQuery
+                .components(separatedBy: "#").first ?? withoutQuery
+
+            let resolved = URL(
+                fileURLWithPath: pathOnly,
+                relativeTo: indexURL
+            ).standardizedFileURL
+
+            let rootPath = archiveRoot.standardizedFileURL.path
+            guard
+                resolved.path == rootPath
+                    || resolved.path.hasPrefix(rootPath + "/"),
+                FileManager.default.fileExists(atPath: resolved.path)
+            else { continue }
+
+            let relative = String(resolved.path.dropFirst(rootPath.count + 1))
+            if relative.isEmpty { continue }
+            return relative
+        }
+
+        return nil
+    }
+
+    /// Finds the archive's entry HTML. Returns whichever of
+    /// `index.html`/`index.htm` sits at the root, or — failing that — the
+    /// shallowest match in a breadth-first walk up to `maxSearchDepth`
+    /// levels. The on-disk layout is left unchanged; callers that need to
+    /// serve the archive over HTTP use `relativePath(of:in:)` to derive the
+    /// URL path the reader should load.
+    ///
+    /// Nested entries are common in zips exported by authoring tools (a
+    /// single top-level "site" folder) and in zips whose HTML uses
+    /// `../sibling/...` references — promoting would silently break those
+    /// references, so we keep the tree intact and let the archive server
+    /// serve whatever the file's own paths already work against.
+    /// Public lookup used by the reader to discover where the archive's
+    /// entry HTML actually lives on disk. Returns the nested or root
+    /// `index.html`/`index.htm`, or nil if the archive doesn't contain one.
+    static func findEntryURL(in root: URL) -> URL? {
+        try? locateIndex(in: root)
+    }
+
+    private static func locateIndex(in root: URL) throws -> URL {
+        let fileManager = FileManager.default
+        let rootIndex = root.appendingPathComponent("index.html")
+        if fileManager.fileExists(atPath: rootIndex.path) {
+            return rootIndex
+        }
+        let rootIndexHTM = root.appendingPathComponent("index.htm")
+        if fileManager.fileExists(atPath: rootIndexHTM.path) {
+            return rootIndexHTM
+        }
+
+        guard let found = breadthFirstSearchIndex(in: root, maxDepth: 4) else {
+            throw UnpackError.noIndexHTML
+        }
+        return found
+    }
+
+    /// Builds the absolute URL for a zip entry by appending each POSIX path
+    /// segment one at a time. Single-argument `appendingPathComponent` has
+    /// historically had subtle differences between platforms around how
+    /// multi-segment strings (`"a/b/c"`), trailing slashes, and embedded
+    /// slashes are handled — some platforms percent-encode the slash, some
+    /// split on it, some preserve a trailing `/` in `.path`, some don't.
+    /// Walking segment-by-segment sidesteps all of that.
+    static func resolvedEntryURL(entry path: String, in destination: URL) -> URL {
+        let segments = path.split(separator: "/", omittingEmptySubsequences: true)
+        var url = destination
+        for segment in segments {
+            url = url.appendingPathComponent(String(segment))
+        }
+        return url
+    }
+
+    /// POSIX-style path of `url` relative to `root` (e.g., `"guide/index.html"`).
+    /// Returns nil if `url` does not live inside `root`. Exposed so the reader
+    /// can build the URL path to load from `LocalArchiveServer`.
+    static func relativePath(of url: URL, in root: URL) -> String? {
+        let rootPath = root.standardizedFileURL.path
+        let urlPath = url.standardizedFileURL.path
+        guard urlPath.hasPrefix(rootPath + "/") else { return nil }
+        return String(urlPath.dropFirst(rootPath.count + 1))
+    }
+
+    /// Breadth-first walk for the shallowest `index.html`/`index.htm` inside
+    /// `root`. Returns the file URL or nil if none is found within `maxDepth`
+    /// directory levels.
+    private static func breadthFirstSearchIndex(in root: URL, maxDepth: Int) -> URL? {
+        let fileManager = FileManager.default
+        var queue: [(url: URL, depth: Int)] = [(root, 0)]
+        while !queue.isEmpty {
+            let (dir, depth) = queue.removeFirst()
+            let children = (try? fileManager.contentsOfDirectory(
+                at: dir,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )) ?? []
+
+            // Files first at this level — any `index.html`/`index.htm` wins.
+            for child in children {
+                let name = child.lastPathComponent.lowercased()
+                if name == "index.html" || name == "index.htm" {
+                    let isDir = (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+                    if !isDir { return child }
+                }
+            }
+
+            if depth >= maxDepth { continue }
+
+            for child in children {
+                let isDir = (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+                if isDir { queue.append((child, depth + 1)) }
+            }
+        }
+        return nil
+    }
+
+    /// Extracts a human-readable title from the given HTML file. Tries, in
+    /// order: `<head><title>`, `<meta property="og:title">`, the first
+    /// `<h1>`. `<svg><title>` blocks and any tag nested inside `<svg>…</svg>`
+    /// are ignored so accent icon titles don't win. Returns nil if none of
+    /// these resolve to non-empty text.
+    static func extractTitle(from indexURL: URL) -> String? {
+        guard
+            let html = try? String(contentsOf: indexURL, encoding: .utf8)
+        else {
+            return nil
+        }
+        return extractTitle(fromHTML: html)
+    }
+
+    /// Pure-string variant of `extractTitle(from:)` — exposed for testing and
+    /// for callers that have the HTML already loaded.
+    static func extractTitle(fromHTML html: String) -> String? {
+        // Strip <svg>…</svg> blocks first so their nested <title> tags never
+        // masquerade as the page title. Regexes over HTML are a known trap;
+        // for this narrow purpose a single-level strip is sufficient.
+        let scrubbed = stripSVGBlocks(in: html)
+
+        if let title = firstMatch(
+            in: scrubbed,
+            pattern: #"<title[^>]*>([\s\S]*?)</title>"#
+        ) {
+            return clean(title)
+        }
+
+        if let ogTitle = firstMatch(
+            in: scrubbed,
+            pattern: #"<meta[^>]+property\s*=\s*["']og:title["'][^>]*content\s*=\s*["']([^"']+)["'][^>]*>"#
+        ) ?? firstMatch(
+            in: scrubbed,
+            pattern: #"<meta[^>]+content\s*=\s*["']([^"']+)["'][^>]*property\s*=\s*["']og:title["'][^>]*>"#
+        ) {
+            return clean(ogTitle)
+        }
+
+        if let h1 = firstMatch(
+            in: scrubbed,
+            pattern: #"<h1[^>]*>([\s\S]*?)</h1>"#
+        ) {
+            // Strip any HTML tags inside the <h1> before cleaning so things
+            // like `<h1><span>Title</span></h1>` don't bleed markup into the
+            // library card.
+            let stripped = h1.replacingOccurrences(
+                of: #"<[^>]+>"#,
+                with: "",
+                options: .regularExpression
+            )
+            return clean(stripped)
+        }
+
+        return nil
+    }
+
+    private static func firstMatch(in html: String, pattern: String) -> String? {
+        guard
+            let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]),
+            let match = regex.firstMatch(
+                in: html,
+                range: NSRange(html.startIndex..., in: html)
+            ),
+            match.numberOfRanges >= 2,
+            let range = Range(match.range(at: 1), in: html)
+        else {
+            return nil
+        }
+        return String(html[range])
+    }
+
+    private static func stripSVGBlocks(in html: String) -> String {
+        guard
+            let regex = try? NSRegularExpression(
+                pattern: #"<svg[\s\S]*?</svg>"#,
+                options: [.caseInsensitive]
+            )
+        else { return html }
+        let range = NSRange(html.startIndex..., in: html)
+        return regex.stringByReplacingMatches(
+            in: html,
+            range: range,
+            withTemplate: ""
+        )
+    }
+
+    private static func clean(_ raw: String) -> String? {
+        let unescaped = raw
+            .replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#39;", with: "'")
+            .replacingOccurrences(of: "&apos;", with: "'")
+            .replacingOccurrences(of: "&nbsp;", with: " ")
+        // Collapse runs of whitespace (common in multi-line <h1>s).
+        let collapsed = unescaped
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return collapsed.isEmpty ? nil : collapsed
+    }
+}

--- a/StowerPackage/Sources/StowerFeatureV2/Support/WebsiteImportService.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/WebsiteImportService.swift
@@ -34,7 +34,7 @@ enum WebsiteImportService {
             switch self {
             case .sizeCapExceeded(let cap):
                 return "The website archive is larger than the \(cap / 1_048_576) MB limit."
-            case .incompleteAsset(let expected, let received, let byteCount):
+            case let .incompleteAsset(expected, received, byteCount):
                 return "Website archive is still downloading (\(byteCount) bytes, expected sha256 \(expected.prefix(8)), got \(received.prefix(8)))."
             }
         }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/WebsiteImportService.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/WebsiteImportService.swift
@@ -1,0 +1,212 @@
+import CryptoKit
+import Foundation
+import OSLog
+import StowerData
+
+private let kWebsiteImportLog = Logger(
+    subsystem: "com.ryanleewilliams.stower",
+    category: "WebsiteImport"
+)
+
+/// Shared entry points for bringing a user-uploaded website zip into the
+/// library. Used by both the in-app file importer (inline, foreground) and
+/// the ingestion job processor (on sync hydration or after share-extension
+/// enqueue). Keeping the implementation here lets the two call sites share
+/// the same size caps, unpack rules, and title-resolution behaviour.
+enum WebsiteImportService {
+    /// Hard ceiling on the compressed zip size users can import.
+    static let maxCompressedBytes: Int64 = 200 * 1_048_576
+    /// Ceiling on total uncompressed bytes during unpack. Generous relative
+    /// to the compressed cap so legitimately compressible sites pass, but
+    /// bounded to defuse zip bombs.
+    static let maxUncompressedBytes: Int64 = 400 * 1_048_576
+
+    enum ImportError: Error, LocalizedError {
+        case sizeCapExceeded(Int64)
+        /// The zip bytes pulled from the CloudKit-synced archive table
+        /// don't match the origin device's stored SHA-256. Typically this
+        /// means the CKAsset hasn't finished downloading and we're reading
+        /// a stale/partial blob. The hydrator should skip and try again on
+        /// the next sync tick instead of unpacking broken data.
+        case incompleteAsset(expected: String, received: String, byteCount: Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .sizeCapExceeded(let cap):
+                return "The website archive is larger than the \(cap / 1_048_576) MB limit."
+            case .incompleteAsset(let expected, let received, let byteCount):
+                return "Website archive is still downloading (\(byteCount) bytes, expected sha256 \(expected.prefix(8)), got \(received.prefix(8)))."
+            }
+        }
+    }
+
+    /// Runs the full import for a zip that already lives on disk:
+    ///   * Reads and hashes the bytes.
+    ///   * Creates a `.webView` item with a filename-derived placeholder title.
+    ///   * Unpacks into the item's archive directory.
+    ///   * Updates the title from the extracted `<title>` tag when present.
+    ///   * Persists the zip bytes into the CloudKit-synced archive table.
+    /// Returns the resulting item so the caller can open it immediately.
+    static func importWebsite(
+        zipURL: URL,
+        repository: StowerRepository
+    ) async throws -> SavedItem {
+        let attrs = try FileManager.default.attributesOfItem(atPath: zipURL.path)
+        let fileSize = (attrs[.size] as? NSNumber)?.int64Value ?? 0
+        guard fileSize <= maxCompressedBytes else {
+            throw ImportError.sizeCapExceeded(maxCompressedBytes)
+        }
+
+        let zipData = try Data(contentsOf: zipURL)
+        let digest = SHA256.hash(data: zipData)
+        let sha256 = digest.map { String(format: "%02x", $0) }.joined()
+
+        let filename = zipURL.lastPathComponent
+        let fallbackTitle = zipURL.deletingPathExtension().lastPathComponent
+            .replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: "-", with: " ")
+
+        // Unpack into a scratch staging directory FIRST, before the DB row
+        // exists. This lets us create the item with the final title and
+        // hero image in a single `createItemFromIngestion` call, instead of
+        // a create→update dance. The update path uses raw SQL that bypasses
+        // SQLiteData's per-field change tracking, so a CloudKit echo of the
+        // original create would revert our updated metadata — observed in
+        // the logs as `Metadata updated title=Archive hero=<nil>` even
+        // though the unpacker extracted correct values. Single-create
+        // threads the real values through SQLiteData's sync tracking and
+        // uploads them as the authoritative first version.
+        let staging = FileManager.default.temporaryDirectory
+            .appendingPathComponent("StowerWebsiteStaging", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: staging) }
+
+        let unpack = try WebsiteArchiveUnpacker.unpack(
+            zipAt: zipURL,
+            into: staging,
+            maxUncompressedBytes: maxUncompressedBytes
+        )
+
+        let stagedRelativeIndex = WebsiteArchiveUnpacker.relativePath(
+            of: unpack.indexURL,
+            in: staging
+        ) ?? "<unknown>"
+        kWebsiteImportLog.info(
+            "Unpacked entries=\(unpack.entryCount, privacy: .public) index=\(stagedRelativeIndex, privacy: .public) title=\(unpack.title ?? "<nil>", privacy: .public) hero=\(unpack.heroImageRelativePath ?? "<nil>", privacy: .public) size=\(fileSize, privacy: .public)"
+        )
+
+        let resolvedTitle = unpack.title ?? fallbackTitle
+        let heroURL = unpack.heroImageRelativePath.map {
+            "\(WebsiteArchiveUnpacker.heroArchiveURLScheme):\($0)"
+        }
+
+        let item = try await repository.createItemFromIngestion(
+            .importedWebsite(
+                title: resolvedTitle,
+                filename: filename,
+                heroImageURL: heroURL
+            )
+        )
+        kWebsiteImportLog.info(
+            "Created item \(item.id.uuidString, privacy: .public) title=\(item.title, privacy: .public) hero=\(item.heroImageURL ?? "<nil>", privacy: .public)"
+        )
+
+        // Move the staged archive to its permanent location keyed by the
+        // just-assigned item ID. Same-filesystem renames are cheap even for
+        // large archives.
+        let archiveDir = AssetArchiver.archiveDirectory(for: item.id)
+        if FileManager.default.fileExists(atPath: archiveDir.path) {
+            try FileManager.default.removeItem(at: archiveDir)
+        }
+        try FileManager.default.createDirectory(
+            at: archiveDir.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.moveItem(at: staging, to: archiveDir)
+
+        try await repository.saveWebsiteArchive(item.id, zipData, sha256, filename)
+        kWebsiteImportLog.info(
+            "Import complete \(item.id.uuidString, privacy: .public)"
+        )
+        return item
+    }
+
+    /// Receive-side unpack. The zip bytes and the item's title/hero come
+    /// in from CloudKit; all we need to do here is materialize the unpacked
+    /// archive on disk and tell the local content table that this item is
+    /// a `.webView` archive that's ready to read. The CloudKit-synced
+    /// `SavedItemSyncTable` row doesn't carry `renderFormat`, which lives
+    /// in the local-only content table — so without this local write the
+    /// reader would keep treating the item as `.structuredV1` and the
+    /// Download button would loop back to the same prompt forever.
+    ///
+    /// Defensive flow:
+    ///   1. Verify the blob we read locally hashes to the stored SHA-256.
+    ///      Mismatches mean the CKAsset is mid-download — throw and let
+    ///      the next sync tick retry instead of unpacking garbage.
+    ///   2. Write the zip and unpack into a scratch staging directory, not
+    ///      directly into the archive directory. Mid-unpack failures are
+    ///      contained to the scratch area and can't leave a partial archive
+    ///      in its final location.
+    ///   3. Only once the unpack reports success, atomically swap the
+    ///      staged tree into the permanent archive directory.
+    ///   4. Hydrate the local content row so the reader recognises the
+    ///      item as a renderable webView archive.
+    static func hydrateWebsite(
+        itemID: UUID,
+        archive: WebsiteArchiveBytes,
+        repository: StowerRepository
+    ) async throws {
+        let received = SHA256.hash(data: archive.zipData)
+            .map { String(format: "%02x", $0) }
+            .joined()
+        if !archive.sha256.isEmpty, received != archive.sha256 {
+            throw ImportError.incompleteAsset(
+                expected: archive.sha256,
+                received: received,
+                byteCount: archive.zipData.count
+            )
+        }
+
+        let scratchRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("StowerWebsiteHydrate", isDirectory: true)
+            .appendingPathComponent(itemID.uuidString, isDirectory: true)
+        try? FileManager.default.removeItem(at: scratchRoot)
+        try FileManager.default.createDirectory(
+            at: scratchRoot,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: scratchRoot) }
+
+        let filename = archive.originalFilename.isEmpty
+            ? "site.zip"
+            : archive.originalFilename
+        let zipURL = scratchRoot.appendingPathComponent(filename)
+        try archive.zipData.write(to: zipURL, options: .atomic)
+
+        let stagingDir = scratchRoot.appendingPathComponent("unpacked", isDirectory: true)
+        _ = try WebsiteArchiveUnpacker.unpack(
+            zipAt: zipURL,
+            into: stagingDir,
+            maxUncompressedBytes: maxUncompressedBytes
+        )
+
+        let archiveDir = AssetArchiver.archiveDirectory(for: itemID)
+        if FileManager.default.fileExists(atPath: archiveDir.path) {
+            try FileManager.default.removeItem(at: archiveDir)
+        }
+        try FileManager.default.createDirectory(
+            at: archiveDir.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.moveItem(at: stagingDir, to: archiveDir)
+
+        try await repository.hydrateItemContent(
+            itemID,
+            .importedWebsite(
+                title: archive.originalFilename,
+                filename: archive.originalFilename
+            )
+        )
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/WebsiteArchiveUnpackerTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/WebsiteArchiveUnpackerTests.swift
@@ -18,8 +18,8 @@ struct WebsiteArchiveUnpackerTests {
 
         let zip = scratch.appendingPathComponent("site.zip")
         try buildZip(at: zip, entries: [
-            "index.html": Data("<html><head><title>Hello</title></head></html>".utf8),
-            "style.css": Data("body{}".utf8),
+            ("index.html", Data("<html><head><title>Hello</title></head></html>".utf8)),
+            ("style.css", Data("body{}".utf8)),
         ])
 
         let destination = scratch.appendingPathComponent("archive")
@@ -40,8 +40,8 @@ struct WebsiteArchiveUnpackerTests {
 
         let zip = scratch.appendingPathComponent("nested.zip")
         try buildZip(at: zip, entries: [
-            "MyGuide/index.html": Data("<html><title>Guide</title></html>".utf8),
-            "MyGuide/assets/app.js": Data("console.log('hi')".utf8),
+            ("MyGuide/index.html", Data("<html><title>Guide</title></html>".utf8)),
+            ("MyGuide/assets/app.js", Data("console.log('hi')".utf8)),
         ])
 
         let destination = scratch.appendingPathComponent("archive")
@@ -71,13 +71,13 @@ struct WebsiteArchiveUnpackerTests {
 
         let zip = scratch.appendingPathComponent("parent-relative.zip")
         try buildZip(at: zip, entries: [
-            "guide/index.html": Data("""
+            ("guide/index.html", Data("""
             <html><head>
               <title>Here Where We Live</title>
               <meta property="og:image" content="../guide-assets/cover.jpg">
             </head></html>
-            """.utf8),
-            "guide-assets/cover.jpg": Data(repeating: 0x11, count: 16),
+            """.utf8)),
+            ("guide-assets/cover.jpg", Data(repeating: 0x11, count: 16)),
         ])
 
         let destination = scratch.appendingPathComponent("archive")
@@ -94,7 +94,7 @@ struct WebsiteArchiveUnpackerTests {
 
         let zip = scratch.appendingPathComponent("no-title.zip")
         try buildZip(at: zip, entries: [
-            "index.html": Data("<html><body>no title</body></html>".utf8),
+            ("index.html", Data("<html><body>no title</body></html>".utf8)),
         ])
 
         let destination = scratch.appendingPathComponent("archive")
@@ -166,7 +166,7 @@ struct WebsiteArchiveUnpackerTests {
 
         let zip = scratch.appendingPathComponent("entities.zip")
         try buildZip(at: zip, entries: [
-            "index.html": Data("<html><title>Ben &amp; Jerry&#39;s</title></html>".utf8),
+            ("index.html", Data("<html><title>Ben &amp; Jerry&#39;s</title></html>".utf8)),
         ])
 
         let destination = scratch.appendingPathComponent("archive")
@@ -184,13 +184,13 @@ struct WebsiteArchiveUnpackerTests {
 
         let zip = scratch.appendingPathComponent("og.zip")
         try buildZip(at: zip, entries: [
-            "index.html": Data("""
+            ("index.html", Data("""
             <html><head>
               <title>t</title>
               <meta property="og:image" content="images/cover.jpg">
             </head></html>
-            """.utf8),
-            "images/cover.jpg": Data(repeating: 0xAB, count: 16),
+            """.utf8)),
+            ("images/cover.jpg", Data(repeating: 0xAB, count: 16)),
         ])
 
         let destination = scratch.appendingPathComponent("archive")
@@ -205,12 +205,12 @@ struct WebsiteArchiveUnpackerTests {
 
         let zip = scratch.appendingPathComponent("img.zip")
         try buildZip(at: zip, entries: [
-            "index.html": Data("""
+            ("index.html", Data("""
             <html><body>
               <img src="cover.png" alt="cover">
             </body></html>
-            """.utf8),
-            "cover.png": Data(repeating: 0xCD, count: 16),
+            """.utf8)),
+            ("cover.png", Data(repeating: 0xCD, count: 16)),
         ])
 
         let destination = scratch.appendingPathComponent("archive")
@@ -225,11 +225,11 @@ struct WebsiteArchiveUnpackerTests {
 
         let zip = scratch.appendingPathComponent("absolute.zip")
         try buildZip(at: zip, entries: [
-            "index.html": Data("""
+            ("index.html", Data("""
             <html><head>
               <meta property="og:image" content="https://cdn.example.com/cover.jpg">
             </head></html>
-            """.utf8),
+            """.utf8)),
         ])
 
         let destination = scratch.appendingPathComponent("archive")
@@ -244,11 +244,11 @@ struct WebsiteArchiveUnpackerTests {
 
         let zip = scratch.appendingPathComponent("traversal-hero.zip")
         try buildZip(at: zip, entries: [
-            "index.html": Data("""
+            ("index.html", Data("""
             <html><head>
               <meta property="og:image" content="../../outside.jpg">
             </head></html>
-            """.utf8),
+            """.utf8)),
         ])
 
         let destination = scratch.appendingPathComponent("archive")
@@ -265,7 +265,7 @@ struct WebsiteArchiveUnpackerTests {
 
         let zip = scratch.appendingPathComponent("no-index.zip")
         try buildZip(at: zip, entries: [
-            "readme.txt": Data("just a readme".utf8),
+            ("readme.txt", Data("just a readme".utf8)),
         ])
 
         let destination = scratch.appendingPathComponent("archive")
@@ -282,8 +282,8 @@ struct WebsiteArchiveUnpackerTests {
 
         let zip = scratch.appendingPathComponent("evil.zip")
         try buildZip(at: zip, entries: [
-            "index.html": Data("<html><title>x</title></html>".utf8),
-            "../escaped.txt": Data("pwn".utf8),
+            ("index.html", Data("<html><title>x</title></html>".utf8)),
+            ("../escaped.txt", Data("pwn".utf8)),
         ])
 
         let destination = scratch.appendingPathComponent("archive")
@@ -306,8 +306,8 @@ struct WebsiteArchiveUnpackerTests {
         // 300 KB of 'A' bytes — will blow a 200 KB cap.
         let big = Data(repeating: UInt8(ascii: "A"), count: 300 * 1024)
         try buildZip(at: zip, entries: [
-            "index.html": Data("<html><title>t</title></html>".utf8),
-            "big.bin": big,
+            ("index.html", Data("<html><title>t</title></html>".utf8)),
+            ("big.bin", big),
         ])
 
         let destination = scratch.appendingPathComponent("archive")
@@ -333,7 +333,13 @@ struct WebsiteArchiveUnpackerTests {
 
     /// Builds a zip at `url` containing the given `path → bytes` entries.
     /// Each entry is compressed with the default compression method.
-    private func buildZip(at url: URL, entries: [String: Data]) throws {
+    ///
+    /// Entries arrive as an ordered tuple array rather than a `[String: Data]`
+    /// dictionary so callers don't have to keep the dictionary colons
+    /// visually aligned per the project's `collection_alignment` lint
+    /// (which is set to `align_colons: true`). Ordering also happens to be
+    /// predictable, which makes the extraction tests easier to reason about.
+    private func buildZip(at url: URL, entries: [(String, Data)]) throws {
         if FileManager.default.fileExists(atPath: url.path) {
             try FileManager.default.removeItem(at: url)
         }
@@ -342,13 +348,12 @@ struct WebsiteArchiveUnpackerTests {
             try archive.addEntry(
                 with: path,
                 type: .file,
-                uncompressedSize: Int64(data.count),
-                provider: { position, size -> Data in
-                    let start = Int(position)
-                    let end = min(start + size, data.count)
-                    return data.subdata(in: start..<end)
-                }
-            )
+                uncompressedSize: Int64(data.count)
+            ) { position, size -> Data in
+                let start = Int(position)
+                let end = min(start + size, data.count)
+                return data.subdata(in: start..<end)
+            }
         }
     }
 }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/WebsiteArchiveUnpackerTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/WebsiteArchiveUnpackerTests.swift
@@ -1,0 +1,354 @@
+import Foundation
+@testable import StowerFeature
+import Testing
+import ZIPFoundation
+
+/// Unit tests for `WebsiteArchiveUnpacker`. Zip fixtures are built at runtime
+/// via ZIPFoundation to keep the test target free of binary blobs. Each test
+/// gets its own scratch directory under the system temp dir so they can run
+/// in parallel safely.
+@Suite
+struct WebsiteArchiveUnpackerTests {
+    // MARK: - Happy paths
+
+    @Test
+    func unpack_withRootIndexHtml_extractsToRoot() throws {
+        let scratch = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let zip = scratch.appendingPathComponent("site.zip")
+        try buildZip(at: zip, entries: [
+            "index.html": Data("<html><head><title>Hello</title></head></html>".utf8),
+            "style.css": Data("body{}".utf8),
+        ])
+
+        let destination = scratch.appendingPathComponent("archive")
+        let result = try WebsiteArchiveUnpacker.unpack(zipAt: zip, into: destination)
+
+        #expect(result.indexURL == destination.appendingPathComponent("index.html"))
+        #expect(result.title == "Hello")
+        #expect(result.entryCount == 2)
+        #expect(FileManager.default.fileExists(
+            atPath: destination.appendingPathComponent("style.css").path
+        ))
+    }
+
+    @Test
+    func unpack_withSingleTopLevelFolder_leavesStructureIntact() throws {
+        let scratch = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let zip = scratch.appendingPathComponent("nested.zip")
+        try buildZip(at: zip, entries: [
+            "MyGuide/index.html": Data("<html><title>Guide</title></html>".utf8),
+            "MyGuide/assets/app.js": Data("console.log('hi')".utf8),
+        ])
+
+        let destination = scratch.appendingPathComponent("archive")
+        let result = try WebsiteArchiveUnpacker.unpack(zipAt: zip, into: destination)
+
+        // Entry points at the nested location; files are not moved so the
+        // HTML's own relative URLs (and sibling-folder `../` references
+        // common in authoring-tool exports) resolve exactly as authored.
+        #expect(
+            WebsiteArchiveUnpacker.relativePath(of: result.indexURL, in: destination)
+                == "MyGuide/index.html"
+        )
+        #expect(result.title == "Guide")
+        #expect(FileManager.default.fileExists(
+            atPath: destination.appendingPathComponent("MyGuide/assets/app.js").path
+        ))
+    }
+
+    @Test
+    func unpack_resolvesHeroImage_usingParentRelativeSrc() throws {
+        // Layout mirrors the real-world "Archive.zip" case: the index
+        // lives under `guide/` and references a hero image via
+        // `../guide-assets/...`. Without promoting, that path stays valid
+        // both on disk and in the running LocalArchiveServer.
+        let scratch = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let zip = scratch.appendingPathComponent("parent-relative.zip")
+        try buildZip(at: zip, entries: [
+            "guide/index.html": Data("""
+            <html><head>
+              <title>Here Where We Live</title>
+              <meta property="og:image" content="../guide-assets/cover.jpg">
+            </head></html>
+            """.utf8),
+            "guide-assets/cover.jpg": Data(repeating: 0x11, count: 16),
+        ])
+
+        let destination = scratch.appendingPathComponent("archive")
+        let result = try WebsiteArchiveUnpacker.unpack(zipAt: zip, into: destination)
+
+        #expect(result.title == "Here Where We Live")
+        #expect(result.heroImageRelativePath == "guide-assets/cover.jpg")
+    }
+
+    @Test
+    func unpack_missingTitleTag_returnsNilTitle() throws {
+        let scratch = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let zip = scratch.appendingPathComponent("no-title.zip")
+        try buildZip(at: zip, entries: [
+            "index.html": Data("<html><body>no title</body></html>".utf8),
+        ])
+
+        let destination = scratch.appendingPathComponent("archive")
+        let result = try WebsiteArchiveUnpacker.unpack(zipAt: zip, into: destination)
+
+        #expect(result.title == nil)
+    }
+
+    @Test
+    func extractTitle_fallsBackToOgTitle_whenHeadTitleMissing() {
+        let html = """
+        <html><head>
+          <meta property="og:title" content="Here Where We Live Is Our Country">
+        </head><body></body></html>
+        """
+        #expect(
+            WebsiteArchiveUnpacker.extractTitle(fromHTML: html)
+                == "Here Where We Live Is Our Country"
+        )
+    }
+
+    @Test
+    func extractTitle_fallsBackToH1_whenTitleAndOgMissing() {
+        let html = """
+        <html><body>
+          <h1><span>Here Where We Live Is Our Country</span></h1>
+        </body></html>
+        """
+        #expect(
+            WebsiteArchiveUnpacker.extractTitle(fromHTML: html)
+                == "Here Where We Live Is Our Country"
+        )
+    }
+
+    @Test
+    func extractTitle_ignoresSvgTitleTag() {
+        // A <title> inside <svg> is a tooltip for the icon, not the page.
+        let html = """
+        <html><head>
+          <svg><title>Menu icon</title></svg>
+          <title>Real Page Title</title>
+        </head></html>
+        """
+        #expect(
+            WebsiteArchiveUnpacker.extractTitle(fromHTML: html) == "Real Page Title"
+        )
+    }
+
+    @Test
+    func extractTitle_collapsesWhitespaceInH1() {
+        let html = """
+        <html><body>
+          <h1>
+            Here Where We Live
+            Is Our Country
+          </h1>
+        </body></html>
+        """
+        #expect(
+            WebsiteArchiveUnpacker.extractTitle(fromHTML: html)
+                == "Here Where We Live Is Our Country"
+        )
+    }
+
+    @Test
+    func unpack_entitiesInTitle_areUnescaped() throws {
+        let scratch = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let zip = scratch.appendingPathComponent("entities.zip")
+        try buildZip(at: zip, entries: [
+            "index.html": Data("<html><title>Ben &amp; Jerry&#39;s</title></html>".utf8),
+        ])
+
+        let destination = scratch.appendingPathComponent("archive")
+        let result = try WebsiteArchiveUnpacker.unpack(zipAt: zip, into: destination)
+
+        #expect(result.title == "Ben & Jerry's")
+    }
+
+    // MARK: - Hero image extraction
+
+    @Test
+    func unpack_populatesHeroImage_fromOgImage() throws {
+        let scratch = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let zip = scratch.appendingPathComponent("og.zip")
+        try buildZip(at: zip, entries: [
+            "index.html": Data("""
+            <html><head>
+              <title>t</title>
+              <meta property="og:image" content="images/cover.jpg">
+            </head></html>
+            """.utf8),
+            "images/cover.jpg": Data(repeating: 0xAB, count: 16),
+        ])
+
+        let destination = scratch.appendingPathComponent("archive")
+        let result = try WebsiteArchiveUnpacker.unpack(zipAt: zip, into: destination)
+        #expect(result.heroImageRelativePath == "images/cover.jpg")
+    }
+
+    @Test
+    func unpack_populatesHeroImage_fromFirstImg_whenMetaMissing() throws {
+        let scratch = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let zip = scratch.appendingPathComponent("img.zip")
+        try buildZip(at: zip, entries: [
+            "index.html": Data("""
+            <html><body>
+              <img src="cover.png" alt="cover">
+            </body></html>
+            """.utf8),
+            "cover.png": Data(repeating: 0xCD, count: 16),
+        ])
+
+        let destination = scratch.appendingPathComponent("archive")
+        let result = try WebsiteArchiveUnpacker.unpack(zipAt: zip, into: destination)
+        #expect(result.heroImageRelativePath == "cover.png")
+    }
+
+    @Test
+    func unpack_skipsAbsoluteHeroImage_asUnusableOffline() throws {
+        let scratch = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let zip = scratch.appendingPathComponent("absolute.zip")
+        try buildZip(at: zip, entries: [
+            "index.html": Data("""
+            <html><head>
+              <meta property="og:image" content="https://cdn.example.com/cover.jpg">
+            </head></html>
+            """.utf8),
+        ])
+
+        let destination = scratch.appendingPathComponent("archive")
+        let result = try WebsiteArchiveUnpacker.unpack(zipAt: zip, into: destination)
+        #expect(result.heroImageRelativePath == nil)
+    }
+
+    @Test
+    func unpack_rejectsHeroImage_thatEscapesArchiveRoot() throws {
+        let scratch = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let zip = scratch.appendingPathComponent("traversal-hero.zip")
+        try buildZip(at: zip, entries: [
+            "index.html": Data("""
+            <html><head>
+              <meta property="og:image" content="../../outside.jpg">
+            </head></html>
+            """.utf8),
+        ])
+
+        let destination = scratch.appendingPathComponent("archive")
+        let result = try WebsiteArchiveUnpacker.unpack(zipAt: zip, into: destination)
+        #expect(result.heroImageRelativePath == nil)
+    }
+
+    // MARK: - Rejection paths
+
+    @Test
+    func unpack_missingIndexHtml_throwsNoIndexHTML() throws {
+        let scratch = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let zip = scratch.appendingPathComponent("no-index.zip")
+        try buildZip(at: zip, entries: [
+            "readme.txt": Data("just a readme".utf8),
+        ])
+
+        let destination = scratch.appendingPathComponent("archive")
+        #expect(throws: WebsiteArchiveUnpacker.UnpackError.self) {
+            _ = try WebsiteArchiveUnpacker.unpack(zipAt: zip, into: destination)
+        }
+        #expect(!FileManager.default.fileExists(atPath: destination.path))
+    }
+
+    @Test
+    func unpack_pathTraversal_throwsAndLeavesNoResidue() throws {
+        let scratch = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let zip = scratch.appendingPathComponent("evil.zip")
+        try buildZip(at: zip, entries: [
+            "index.html": Data("<html><title>x</title></html>".utf8),
+            "../escaped.txt": Data("pwn".utf8),
+        ])
+
+        let destination = scratch.appendingPathComponent("archive")
+        #expect(throws: WebsiteArchiveUnpacker.UnpackError.self) {
+            _ = try WebsiteArchiveUnpacker.unpack(zipAt: zip, into: destination)
+        }
+        // Destination is wiped on any UnpackError.
+        #expect(!FileManager.default.fileExists(atPath: destination.path))
+        // The traversal target must not have been written.
+        let escaped = scratch.appendingPathComponent("escaped.txt")
+        #expect(!FileManager.default.fileExists(atPath: escaped.path))
+    }
+
+    @Test
+    func unpack_exceedingUncompressedCap_throws() throws {
+        let scratch = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let zip = scratch.appendingPathComponent("too-big.zip")
+        // 300 KB of 'A' bytes — will blow a 200 KB cap.
+        let big = Data(repeating: UInt8(ascii: "A"), count: 300 * 1024)
+        try buildZip(at: zip, entries: [
+            "index.html": Data("<html><title>t</title></html>".utf8),
+            "big.bin": big,
+        ])
+
+        let destination = scratch.appendingPathComponent("archive")
+        #expect(throws: WebsiteArchiveUnpacker.UnpackError.self) {
+            _ = try WebsiteArchiveUnpacker.unpack(
+                zipAt: zip,
+                into: destination,
+                maxUncompressedBytes: 200 * 1024
+            )
+        }
+        #expect(!FileManager.default.fileExists(atPath: destination.path))
+    }
+
+    // MARK: - Helpers
+
+    private func makeScratchDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WebsiteArchiveUnpackerTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    /// Builds a zip at `url` containing the given `path → bytes` entries.
+    /// Each entry is compressed with the default compression method.
+    private func buildZip(at url: URL, entries: [String: Data]) throws {
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
+        }
+        let archive = try Archive(url: url, accessMode: .create)
+        for (path, data) in entries {
+            try archive.addEntry(
+                with: path,
+                type: .file,
+                uncompressedSize: Int64(data.count),
+                provider: { position, size -> Data in
+                    let start = Int(position)
+                    let end = min(start + size, data.count)
+                    return data.subdata(in: start..<end)
+                }
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New ingestion path for user-supplied static website zips, routed through the existing `.webView` renderer + `LocalArchiveServer` (no new rendering layer needed).
- Zip bytes persist in a new CloudKit-synced table; SQLiteData promotes the blob to a CKAsset so the full site reaches every signed-in device.
- Title and hero-image thumbnail are extracted from `index.html` at import time and ride the synced item record, so the receiver shows the real metadata before the archive finishes downloading.
- Horizontal-pan lock on imported sites so interactive widgets (carousels, swipe menus) keep their gestures when the page already fits the viewport.
- Version bump to 0.3.0 (build 3).

## Data & migrations
- New `SavedWebsiteArchiveSyncTable` + migration v12, registered with the CloudKit SyncEngine.
- Migration v13 purges misplaced rows in `savedTextContentSyncTables` left by an earlier bug that mirrored every non-PDF item into the text sync table, which had been causing an echo loop on devices with imported websites.
- Scopes the text-sync mirror in `persistLocalContentAndCaches` to text-authored formats (`plainText`, `structuredV1`, `htmlFallback`) so webView items stay out of it going forward.

## Known gotchas for production
- CloudKit Production schema must include every new field on `savedWebsiteArchiveSyncTables`; Dev schemas don't auto-promote.
- 200 MB compressed / 400 MB uncompressed caps, silent to the user until hit (error messages are readable when they do).
- Users on the free 5 GB iCloud plan will consume meaningful quota per imported site.