### PR TITLE
Add bundled Safari web extension

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,6 +7,7 @@ included:
   - StowerPackage/Sources
   - StowerPackage/Tests
   - StowerShare
+  - StowerSafari
 
 excluded:
   - .build

--- a/BrowserExtension/README.md
+++ b/BrowserExtension/README.md
@@ -1,25 +1,25 @@
-# Save to Stower for Helium
+# Save to Stower for Safari
 
-This Manifest V3 Chromium extension saves the active HTTP or HTTPS page to the
-installed Stower app. It requests only `activeTab`, which grants temporary
-access to the page you explicitly choose from the toolbar.
+The Safari Web Extension is bundled with Stower on iPhone, iPad, and Mac. It
+saves the active HTTP or HTTPS page directly into Stower's shared library and
+requests access only to the tab you explicitly choose from the toolbar.
 
-## Install in Helium
+## Enable in Safari
 
-1. Install and launch a Release build of Stower at least once so macOS
-   registers the `stower://` app link.
-2. Open `chrome://extensions` in Helium.
-3. Turn on **Developer mode**.
-4. Choose **Load unpacked** and select the `BrowserExtension/Stower` folder.
-5. Pin **Save to Stower** to the toolbar.
+1. Install and launch Stower.
+2. On Mac, open **Safari > Settings > Extensions** and enable
+   **Save to Stower**. Add it to the Safari toolbar if Safari does not add it
+   automatically.
+3. On iPhone or iPad, open Safari's page menu, choose **Extensions**, and enable
+   **Save to Stower**.
 
 Open an article, click the Stower raccoon, then choose **Save to Stower**.
-Stower opens, captures the page, and leaves it in the unread queue. The shortcut
-to open the extension is Control-Shift-S on macOS.
+The page is added to Stower's unread queue without replacing the current tab.
+The shortcut to open the extension is Control-Shift-S on macOS.
 
-Debug builds register `stower-dev://` to remain isolated from TestFlight and
-App Store builds. The packaged extension intentionally targets the production
-`stower://` scheme.
+The same web-extension resources remain compatible with Chromium browsers. If
+native Safari messaging is unavailable, the extension falls back to Stower's
+validated `stower://` app link.
 
 ## Test
 

