### PR TITLE
Fix macOS reader focus crash for 0.4.1

### DIFF
--- a/Config/Shared.xcconfig
+++ b/Config/Shared.xcconfig
@@ -9,7 +9,7 @@
 PRODUCT_NAME = Stower
 PRODUCT_DISPLAY_NAME = Stower
 PRODUCT_BUNDLE_IDENTIFIER = com.ryanleewilliams.stower
-MARKETING_VERSION = 0.4.0
+MARKETING_VERSION = 0.4.1
 CURRENT_PROJECT_VERSION = 10
 
 // ==========================================

--- a/StowerPackage/Sources/StowerFeatureV2/ContentView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/ContentView.swift
@@ -78,24 +78,11 @@ public struct ReaderCommands: Commands {
 }
 #endif
 
-#if os(macOS)
-private enum MacReaderPlacement: Equatable {
-    case split
-    case detached
-    case focused
-}
-#endif
-
 public struct AppView: View {
     @Bindable var store: StoreOf<AppFeature>
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
     @State private var previousColumnVisibility: NavigationSplitViewVisibility = .all
     @State private var readerSession = ReaderWebSession()
-    #if os(macOS)
-    @State private var macReaderPlacement = MacReaderPlacement.split
-    @State private var pendingMacReaderPlacement: MacReaderPlacement?
-    @State private var macReaderTransitionTask: Task<Void, Never>?
-    #endif
     #if os(iOS)
     @Environment(\.horizontalSizeClass)
     private var horizontalSizeClass
@@ -214,28 +201,6 @@ public struct AppView: View {
 
     @ViewBuilder
     private func navigationContainer(palette: FlexokiPalette) -> some View {
-        #if os(macOS)
-        Group {
-            switch macReaderPlacement {
-            case .focused:
-                if let readerStore = store.scope(\.reader, action: \.reader.presented) {
-                    readerSurface(
-                        readerStore,
-                        palette: palette,
-                        isFocused: true
-                    )
-                    .onDisappear(perform: macReaderSurfaceDidDisappear)
-                } else {
-                    splitNavigationView(palette: palette)
-                }
-            case .split, .detached:
-                splitNavigationView(palette: palette)
-            }
-        }
-        .onChange(of: store.isReaderFocused) { _, isFocused in
-            beginMacReaderTransition(isFocused: isFocused)
-        }
-        #else
         #if os(iOS)
         // On iPhone (compact), NavigationSplitView's detail column does not
         // reliably push when an `if let` swap toggles its content — taps on
@@ -268,42 +233,7 @@ public struct AppView: View {
         #else
         splitNavigationView(palette: palette)
         #endif
-        #endif
     }
-
-    #if os(macOS)
-    private func beginMacReaderTransition(isFocused: Bool) {
-        let target: MacReaderPlacement = isFocused ? .focused : .split
-        guard macReaderPlacement != target else { return }
-
-        macReaderTransitionTask?.cancel()
-        guard store.reader != nil else {
-            pendingMacReaderPlacement = nil
-            macReaderPlacement = .split
-            return
-        }
-
-        pendingMacReaderPlacement = target
-        macReaderPlacement = .detached
-    }
-
-    private func macReaderSurfaceDidDisappear() {
-        guard macReaderPlacement == .detached else { return }
-        macReaderTransitionTask?.cancel()
-        macReaderTransitionTask = Task { @MainActor in
-            // Wait until SwiftUI has removed the old native WebView before
-            // binding this session's WebPage to the destination WebView.
-            await Task.yield()
-            guard
-                !Task.isCancelled,
-                macReaderPlacement == .detached,
-                let pendingMacReaderPlacement
-            else { return }
-            self.pendingMacReaderPlacement = nil
-            macReaderPlacement = pendingMacReaderPlacement
-        }
-    }
-    #endif
 
     #if os(iOS)
     /// Modal sidebar presented from the iPhone library toolbar. Reuses the
@@ -361,19 +291,6 @@ public struct AppView: View {
             // `windowBackgroundColor` (white in light mode). We have to
             // explicitly expand the content to fill the column *before*
             // applying the background so the fill paints the entire pane.
-            #if os(macOS)
-            if macReaderPlacement == .split,
-               let readerStore = store.scope(\.reader, action: \.reader.presented) {
-                readerSurface(
-                    readerStore,
-                    palette: palette,
-                    isFocused: false
-                )
-                .onDisappear(perform: macReaderSurfaceDidDisappear)
-            } else {
-                macOSReaderPlaceholder(palette: palette)
-            }
-            #else
             if let readerStore = store.scope(\.reader, action: \.reader.presented) {
                 NavigationStack {
                     ReaderScreen(
@@ -393,9 +310,11 @@ public struct AppView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(palette.bg)
             }
-            #endif
         }
-        #if os(iOS)
+        // Keep the reader in one stable detail hierarchy. WebKit permits a
+        // WebPage to be bound to only one WebView at a time, so moving this
+        // screen into a second focus-mode hierarchy can trap while SwiftUI is
+        // still dismantling the first native view.
         .onChange(of: store.isReaderFocused) { _, isFocused in
             if isFocused {
                 previousColumnVisibility = columnVisibility
@@ -404,41 +323,5 @@ public struct AppView: View {
                 columnVisibility = previousColumnVisibility
             }
         }
-        #endif
     }
-
-    #if os(macOS)
-    @ViewBuilder
-    private func macOSReaderPlaceholder(palette: FlexokiPalette) -> some View {
-        Group {
-            if store.reader == nil {
-                ContentUnavailableView(
-                    "Select an Item",
-                    systemImage: "doc.text",
-                    description: Text("Choose an article from Library to read.")
-                )
-            } else {
-                Color.clear
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(palette.bg)
-    }
-
-    private func readerSurface(
-        _ readerStore: StoreOf<ReaderFeature>,
-        palette: FlexokiPalette,
-        isFocused: Bool
-    ) -> some View {
-        NavigationStack {
-            ReaderScreen(
-                store: readerStore,
-                session: readerSession,
-                isReaderFocused: isFocused
-            ) { store.send(.readerFocusButtonTapped) }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(palette.bg)
-    }
-    #endif
 }


### PR DESCRIPTION
## What changed

- Keep the macOS reader in one stable `NavigationSplitView` detail hierarchy.
- Enter and exit reader focus mode by changing column visibility instead of detaching and recreating the reader surface.
- Remove the timing-based `Task.yield()` transition and its temporary placement state.
- Bump the shared iOS/macOS marketing version from 0.4.0 to 0.4.1.

## Why

Build 11 crashed in `_WebKit_SwiftUI` while SwiftUI was creating a native `WebView`. WebKit permits a `WebPage` to be bound to only one `WebView`. Stower's focus transition reused the same `ReaderWebSession` in a second view hierarchy after only one task yield, which could run before SwiftUI dismantled the first native view and cleared WebKit's binding flag.

The new structure never moves the reader or binds its page to a second web view. Focus mode still hides the sidebar and library, while preserving the live page, reading position, and reader controls.

## Validation

- macOS app build with Xcode 27 beta 4
- generic iOS app build with Xcode 27 beta 4
- `swift test --package-path StowerPackage` — 241 tests passed
- `swiftlint lint --config .swiftlint.yml --strict --quiet`
