### PR TITLE
Restore macOS reader focus layout in 0.4.2

### DIFF
--- a/Config/Shared.xcconfig
+++ b/Config/Shared.xcconfig
@@ -9,7 +9,7 @@
 PRODUCT_NAME = Stower
 PRODUCT_DISPLAY_NAME = Stower
 PRODUCT_BUNDLE_IDENTIFIER = com.ryanleewilliams.stower
-MARKETING_VERSION = 0.4.1
+MARKETING_VERSION = 0.4.2
 CURRENT_PROJECT_VERSION = 10
 
 // ==========================================

--- a/StowerPackage/Sources/StowerFeatureV2/ContentView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/ContentView.swift
@@ -201,6 +201,18 @@ public struct AppView: View {
 
     @ViewBuilder
     private func navigationContainer(palette: FlexokiPalette) -> some View {
+        #if os(macOS)
+        if store.isReaderFocused,
+           let readerStore = store.scope(\.reader, action: \.reader.presented) {
+            readerSurface(
+                readerStore,
+                palette: palette,
+                isFocused: true
+            )
+        } else {
+            splitNavigationView(palette: palette)
+        }
+        #else
         #if os(iOS)
         // On iPhone (compact), NavigationSplitView's detail column does not
         // reliably push when an `if let` swap toggles its content — taps on
@@ -232,6 +244,7 @@ public struct AppView: View {
         }
         #else
         splitNavigationView(palette: palette)
+        #endif
         #endif
     }
 
@@ -291,6 +304,23 @@ public struct AppView: View {
             // `windowBackgroundColor` (white in light mode). We have to
             // explicitly expand the content to fill the column *before*
             // applying the background so the fill paints the entire pane.
+            #if os(macOS)
+            if let readerStore = store.scope(\.reader, action: \.reader.presented) {
+                readerSurface(
+                    readerStore,
+                    palette: palette,
+                    isFocused: false
+                )
+            } else {
+                ContentUnavailableView(
+                    "Select an Item",
+                    systemImage: "doc.text",
+                    description: Text("Choose an article from Library to read.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(palette.bg)
+            }
+            #else
             if let readerStore = store.scope(\.reader, action: \.reader.presented) {
                 NavigationStack {
                     ReaderScreen(
@@ -310,11 +340,9 @@ public struct AppView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(palette.bg)
             }
+            #endif
         }
-        // Keep the reader in one stable detail hierarchy. WebKit permits a
-        // WebPage to be bound to only one WebView at a time, so moving this
-        // screen into a second focus-mode hierarchy can trap while SwiftUI is
-        // still dismantling the first native view.
+        #if os(iOS)
         .onChange(of: store.isReaderFocused) { _, isFocused in
             if isFocused {
                 previousColumnVisibility = columnVisibility
@@ -323,5 +351,24 @@ public struct AppView: View {
                 columnVisibility = previousColumnVisibility
             }
         }
+        #endif
     }
+
+    #if os(macOS)
+    private func readerSurface(
+        _ readerStore: StoreOf<ReaderFeature>,
+        palette: FlexokiPalette,
+        isFocused: Bool
+    ) -> some View {
+        NavigationStack {
+            ReaderScreen(
+                store: readerStore,
+                session: readerSession,
+                isReaderFocused: isFocused
+            ) { store.send(.readerFocusButtonTapped) }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(palette.bg)
+    }
+    #endif
 }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderWebViewLifecycleTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderWebViewLifecycleTests.swift
@@ -1,7 +1,6 @@
 #if os(macOS)
 import AppKit
 import ComposableArchitecture
-import Observation
 import StowerData
 @testable import StowerFeature
 import SwiftUI
@@ -27,13 +26,10 @@ struct ReaderWebViewLifecycleTests {
         )
     }
 
-    @Test("Reader remains alive while entering and exiting focus mode")
-    func focusTransitionDoesNotRebindWebPage() async throws {
-        let model = ReaderFocusHarnessModel()
-        let store = makeReaderStore()
-        let hostingView = NSHostingView(
-            rootView: ReaderFocusHarness(model: model, store: store)
-        )
+    @Test("Focus mode replaces the split view with a reader-only layout")
+    func focusTransitionUsesReaderOnlyLayout() async throws {
+        let store = makeAppStore()
+        let hostingView = NSHostingView(rootView: AppView(store: store))
         let window = makeWindow(contentView: hostingView)
         defer {
             window.orderOut(nil)
@@ -42,14 +38,33 @@ struct ReaderWebViewLifecycleTests {
 
         let initialWebView = await waitForWebView(in: hostingView)
         #expect(initialWebView != nil, "The test must mount the native WebView before changing focus.")
+        #expect(
+            descendants(of: NSSplitView.self, in: hostingView).isEmpty == false,
+            "The ordinary reader layout must begin inside the navigation split view."
+        )
 
-        for isFocused in [true, false, true, false] {
-            model.setFocused(isFocused)
-            try await Task.sleep(for: .milliseconds(400))
-            hostingView.layoutSubtreeIfNeeded()
+        for transitionNumber in 1 ... 2 {
+            store.send(.readerFocusButtonTapped)
+            let didEnterReaderOnlyLayout = await waitUntil {
+                hostingView.layoutSubtreeIfNeeded()
+                return descendants(of: NSSplitView.self, in: hostingView).isEmpty
+                    && descendants(of: WKWebView.self, in: hostingView).count == 1
+            }
+            #expect(
+                didEnterReaderOnlyLayout,
+                "Focus transition \(transitionNumber) must remove the sidebar and library split view while keeping one reader alive."
+            )
 
-            let webViews = descendants(of: WKWebView.self, in: hostingView)
-            #expect(webViews.count == 1, "The reader should have exactly one native WebView after a focus transition.")
+            store.send(.readerFocusButtonTapped)
+            let didRestoreSplitLayout = await waitUntil {
+                hostingView.layoutSubtreeIfNeeded()
+                return descendants(of: NSSplitView.self, in: hostingView).isEmpty == false
+                    && descendants(of: WKWebView.self, in: hostingView).count == 1
+            }
+            #expect(
+                didRestoreSplitLayout,
+                "Exit transition \(transitionNumber) must restore the split view while keeping one reader alive."
+            )
         }
     }
 
@@ -66,6 +81,24 @@ struct ReaderWebViewLifecycleTests {
         )
         return Store(initialState: state) {
             ReaderFeature()
+        }
+    }
+
+    private func makeAppStore() -> StoreOf<AppFeature> {
+        let item = SavedItem(
+            title: "Reader focus test",
+            content: "Reader focus test",
+            renderFormat: .structuredV1
+        )
+        var state = AppFeature.State()
+        var reader = ReaderFeature.State(item: item, appearance: state.cachedAppearance)
+        reader.document = ReaderDocument(
+            title: item.title,
+            blocks: [.paragraph([.text("Reader focus test")])]
+        )
+        state.reader = reader
+        return Store(initialState: state) {
+            AppFeature()
         }
     }
 
@@ -100,6 +133,22 @@ struct ReaderWebViewLifecycleTests {
         return descendants(of: WKWebView.self, in: rootView)
     }
 
+    private func waitUntil(
+        timeout: Duration = .seconds(5),
+        _ predicate: () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+
+        while clock.now < deadline {
+            if predicate() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        return predicate()
+    }
+
     private func descendants<ViewType: NSView>(
         of type: ViewType.Type,
         in rootView: NSView
@@ -123,41 +172,4 @@ private struct ReaderOverlapHarness: View {
     }
 }
 
-@MainActor
-@Observable
-private final class ReaderFocusHarnessModel {
-    var columnVisibility: NavigationSplitViewVisibility = .all
-    var isFocused = false
-
-    func setFocused(_ newValue: Bool) {
-        isFocused = newValue
-    }
-}
-
-private struct ReaderFocusHarness: View {
-    @Bindable var model: ReaderFocusHarnessModel
-    let store: StoreOf<ReaderFeature>
-    @State private var session = ReaderWebSession()
-
-    var body: some View {
-        NavigationSplitView(columnVisibility: $model.columnVisibility) {
-            Text("Sidebar")
-        } content: {
-            Text("Library")
-        } detail: {
-            NavigationStack {
-                ReaderScreen(
-                    store: store,
-                    session: session,
-                    isReaderFocused: model.isFocused
-                ) {
-                    model.setFocused(model.isFocused == false)
-                }
-            }
-        }
-        .onChange(of: model.isFocused) { _, isFocused in
-            model.columnVisibility = isFocused ? .detailOnly : .all
-        }
-    }
-}
 #endif


### PR DESCRIPTION
## What changed

- Restore a true reader-only layout on macOS when Focus is enabled.
- Keep the reducer as the single source of truth instead of relying on `NavigationSplitViewVisibility.detailOnly`.
- Replace the previous survival-only harness with a native `AppView` regression test that verifies the split view disappears, exactly one WebView remains, and the split layout returns across repeated focus cycles.
- Bump the marketing version from 0.4.1 to 0.4.2 for the next TestFlight release.

## Root cause

On macOS 27, mutating the three-column `NavigationSplitView` binding to `.detailOnly` did not actually hide the sidebar and library columns. The focus state toggled, but the visible layout stayed unchanged. The prior test only counted WebViews, so it could pass without proving that focus mode appeared.

The reader-only hierarchy is now safe because each `ReaderWebView` owns its own `WebPage`, including during transient SwiftUI overlap.

## Validation

- `swift test` — 243 tests passed
- `swiftlint lint --config .swiftlint.yml --strict --quiet`
- macOS Release workspace build
- iOS 27 Simulator Release workspace build
- Release build settings resolve `MARKETING_VERSION = 0.4.2` and `CURRENT_PROJECT_VERSION = 10`