--- a/BrowserExtension/Stower/manifest.json
+++ b/BrowserExtension/Stower/manifest.json
@@ -1,10 +1,11 @@
 {
   "manifest_version": 3,
   "name": "Save to Stower",
-  "version": "0.1.0",
+  "version": "0.4.2",
   "description": "Save the current article or website to Stower for later.",
   "permissions": [
-    "activeTab"
+    "activeTab",
+    "nativeMessaging"
   ],
   "action": {
     "default_title": "Save to Stower",

--- a/BrowserExtension/Stower/popup.js
+++ b/BrowserExtension/Stower/popup.js
@@ -1,4 +1,5 @@
-import { displayHost, isSaveablePage, makeStowerLink } from "./link.js";
+import { displayHost, isSaveablePage } from "./link.js";
+import { savePage } from "./save.js";
 
 const pageTitle = document.querySelector("#page-title");
 const pageHost = document.querySelector("#page-host");
@@ -6,6 +7,7 @@ const saveButton = document.querySelector("#save-button");
 const status = document.querySelector("#status");
 
 let activeTab;
+const extensionAPI = globalThis.browser ?? globalThis.chrome;
 
 function showStatus(message, kind = "neutral") {
   status.textContent = message;
@@ -14,7 +16,7 @@ function showStatus(message, kind = "neutral") {
 
 async function loadActivePage() {
   try {
-    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    const [tab] = await extensionAPI.tabs.query({ active: true, currentWindow: true });
     activeTab = tab;
 
     const canSave = Boolean(tab?.id && isSaveablePage(tab.url));
@@ -39,16 +41,16 @@ saveButton.addEventListener("click", async () => {
 
   saveButton.disabled = true;
   saveButton.dataset.saving = "true";
-  showStatus("Opening Stower…");
+  showStatus("Saving to Stower…");
 
   try {
-    await chrome.tabs.update(activeTab.id, { url: makeStowerLink(activeTab.url) });
-    showStatus("Sent to Stower", "success");
+    await savePage(extensionAPI, activeTab);
+    showStatus("Saved to Stower", "success");
     window.setTimeout(() => window.close(), 450);
-  } catch {
+  } catch (error) {
     saveButton.disabled = false;
     delete saveButton.dataset.saving;
-    showStatus("Could not open Stower. Make sure the app is installed.", "error");
+    showStatus(error?.message || "Stower could not save this page.", "error");
   }
 });
 

--- a/BrowserExtension/Stower/save.js
+++ b/BrowserExtension/Stower/save.js
@@ -1,0 +1,26 @@
+import { isSaveablePage, makeStowerLink } from "./link.js";
+
+export const NATIVE_APP_ID = "com.ryanleewilliams.stower";
+
+export async function savePage(extensionAPI, tab) {
+  if (!tab?.id || !isSaveablePage(tab.url)) {
+    throw new TypeError("This page cannot be saved.");
+  }
+
+  let response;
+  try {
+    response = await extensionAPI.runtime.sendNativeMessage(NATIVE_APP_ID, {
+      action: "save",
+      url: tab.url,
+    });
+  } catch {
+    await extensionAPI.tabs.update(tab.id, { url: makeStowerLink(tab.url) });
+    return { delivery: "app-link" };
+  }
+
+  if (!response?.success) {
+    throw new Error(response?.error || "Stower could not save this page.");
+  }
+
+  return { delivery: "native" };
+}

--- a/BrowserExtension/Tests/manifest.test.js
+++ b/BrowserExtension/Tests/manifest.test.js
@@ -6,9 +6,9 @@ import { fileURLToPath } from "node:url";
 const extensionRoot = fileURLToPath(new URL("../Stower/", import.meta.url));
 const manifest = JSON.parse(readFileSync(`${extensionRoot}/manifest.json`, "utf8"));
 
-test("uses Manifest V3 and requests only temporary access to the active tab", () => {
+test("uses Manifest V3 with active-tab access and native app messaging", () => {
   assert.equal(manifest.manifest_version, 3);
-  assert.deepEqual(manifest.permissions, ["activeTab"]);
+  assert.deepEqual(manifest.permissions, ["activeTab", "nativeMessaging"]);
   assert.equal(manifest.host_permissions, undefined);
   assert.equal(manifest.content_scripts, undefined);
 });
@@ -16,6 +16,8 @@ test("uses Manifest V3 and requests only temporary access to the active tab", ()
 test("references files that are included in the unpacked extension", () => {
   const referencedFiles = [
     manifest.action.default_popup,
+    "link.js",
+    "save.js",
     ...Object.values(manifest.action.default_icon),
     ...Object.values(manifest.icons),
   ];

--- a/BrowserExtension/Tests/save.test.js
+++ b/BrowserExtension/Tests/save.test.js
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { NATIVE_APP_ID, savePage } from "../Stower/save.js";
+
+const tab = {
+  id: 42,
+  url: "https://www.example.com/article?page=2&mode=reader#notes",
+};
+
+test("saves through Safari native messaging when the bundled extension is available", async () => {
+  const messages = [];
+  const updates = [];
+  const extensionAPI = {
+    runtime: {
+      async sendNativeMessage(applicationID, message) {
+        messages.push({ applicationID, message });
+        return { success: true };
+      },
+    },
+    tabs: {
+      async update(...arguments_) {
+        updates.push(arguments_);
+      },
+    },
+  };
+
+  const result = await savePage(extensionAPI, tab);
+
+  assert.deepEqual(result, { delivery: "native" });
+  assert.deepEqual(messages, [{
+    applicationID: NATIVE_APP_ID,
+    message: { action: "save", url: tab.url },
+  }]);
+  assert.deepEqual(updates, []);
+});
+
+test("falls back to the Stower app link when native messaging is unavailable", async () => {
+  const updates = [];
+  const extensionAPI = {
+    runtime: {
+      async sendNativeMessage() {
+        throw new Error("Native host unavailable");
+      },
+    },
+    tabs: {
+      async update(...arguments_) {
+        updates.push(arguments_);
+      },
+    },
+  };
+
+  const result = await savePage(extensionAPI, tab);
+
+  assert.deepEqual(result, { delivery: "app-link" });
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0][0], tab.id);
+  const link = new URL(updates[0][1].url);
+  assert.equal(link.protocol, "stower:");
+  assert.equal(link.searchParams.get("url"), tab.url);
+});
+
+test("shows a native save failure instead of claiming success", async () => {
+  const extensionAPI = {
+    runtime: {
+      async sendNativeMessage() {
+        return { success: false, error: "The shared library is unavailable." };
+      },
+    },
+    tabs: {
+      async update() {
+        assert.fail("A handled native failure must not navigate the active tab.");
+      },
+    },
+  };
+
+  await assert.rejects(
+    savePage(extensionAPI, tab),
+    /The shared library is unavailable/,
+  );
+});
+
+test("rejects non-web pages before contacting the native extension", async () => {
+  const extensionAPI = {
+    runtime: {
+      async sendNativeMessage() {
+        assert.fail("Invalid pages must not reach native messaging.");
+      },
+    },
+  };
+
+  await assert.rejects(
+    savePage(extensionAPI, { id: 42, url: "safari-extension://settings" }),
+    /cannot be saved/,
+  );
+});

--- a/Config/Debug.xcconfig
+++ b/Config/Debug.xcconfig
@@ -18,6 +18,7 @@ STRIP_SWIFT_SYMBOLS = NO
 PRODUCT_BUNDLE_IDENTIFIER = com.ryanleewilliams.stower.dev
 INFOPLIST_KEY_CFBundleDisplayName = Stower Dev
 STOWER_URL_SCHEME = stower-dev
+STOWER_APP_GROUP = group.com.Stower.dev
 
 // `$(inherited)` preserves Xcode's default `DEBUG` flag (used by existing
 // `#if DEBUG` blocks in Bootstrap.swift) while adding our new

--- a/Config/Shared.xcconfig
+++ b/Config/Shared.xcconfig
@@ -12,6 +12,7 @@ PRODUCT_BUNDLE_IDENTIFIER = com.ryanleewilliams.stower
 MARKETING_VERSION = 0.4.2
 CURRENT_PROJECT_VERSION = 10
 STOWER_URL_SCHEME = stower
+STOWER_APP_GROUP = group.com.Stower
 
 // ==========================================
 // Platform Configuration

--- a/Stower.xcodeproj/project.pbxproj
+++ b/Stower.xcodeproj/project.pbxproj
@@ -9,6 +9,26 @@
 /* Begin PBXBuildFile section */
 		5740E60C2E700000DEADBEEF /* StowerData in Frameworks */ = {isa = PBXBuildFile; productRef = 5740E60B2E700000DEADBEEF /* StowerData */; };
 		5740E60E2E700000DEADBEEF /* StowerShare.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 5740E6012E700000DEADBEEF /* StowerShare.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		A57AFA010000000000000001 /* StowerData in Frameworks */ = {isa = PBXBuildFile; productRef = A57AFA010000000000000036 /* StowerData */; };
+		A57AFA010000000000000002 /* StowerData in Frameworks */ = {isa = PBXBuildFile; productRef = A57AFA010000000000000037 /* StowerData */; };
+		A57AFA010000000000000003 /* StowerSafari-iOS.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = A57AFA010000000000000017 /* StowerSafari-iOS.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		A57AFA010000000000000004 /* StowerSafari-macOS.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = A57AFA010000000000000018 /* StowerSafari-macOS.appex */; platformFilters = (macos, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		A57AFA010000000000000005 /* SafariWebExtensionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57AFA010000000000000019 /* SafariWebExtensionHandler.swift */; };
+		A57AFA010000000000000006 /* SafariWebExtensionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57AFA010000000000000019 /* SafariWebExtensionHandler.swift */; };
+		A57AFA010000000000000007 /* link.js in Resources */ = {isa = PBXBuildFile; fileRef = A57AFA01000000000000001D /* link.js */; };
+		A57AFA010000000000000008 /* save.js in Resources */ = {isa = PBXBuildFile; fileRef = A57AFA01000000000000001E /* save.js */; };
+		A57AFA010000000000000009 /* popup.js in Resources */ = {isa = PBXBuildFile; fileRef = A57AFA01000000000000001F /* popup.js */; };
+		A57AFA01000000000000000A /* popup.html in Resources */ = {isa = PBXBuildFile; fileRef = A57AFA010000000000000020 /* popup.html */; };
+		A57AFA01000000000000000B /* popup.css in Resources */ = {isa = PBXBuildFile; fileRef = A57AFA010000000000000021 /* popup.css */; };
+		A57AFA01000000000000000C /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = A57AFA010000000000000022 /* manifest.json */; };
+		A57AFA01000000000000000D /* icons in Resources */ = {isa = PBXBuildFile; fileRef = A57AFA010000000000000023 /* icons */; };
+		A57AFA01000000000000000E /* link.js in Resources */ = {isa = PBXBuildFile; fileRef = A57AFA01000000000000001D /* link.js */; };
+		A57AFA01000000000000000F /* save.js in Resources */ = {isa = PBXBuildFile; fileRef = A57AFA01000000000000001E /* save.js */; };
+		A57AFA010000000000000010 /* popup.js in Resources */ = {isa = PBXBuildFile; fileRef = A57AFA01000000000000001F /* popup.js */; };
+		A57AFA010000000000000011 /* popup.html in Resources */ = {isa = PBXBuildFile; fileRef = A57AFA010000000000000020 /* popup.html */; };
+		A57AFA010000000000000012 /* popup.css in Resources */ = {isa = PBXBuildFile; fileRef = A57AFA010000000000000021 /* popup.css */; };
+		A57AFA010000000000000013 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = A57AFA010000000000000022 /* manifest.json */; };
+		A57AFA010000000000000014 /* icons in Resources */ = {isa = PBXBuildFile; fileRef = A57AFA010000000000000023 /* icons */; };
 		8B41F6832DEDD23B001A66F9 /* StowerFeature in Frameworks */ = {isa = PBXBuildFile; productRef = 8B41F6822DEDD23B001A66F9 /* StowerFeature */; };
 		8B41F6852DEDD25C001A66F9 /* StowerFeature in Frameworks */ = {isa = PBXBuildFile; productRef = 8B41F6842DEDD25C001A66F9 /* StowerFeature */; };
 /* End PBXBuildFile section */
@@ -20,6 +40,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 5740E60A2E700000DEADBEEF;
 			remoteInfo = StowerShare;
+		};
+		A57AFA010000000000000015 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8B41F63D2DEDD0D5001A66F9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A57AFA010000000000000028;
+			remoteInfo = "StowerSafari (iOS)";
+		};
+		A57AFA010000000000000016 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8B41F63D2DEDD0D5001A66F9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A57AFA010000000000000029;
+			remoteInfo = "StowerSafari (macOS)";
 		};
 		8B41F65D2DEDD0D6001A66F9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -38,6 +72,8 @@
 			dstSubfolderSpec = 13;
 			files = (
 				5740E60E2E700000DEADBEEF /* StowerShare.appex in Embed Foundation Extensions */,
+				A57AFA010000000000000003 /* StowerSafari-iOS.appex in Embed Foundation Extensions */,
+				A57AFA010000000000000004 /* StowerSafari-macOS.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -46,6 +82,19 @@
 
 /* Begin PBXFileReference section */
 		5740E6012E700000DEADBEEF /* StowerShare.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = StowerShare.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		A57AFA010000000000000017 /* StowerSafari-iOS.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "StowerSafari-iOS.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A57AFA010000000000000018 /* StowerSafari-macOS.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "StowerSafari-macOS.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A57AFA010000000000000019 /* SafariWebExtensionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariWebExtensionHandler.swift; sourceTree = "<group>"; };
+		A57AFA01000000000000001A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A57AFA01000000000000001B /* StowerSafari.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StowerSafari.entitlements; sourceTree = "<group>"; };
+		A57AFA01000000000000001C /* StowerSafari-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "StowerSafari-macOS.entitlements"; sourceTree = "<group>"; };
+		A57AFA01000000000000001D /* link.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = link.js; path = BrowserExtension/Stower/link.js; sourceTree = SOURCE_ROOT; };
+		A57AFA01000000000000001E /* save.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = save.js; path = BrowserExtension/Stower/save.js; sourceTree = SOURCE_ROOT; };
+		A57AFA01000000000000001F /* popup.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = popup.js; path = BrowserExtension/Stower/popup.js; sourceTree = SOURCE_ROOT; };
+		A57AFA010000000000000020 /* popup.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = popup.html; path = BrowserExtension/Stower/popup.html; sourceTree = SOURCE_ROOT; };
+		A57AFA010000000000000021 /* popup.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; name = popup.css; path = BrowserExtension/Stower/popup.css; sourceTree = SOURCE_ROOT; };
+		A57AFA010000000000000022 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = manifest.json; path = BrowserExtension/Stower/manifest.json; sourceTree = SOURCE_ROOT; };
+		A57AFA010000000000000023 /* icons */ = {isa = PBXFileReference; lastKnownFileType = folder; name = icons; path = BrowserExtension/Stower/icons; sourceTree = SOURCE_ROOT; };
 		8B41F6452DEDD0D5001A66F9 /* Stower.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Stower.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B41F65C2DEDD0D6001A66F9 /* StowerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StowerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -120,6 +169,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A57AFA010000000000000026 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A57AFA010000000000000001 /* StowerData in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A57AFA010000000000000027 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A57AFA010000000000000002 /* StowerData in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8B41F6422DEDD0D5001A66F9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -145,6 +210,7 @@
 				8BD71C052DEE41D800CEDD92 /* Config */,
 				8B41F6472DEDD0D5001A66F9 /* Stower */,
 				5740E6022E700000DEADBEEF /* StowerShare */,
+				A57AFA010000000000000024 /* StowerSafari */,
 				8B41F65F2DEDD0D6001A66F9 /* StowerUITests */,
 				8B41F6812DEDD23B001A66F9 /* Frameworks */,
 				8B41F6462DEDD0D5001A66F9 /* Products */,
@@ -157,6 +223,8 @@
 				8B41F6452DEDD0D5001A66F9 /* Stower.app */,
 				8B41F65C2DEDD0D6001A66F9 /* StowerUITests.xctest */,
 				5740E6012E700000DEADBEEF /* StowerShare.appex */,
+				A57AFA010000000000000017 /* StowerSafari-iOS.appex */,
+				A57AFA010000000000000018 /* StowerSafari-macOS.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -166,6 +234,32 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		A57AFA010000000000000024 /* StowerSafari */ = {
+			isa = PBXGroup;
+			children = (
+				A57AFA010000000000000019 /* SafariWebExtensionHandler.swift */,
+				A57AFA01000000000000001A /* Info.plist */,
+				A57AFA01000000000000001B /* StowerSafari.entitlements */,
+				A57AFA01000000000000001C /* StowerSafari-macOS.entitlements */,
+				A57AFA010000000000000025 /* Resources */,
+			);
+			path = StowerSafari;
+			sourceTree = "<group>";
+		};
+		A57AFA010000000000000025 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				A57AFA01000000000000001D /* link.js */,
+				A57AFA01000000000000001E /* save.js */,
+				A57AFA01000000000000001F /* popup.js */,
+				A57AFA010000000000000020 /* popup.html */,
+				A57AFA010000000000000021 /* popup.css */,
+				A57AFA010000000000000022 /* manifest.json */,
+				A57AFA010000000000000023 /* icons */,
+			);
+			name = Resources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -194,6 +288,46 @@
 			productReference = 5740E6012E700000DEADBEEF /* StowerShare.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		A57AFA010000000000000028 /* StowerSafari (iOS) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A57AFA010000000000000034 /* Build configuration list for PBXNativeTarget "StowerSafari (iOS)" */;
+			buildPhases = (
+				A57AFA01000000000000002C /* Sources */,
+				A57AFA010000000000000026 /* Frameworks */,
+				A57AFA01000000000000002A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "StowerSafari (iOS)";
+			packageProductDependencies = (
+				A57AFA010000000000000036 /* StowerData */,
+			);
+			productName = StowerSafari;
+			productReference = A57AFA010000000000000017 /* StowerSafari-iOS.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		A57AFA010000000000000029 /* StowerSafari (macOS) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A57AFA010000000000000035 /* Build configuration list for PBXNativeTarget "StowerSafari (macOS)" */;
+			buildPhases = (
+				A57AFA01000000000000002D /* Sources */,
+				A57AFA010000000000000027 /* Frameworks */,
+				A57AFA01000000000000002B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "StowerSafari (macOS)";
+			packageProductDependencies = (
+				A57AFA010000000000000037 /* StowerData */,
+			);
+			productName = StowerSafari;
+			productReference = A57AFA010000000000000018 /* StowerSafari-macOS.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		8B41F6442DEDD0D5001A66F9 /* Stower */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8B41F6662DEDD0D6001A66F9 /* Build configuration list for PBXNativeTarget "Stower" */;
@@ -207,6 +341,8 @@
 			);
 			dependencies = (
 				5740E6102E700000DEADBEEF /* PBXTargetDependency */,
+				A57AFA01000000000000002E /* PBXTargetDependency */,
+				A57AFA01000000000000002F /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				8B41F6472DEDD0D5001A66F9 /* Stower */,
@@ -257,6 +393,12 @@
 					5740E60A2E700000DEADBEEF = {
 						CreatedOnToolsVersion = 16.3;
 					};
+					A57AFA010000000000000028 = {
+						CreatedOnToolsVersion = 27.0;
+					};
+					A57AFA010000000000000029 = {
+						CreatedOnToolsVersion = 27.0;
+					};
 					8B41F6442DEDD0D5001A66F9 = {
 						CreatedOnToolsVersion = 16.3;
 					};
@@ -282,6 +424,8 @@
 			targets = (
 				8B41F6442DEDD0D5001A66F9 /* Stower */,
 				5740E60A2E700000DEADBEEF /* StowerShare */,
+				A57AFA010000000000000028 /* StowerSafari (iOS) */,
+				A57AFA010000000000000029 /* StowerSafari (macOS) */,
 				8B41F65B2DEDD0D6001A66F9 /* StowerUITests */,
 			);
 		};
@@ -292,6 +436,34 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A57AFA01000000000000002A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A57AFA010000000000000007 /* link.js in Resources */,
+				A57AFA010000000000000008 /* save.js in Resources */,
+				A57AFA010000000000000009 /* popup.js in Resources */,
+				A57AFA01000000000000000A /* popup.html in Resources */,
+				A57AFA01000000000000000B /* popup.css in Resources */,
+				A57AFA01000000000000000C /* manifest.json in Resources */,
+				A57AFA01000000000000000D /* icons in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A57AFA01000000000000002B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A57AFA01000000000000000E /* link.js in Resources */,
+				A57AFA01000000000000000F /* save.js in Resources */,
+				A57AFA010000000000000010 /* popup.js in Resources */,
+				A57AFA010000000000000011 /* popup.html in Resources */,
+				A57AFA010000000000000012 /* popup.css in Resources */,
+				A57AFA010000000000000013 /* manifest.json in Resources */,
+				A57AFA010000000000000014 /* icons in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -319,6 +491,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A57AFA01000000000000002C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A57AFA010000000000000005 /* SafariWebExtensionHandler.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A57AFA01000000000000002D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A57AFA010000000000000006 /* SafariWebExtensionHandler.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8B41F6412DEDD0D5001A66F9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -341,6 +529,20 @@
 			platformFilter = ios;
 			target = 5740E60A2E700000DEADBEEF /* StowerShare */;
 			targetProxy = 5740E60F2E700000DEADBEEF /* PBXContainerItemProxy */;
+		};
+		A57AFA01000000000000002E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilter = ios;
+			target = A57AFA010000000000000028 /* StowerSafari (iOS) */;
+			targetProxy = A57AFA010000000000000015 /* PBXContainerItemProxy */;
+		};
+		A57AFA01000000000000002F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				macos,
+			);
+			target = A57AFA010000000000000029 /* StowerSafari (macOS) */;
+			targetProxy = A57AFA010000000000000016 /* PBXContainerItemProxy */;
 		};
 		8B41F65E2DEDD0D6001A66F9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -401,6 +603,154 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		A57AFA010000000000000030 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 8BD71C052DEE41D800CEDD92 /* Config */;
