### PR TITLE
Fix reader WebPage ownership crash

### DIFF
--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderProgressClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderProgressClient.swift
@@ -36,6 +36,14 @@ public final class ReaderProgressCoordinator {
         self.currentPage = page
     }
 
+    /// Clears a page only if it is still the active registration. During a
+    /// SwiftUI transition an outgoing reader can disappear after the incoming
+    /// reader has registered, and must not clear the newer reader's page.
+    public func unregister(_ page: WebPage?) {
+        guard let page, currentPage === page else { return }
+        currentPage = nil
+    }
+
     public func topBlockIndex() async -> Int? {
         guard let currentPage else { return nil }
         return await ReaderWebPageFactory.fetchTopBlockIndex(on: currentPage)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
@@ -12,7 +12,7 @@ import WebKit
 /// failed to scale on large documents.
 public struct ReaderScreen: View {
     @Bindable var store: StoreOf<ReaderFeature>
-    @State private var session: ReaderWebSession
+    @Bindable private var session: ReaderWebSession
     @ScaledMetric(relativeTo: .body)
     private var dynamicBodySize: CGFloat = 19
     private let isReaderFocused: Bool
@@ -31,7 +31,7 @@ public struct ReaderScreen: View {
         onToggleReaderFocus: (() -> Void)? = nil
     ) {
         self.store = store
-        self._session = State(initialValue: session)
+        self.session = session
         self.isReaderFocused = isReaderFocused
         self.onToggleReaderFocus = onToggleReaderFocus
     }
@@ -399,7 +399,6 @@ public struct ReaderScreen: View {
                     contentVersion: contentReloadToken(for: item),
                     appearance: store.appearance,
                     fontScale: readerFontScale,
-                    session: session,
                     viewportWidth: store.viewportWidth,
                     isWebViewFormat: store.effectiveRenderFormat == .webView,
                     usesNativeCapture: item.captureVersion > 0,

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebSession.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebSession.swift
@@ -1,47 +1,22 @@
-import Foundation
 import Observation
-import WebKit
 
-/// Owns the live reader resources independently of transient SwiftUI updates.
-/// During the macOS focus transition the reader view explicitly detaches and
-/// reattaches, while this session keeps its page, archive server, restoration,
-/// and panel state stable.
+/// Owns reader controls that should remain stable across transient SwiftUI updates.
+///
+/// The live `WebPage` deliberately does not live here. A `WebPage` can be bound
+/// to only one native `WebView`, while a shared reader session can briefly be
+/// observed by more than one SwiftUI view during navigation transitions.
 @MainActor
 @Observable
 public final class ReaderWebSession {
-    struct LoadKey: Hashable {
-        let contentVersion: Int
-        let itemID: UUID
-    }
-
-    var archiveServer: LocalArchiveServer?
-    var hasRestoredPosition = false
     var isAIPanelPresented = false
     var isAppearancePanelPresented = false
     var isFindNavigatorPresented = false
     var isListenPanelPresented = false
     var isPDFViewerPresented = false
-    var loadKey: LoadKey?
-    var page: WebPage?
 
     public init() {}
 
-    func beginLoading(_ key: LoadKey) {
-        ReaderProgressCoordinator.shared.register(nil)
-        archiveServer?.stop()
-        archiveServer = nil
-        hasRestoredPosition = false
-        loadKey = key
-        page = nil
-    }
-
     func reset() {
-        ReaderProgressCoordinator.shared.register(nil)
-        archiveServer?.stop()
-        archiveServer = nil
-        hasRestoredPosition = false
-        loadKey = nil
-        page = nil
         isAIPanelPresented = false
         isAppearancePanelPresented = false
         isFindNavigatorPresented = false

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderWebView.swift
@@ -1,6 +1,43 @@
 import SwiftUI
 import WebKit
 
+/// Owns the native web resources for exactly one `ReaderWebView` identity.
+///
+/// WebKit traps if one `WebPage` is bound to two native `WebView` instances.
+/// Keeping this session private and view-owned prevents navigation and split-view
+/// transitions from sharing a page while SwiftUI dismantles the previous view.
+@MainActor
+@Observable
+private final class ReaderWebViewSession {
+    struct LoadKey: Hashable {
+        let contentVersion: Int
+        let itemID: UUID
+    }
+
+    var archiveServer: LocalArchiveServer?
+    var hasRestoredPosition = false
+    var loadKey: LoadKey?
+    var page: WebPage?
+
+    func beginLoading(_ key: LoadKey) {
+        ReaderProgressCoordinator.shared.unregister(page)
+        archiveServer?.stop()
+        archiveServer = nil
+        hasRestoredPosition = false
+        loadKey = key
+        page = nil
+    }
+
+    func reset() {
+        ReaderProgressCoordinator.shared.unregister(page)
+        archiveServer?.stop()
+        archiveServer = nil
+        hasRestoredPosition = false
+        loadKey = nil
+        page = nil
+    }
+}
+
 /// Renders articles in a WKWebView — the single rendering path for the reader.
 ///
 /// Two content sources are supported:
@@ -30,7 +67,7 @@ public struct ReaderWebView: View {
     let onOpenInlineEmbed: ((String) -> Void)?
     let onContentTap: (() -> Void)?
 
-    @State private var session: ReaderWebSession
+    @State private var session = ReaderWebViewSession()
     @Environment(\.openURL)
     private var openURL
 
@@ -41,7 +78,6 @@ public struct ReaderWebView: View {
         contentVersion: Int,
         appearance: ReaderAppearanceSettings,
         fontScale: Double = 1,
-        session: ReaderWebSession = ReaderWebSession(),
         viewportWidth: Double? = nil,
         isWebViewFormat: Bool = false,
         usesNativeCapture: Bool = false,
@@ -56,7 +92,6 @@ public struct ReaderWebView: View {
         self.contentVersion = contentVersion
         self.appearance = appearance
         self.fontScale = fontScale
-        self._session = State(initialValue: session)
         self.viewportWidth = viewportWidth
         self.isWebViewFormat = isWebViewFormat
         self.usesNativeCapture = usesNativeCapture
@@ -85,8 +120,8 @@ public struct ReaderWebView: View {
         // Keyed on item identity plus content version, not on the rendered
         // HTML bytes. Appearance changes update CSS live; they must not tear
         // down and recreate the whole WKWebView while the user drags a slider.
-        .task(id: ReaderWebSession.LoadKey(contentVersion: contentVersion, itemID: itemID)) {
-            loadContent()
+        .task(id: ReaderWebViewSession.LoadKey(contentVersion: contentVersion, itemID: itemID)) {
+            await loadContent()
         }
         .onChange(of: appearance) { _, newAppearance in
             updateCSS(newAppearance)
@@ -123,15 +158,15 @@ public struct ReaderWebView: View {
             runHighlight(newValue)
         }
         .onDisappear {
-            ReaderProgressCoordinator.shared.register(nil)
+            session.reset()
         }
     }
 
     // MARK: - Loading
 
     @MainActor
-    private func loadContent() {
-        let loadKey = ReaderWebSession.LoadKey(contentVersion: contentVersion, itemID: itemID)
+    private func loadContent() async {
+        let loadKey = ReaderWebViewSession.LoadKey(contentVersion: contentVersion, itemID: itemID)
         guard session.loadKey != loadKey || session.page == nil else {
             ReaderProgressCoordinator.shared.register(session.page)
             return
@@ -151,31 +186,66 @@ public struct ReaderWebView: View {
         let openEmbed = onOpenInlineEmbed ?? { _ in }
         let toggleChrome = onContentTap ?? {}
 
-        Task {
-            if let nativeArchiveURL,
-               let archiveData = try? Data(contentsOf: nativeArchiveURL, options: .mappedIfSafe) {
-                let newPage = ReaderWebPageFactory.makePage(
-                    openExternalURL: { [openURL] url in openURL(url) },
-                    openInlineEmbed: { openEmbed($0) },
-                    toggleChrome: { toggleChrome() }
-                )
-                let baseURL = currentSourceURL.flatMap(URL.init(string:)) ?? URL(string: "about:blank")!
-                _ = newPage.load(
-                    archiveData,
-                    mimeType: "application/x-webarchive",
-                    characterEncoding: .utf8,
-                    baseURL: baseURL
-                )
-                session.page = newPage
-            } else if isArchive {
-                let (loadURL, server) = await Self.prepareArchive(
-                    html: currentHTML,
-                    sourceURL: currentSourceURL,
-                    itemID: currentItemID,
-                    appearance: currentAppearance
-                )
-                guard let loadURL, let server else { return }
+        if let nativeArchiveURL,
+           let archiveData = try? Data(contentsOf: nativeArchiveURL, options: .mappedIfSafe) {
+            let newPage = ReaderWebPageFactory.makePage(
+                openExternalURL: { [openURL] url in openURL(url) },
+                openInlineEmbed: { openEmbed($0) },
+                toggleChrome: { toggleChrome() }
+            )
+            let baseURL = currentSourceURL.flatMap(URL.init(string:)) ?? URL(string: "about:blank")!
+            _ = newPage.load(
+                archiveData,
+                mimeType: "application/x-webarchive",
+                characterEncoding: .utf8,
+                baseURL: baseURL
+            )
+            guard Task.isCancelled == false, session.loadKey == loadKey else { return }
+            session.page = newPage
+        } else if isArchive {
+            let (loadURL, server) = await Self.prepareArchive(
+                html: currentHTML,
+                sourceURL: currentSourceURL,
+                itemID: currentItemID,
+                appearance: currentAppearance
+            )
+            guard let loadURL, let server else { return }
+            guard Task.isCancelled == false, session.loadKey == loadKey else {
+                server.stop()
+                return
+            }
 
+            let newPage = ReaderWebPageFactory.makePage(
+                openExternalURL: { [openURL] url in openURL(url) },
+                openInlineEmbed: { openEmbed($0) },
+                toggleChrome: { toggleChrome() }
+            )
+            session.archiveServer = server
+            _ = newPage.load(URLRequest(url: loadURL))
+            session.page = newPage
+        } else {
+            // Structured / HTML-fallback path.
+            //
+            // YouTube-card documents contain an iframe that loads
+            // youtube-nocookie.com/embed/…. If we hand WKWebView the HTML
+            // via `load(html:baseURL:)` with the item's sourceURL as the
+            // base, the document's origin becomes youtube.com — and
+            // YouTube's embed player rejects what then looks like a
+            // youtube.com page embedding its own videos (error 152-4).
+            // Serving the HTML through the same `LocalArchiveServer` used
+            // for archived pages gives the document a legitimate
+            // `http://localhost:PORT` origin, and the embed player
+            // accepts it. Non-YouTube structured articles go through the
+            // same path too for consistency — the server startup cost is
+            // ~10ms, well below perceivable latency.
+            if let (loadURL, server) = await Self.prepareStructuredServer(
+                html: currentHTML,
+                itemID: currentItemID
+            ) {
+                guard Task.isCancelled == false, session.loadKey == loadKey else {
+                    server.stop()
+                    return
+                }
                 let newPage = ReaderWebPageFactory.makePage(
                     openExternalURL: { [openURL] url in openURL(url) },
                     openInlineEmbed: { openEmbed($0) },
@@ -185,46 +255,19 @@ public struct ReaderWebView: View {
                 _ = newPage.load(URLRequest(url: loadURL))
                 session.page = newPage
             } else {
-                // Structured / HTML-fallback path.
-                //
-                // YouTube-card documents contain an iframe that loads
-                // youtube-nocookie.com/embed/…. If we hand WKWebView the HTML
-                // via `load(html:baseURL:)` with the item's sourceURL as the
-                // base, the document's origin becomes youtube.com — and
-                // YouTube's embed player rejects what then looks like a
-                // youtube.com page embedding its own videos (error 152-4).
-                // Serving the HTML through the same `LocalArchiveServer` used
-                // for archived pages gives the document a legitimate
-                // `http://localhost:PORT` origin, and the embed player
-                // accepts it. Non-YouTube structured articles go through the
-                // same path too for consistency — the server startup cost is
-                // ~10ms, well below perceivable latency.
-                if let (loadURL, server) = await Self.prepareStructuredServer(
-                    html: currentHTML,
-                    itemID: currentItemID
-                ) {
-                    let newPage = ReaderWebPageFactory.makePage(
-                        openExternalURL: { [openURL] url in openURL(url) },
-                        openInlineEmbed: { openEmbed($0) },
-                        toggleChrome: { toggleChrome() }
-                    )
-                    session.archiveServer = server
-                    _ = newPage.load(URLRequest(url: loadURL))
-                    session.page = newPage
-                } else {
-                    // Fallback: if the scratch dir write or server start fails,
-                    // fall back to the original in-memory load so the reader
-                    // still shows content (the only thing we lose is YouTube
-                    // embed playback on that particular open).
-                    let base = currentSourceURL.flatMap(URL.init(string:)) ?? URL(string: "about:blank")!
-                    let newPage = ReaderWebPageFactory.makePage(
-                        openExternalURL: { [openURL] url in openURL(url) },
-                        openInlineEmbed: { openEmbed($0) },
-                        toggleChrome: { toggleChrome() }
-                    )
-                    _ = newPage.load(html: currentHTML, baseURL: base)
-                    session.page = newPage
-                }
+                guard Task.isCancelled == false, session.loadKey == loadKey else { return }
+                // Fallback: if the scratch dir write or server start fails,
+                // fall back to the original in-memory load so the reader
+                // still shows content (the only thing we lose is YouTube
+                // embed playback on that particular open).
+                let base = currentSourceURL.flatMap(URL.init(string:)) ?? URL(string: "about:blank")!
+                let newPage = ReaderWebPageFactory.makePage(
+                    openExternalURL: { [openURL] url in openURL(url) },
+                    openInlineEmbed: { openEmbed($0) },
+                    toggleChrome: { toggleChrome() }
+                )
+                _ = newPage.load(html: currentHTML, baseURL: base)
+                session.page = newPage
             }
         }
     }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderWebViewLifecycleTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderWebViewLifecycleTests.swift
@@ -1,0 +1,163 @@
+#if os(macOS)
+import AppKit
+import ComposableArchitecture
+import Observation
+import StowerData
+@testable import StowerFeature
+import SwiftUI
+import Testing
+import WebKit
+
+@MainActor
+struct ReaderWebViewLifecycleTests {
+    @Test("Transient reader overlap gives each native WebView its own WebPage")
+    func transientReaderOverlapDoesNotShareWebPage() async throws {
+        let store = makeReaderStore()
+        let hostingView = NSHostingView(rootView: ReaderOverlapHarness(store: store))
+        let window = makeWindow(contentView: hostingView)
+        defer {
+            window.orderOut(nil)
+            window.contentView = nil
+        }
+
+        let webViews = await waitForWebViews(count: 2, in: hostingView)
+        #expect(
+            webViews.count == 2,
+            "Each temporarily overlapping reader must mount an independently owned WebView."
+        )
+    }
+
+    @Test("Reader remains alive while entering and exiting focus mode")
+    func focusTransitionDoesNotRebindWebPage() async throws {
+        let model = ReaderFocusHarnessModel()
+        let store = makeReaderStore()
+        let hostingView = NSHostingView(
+            rootView: ReaderFocusHarness(model: model, store: store)
+        )
+        let window = makeWindow(contentView: hostingView)
+        defer {
+            window.orderOut(nil)
+            window.contentView = nil
+        }
+
+        let initialWebView = await waitForWebView(in: hostingView)
+        #expect(initialWebView != nil, "The test must mount the native WebView before changing focus.")
+
+        for isFocused in [true, false, true, false] {
+            model.setFocused(isFocused)
+            try await Task.sleep(for: .milliseconds(400))
+            hostingView.layoutSubtreeIfNeeded()
+
+            let webViews = descendants(of: WKWebView.self, in: hostingView)
+            #expect(webViews.count == 1, "The reader should have exactly one native WebView after a focus transition.")
+        }
+    }
+
+    private func makeReaderStore() -> StoreOf<ReaderFeature> {
+        let item = SavedItem(
+            title: "Reader lifecycle test",
+            content: "Reader lifecycle test",
+            renderFormat: .structuredV1
+        )
+        var state = ReaderFeature.State(item: item)
+        state.document = ReaderDocument(
+            title: item.title,
+            blocks: [.paragraph([.text("Reader lifecycle test")])]
+        )
+        return Store(initialState: state) {
+            ReaderFeature()
+        }
+    }
+
+    private func makeWindow(contentView: NSView) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1000, height: 700),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = contentView
+        window.makeKeyAndOrderFront(nil)
+        return window
+    }
+
+    private func waitForWebView(in rootView: NSView) async -> WKWebView? {
+        await waitForWebViews(count: 1, in: rootView).first
+    }
+
+    private func waitForWebViews(count: Int, in rootView: NSView) async -> [WKWebView] {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(5))
+
+        while clock.now < deadline {
+            rootView.layoutSubtreeIfNeeded()
+            let webViews = descendants(of: WKWebView.self, in: rootView)
+            if webViews.count == count {
+                return webViews
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        return descendants(of: WKWebView.self, in: rootView)
+    }
+
+    private func descendants<ViewType: NSView>(
+        of type: ViewType.Type,
+        in rootView: NSView
+    ) -> [ViewType] {
+        rootView.subviews.flatMap { subview in
+            let current = (subview as? ViewType).map { [$0] } ?? []
+            return current + descendants(of: type, in: subview)
+        }
+    }
+}
+
+private struct ReaderOverlapHarness: View {
+    let store: StoreOf<ReaderFeature>
+    @State private var session = ReaderWebSession()
+
+    var body: some View {
+        ZStack {
+            ReaderScreen(store: store, session: session)
+            ReaderScreen(store: store, session: session)
+        }
+    }
+}
+
+@MainActor
+@Observable
+private final class ReaderFocusHarnessModel {
+    var columnVisibility: NavigationSplitViewVisibility = .all
+    var isFocused = false
+
+    func setFocused(_ newValue: Bool) {
+        isFocused = newValue
+    }
+}
+
+private struct ReaderFocusHarness: View {
+    @Bindable var model: ReaderFocusHarnessModel
+    let store: StoreOf<ReaderFeature>
+    @State private var session = ReaderWebSession()
+
+    var body: some View {
+        NavigationSplitView(columnVisibility: $model.columnVisibility) {
+            Text("Sidebar")
+        } content: {
+            Text("Library")
+        } detail: {
+            NavigationStack {
+                ReaderScreen(
+                    store: store,
+                    session: session,
+                    isReaderFocused: model.isFocused
+                ) {
+                    model.setFocused(model.isFocused == false)
+                }
+            }
+        }
+        .onChange(of: model.isFocused) { _, isFocused in
+            model.columnVisibility = isFocused ? .detailOnly : .all
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## What changed

- Keep reader panel state shareable while moving the live `WebPage`, archive server, load identity, and restoration state into a private session owned by each `ReaderWebView`.
- Tie page loading to SwiftUI's cancellable `.task(id:)` instead of spawning an unstructured task, and reject stale or cancelled load completions.
- Make progress-page unregistration identity-aware so an outgoing reader cannot clear a newer reader's registration.
- Add macOS native lifecycle coverage for focus transitions and transiently overlapping reader hierarchies.

## Root cause

Build 12 still allowed a shared `ReaderWebSession` to carry one live `WebPage` into more than one SwiftUI reader hierarchy during a native view transition. WebKit permits a `WebPage` to be bound to only one `WebView`; the second bind triggers the observed `EXC_BREAKPOINT` / signal 5 precondition in `_WebKit_SwiftUI`.

The new ownership boundary makes sharing a live page through `ReaderScreen` impossible.

## Validation

- The new transient-overlap regression test exits with signal 5 when run against shipped 0.4.1 build-12 source (`04eff88`), matching the crash report.
- The same test and the focus-transition lifecycle test pass with this fix.
- All 243 Swift package tests pass.
- Strict SwiftLint passes.
- macOS Release workspace build passes.
- iOS Simulator Release workspace build passes.
