### PR TITLE
Capture articles hidden during page hydration

### DIFF
--- a/StowerPackage/Sources/StowerFeatureV2/Support/WebArticleCaptureClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/WebArticleCaptureClient.swift
@@ -38,6 +38,15 @@ extension DependencyValues {
     }
 }
 
+enum WebCaptureDOMProbe {
+    static let deliveredTextJavaScript = "document.body ? document.body.textContent : ''"
+
+    static func containsUsableText(_ text: String?) -> Bool {
+        guard let text else { return false }
+        return text.trimmingCharacters(in: .whitespacesAndNewlines).count >= 40
+    }
+}
+
 @MainActor
 private final class WebArticleCaptureSession {
     private let webView: WKWebView
@@ -70,8 +79,8 @@ private final class WebArticleCaptureSession {
         do {
             try await navigator.load(timeout: .seconds(30)) { self.webView.load(request) }
         } catch CaptureNavigationError.timeout {
-            let text = (try? await javascriptString("document.body ? document.body.innerText : ''")) ?? ""
-            guard text.trimmingCharacters(in: .whitespacesAndNewlines).count >= 40 else { throw CaptureNavigationError.timeout }
+            let text = try? await javascriptString(WebCaptureDOMProbe.deliveredTextJavaScript)
+            guard WebCaptureDOMProbe.containsUsableText(text) else { throw CaptureNavigationError.timeout }
             completeness = .partial
             warnings.append("The page did not finish loading within 30 seconds; content that had rendered was saved.")
         }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/WebArticleCaptureIntegrationTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/WebArticleCaptureIntegrationTests.swift
@@ -7,6 +7,38 @@ import WebKit
 struct WebArticleCaptureIntegrationTests {
     @Test
     @MainActor
+    func recognizesArticleContentHiddenDuringClientSideHydration() async throws {
+        let page = WebPage()
+        let html = """
+            <!doctype html><html><head></head><body>
+            <article style="display: none;">
+              <h1>Delivered before hydration finishes</h1>
+              <p>This article is already present in the document even though client-side JavaScript has not made it visible yet.</p>
+            </article>
+            </body></html>
+            """
+        for try await event in page.load(
+            Data(html.utf8),
+            mimeType: "text/html",
+            characterEncoding: .utf8,
+            baseURL: URL(string: "https://example.com/article")!
+        ) where event == .finished {
+            break
+        }
+
+        let visibleText = try await page.callJavaScript(
+            "return document.body ? document.body.innerText : '';"
+        ) as? String
+        let deliveredText = try await page.callJavaScript(
+            "return \(WebCaptureDOMProbe.deliveredTextJavaScript);"
+        ) as? String
+
+        #expect(!WebCaptureDOMProbe.containsUsableText(visibleText))
+        #expect(WebCaptureDOMProbe.containsUsableText(deliveredText))
+    }
+
+    @Test
+    @MainActor
     func capturesJavaScriptRenderedPageAndReplaysOffline() async throws {
         let fixture = FileManager.default.temporaryDirectory
             .appendingPathComponent("web-capture-fixture-\(UUID())", isDirectory: true)


### PR DESCRIPTION
## Summary
- recognize article DOM text that has loaded but remains visually hidden during client-side hydration
- preserve the existing partial-capture warning when navigation times out
- add a deterministic WebKit regression test for hidden-but-delivered article content

## Validation
- reproduced the failure with https://blog.jacobstechtavern.com/p/design-kisses
- verified the exact URL captures successfully after the fix
- `swift test` (248 tests)
- `swiftlint lint --strict` (0 violations)