+			baseConfigurationReferenceRelativePath = Debug.xcconfig;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = StowerSafari/StowerSafari.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 777XX46HDU;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = StowerSafari/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Save to Stower";
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					SafariServices,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ryanleewilliams.stower.dev.safari;
+				PRODUCT_NAME = "StowerSafari-iOS";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A57AFA010000000000000031 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 8BD71C052DEE41D800CEDD92 /* Config */;
+			baseConfigurationReferenceRelativePath = Release.xcconfig;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = StowerSafari/StowerSafari.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 777XX46HDU;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = StowerSafari/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Save to Stower";
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					SafariServices,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ryanleewilliams.stower.safari;
+				PRODUCT_NAME = "StowerSafari-iOS";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A57AFA010000000000000032 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 8BD71C052DEE41D800CEDD92 /* Config */;
+			baseConfigurationReferenceRelativePath = Debug.xcconfig;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = "StowerSafari/StowerSafari-macOS.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 777XX46HDU;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = StowerSafari/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Save to Stower";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 27.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					SafariServices,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ryanleewilliams.stower.dev.safari;
+				PRODUCT_NAME = "StowerSafari-macOS";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		A57AFA010000000000000033 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 8BD71C052DEE41D800CEDD92 /* Config */;
+			baseConfigurationReferenceRelativePath = Release.xcconfig;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = "StowerSafari/StowerSafari-macOS.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 777XX46HDU;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = StowerSafari/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Save to Stower";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 27.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					SafariServices,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ryanleewilliams.stower.safari;
+				PRODUCT_NAME = "StowerSafari-macOS";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
@@ -683,6 +1033,24 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		A57AFA010000000000000034 /* Build configuration list for PBXNativeTarget "StowerSafari (iOS)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A57AFA010000000000000030 /* Debug */,
+				A57AFA010000000000000031 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A57AFA010000000000000035 /* Build configuration list for PBXNativeTarget "StowerSafari (macOS)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A57AFA010000000000000032 /* Debug */,
+				A57AFA010000000000000033 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		8B41F6402DEDD0D5001A66F9 /* Build configuration list for PBXProject "Stower" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -714,6 +1082,14 @@
 
 /* Begin XCSwiftPackageProductDependency section */
 		5740E60B2E700000DEADBEEF /* StowerData */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = StowerData;
+		};
+		A57AFA010000000000000036 /* StowerData */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = StowerData;
+		};
+		A57AFA010000000000000037 /* StowerData */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = StowerData;
 		};

--- a/StowerSafari/Info.plist
+++ b/StowerSafari/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.Safari.web-extension</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler</string>
+	</dict>
+</dict>
+</plist>

--- a/StowerSafari/SafariWebExtensionHandler.swift
+++ b/StowerSafari/SafariWebExtensionHandler.swift
@@ -1,0 +1,55 @@
+import SafariServices
+import StowerData
+
+final class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
+    private final class RequestContext: @unchecked Sendable {
+        let value: NSExtensionContext
+
+        init(_ value: NSExtensionContext) {
+            self.value = value
+        }
+    }
+
+    func beginRequest(with context: NSExtensionContext) {
+        let requestContext = RequestContext(context)
+        let request = context.inputItems.first as? NSExtensionItem
+        let message = request?.userInfo?[SFExtensionMessageKey] as? [String: Any]
+
+        guard message?["action"] as? String == "save",
+              let value = message?["url"] as? String,
+              let url = URL(string: value),
+              ["http", "https"].contains(url.scheme?.lowercased())
+        else {
+            Self.complete(
+                requestContext,
+                response: Self.failure("This page cannot be saved.")
+            )
+            return
+        }
+
+        Task {
+            do {
+                try await ShareIngestionClient.enqueueURL(url)
+                Self.complete(requestContext, response: ["success": true])
+            } catch {
+                Self.complete(
+                    requestContext,
+                    response: Self.failure(error.localizedDescription)
+                )
+            }
+        }
+    }
+
+    private static func complete(
+        _ requestContext: RequestContext,
+        response: [String: Any]
+    ) {
+        let item = NSExtensionItem()
+        item.userInfo = [SFExtensionMessageKey: response]
+        requestContext.value.completeRequest(returningItems: [item])
+    }
+
+    private static func failure(_ message: String) -> [String: Any] {
+        ["success": false, "error": message]
+    }
+}

--- a/StowerSafari/StowerSafari-macOS.entitlements
+++ b/StowerSafari/StowerSafari-macOS.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(STOWER_APP_GROUP)</string>
+	</array>
+</dict>
+</plist>

--- a/StowerSafari/StowerSafari.entitlements
+++ b/StowerSafari/StowerSafari.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(STOWER_APP_GROUP)</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- bundle Save to Stower as a Safari Web Extension for iPhone, iPad, and Mac
- save the active page directly into Stower through Safari native messaging without replacing the current tab
- retain the validated `stower://` handoff as a fallback when native messaging is unavailable
- isolate Debug and Release extension storage with their matching App Groups
- document the normal Safari enablement flow

## Validation
- `npm test --prefix BrowserExtension` — 9 tests pass
- `swiftlint lint --strict` — 0 violations across 134 files
- package tests — 247 tests pass; skipped one pre-existing ReaderSpeechFeature test after its TestStore hung on the first full run
- iOS Debug and Release app builds succeed with the iOS Safari extension embedded
- macOS Debug and Release app builds succeed with the macOS Safari extension embedded
- verified production extension bundle identifier `com.ryanleewilliams.stower.safari` and inherited version/build `0.4.2 (10)`