### PR TITLE
Fix dropped share imports and reader formatting fidelity

### DIFF
--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Jobs.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Jobs.swift
@@ -10,11 +10,20 @@ extension StowerRepository {
             @Dependency(\.uuid)
             var uuid
             try await database.write { db in
-                if kind.isHydrationJob {
+                if kind.isDeduplicated {
+                    // Only jobs that are still going to run count as
+                    // duplicates. A job that already gave up (`failed`) must
+                    // NOT suppress a re-enqueue — re-saving is exactly how the
+                    // user retries a failed import, and swallowing it would
+                    // make the second attempt do nothing at all.
                     let existing = try IngestionJobLocalTable
                         .where { $0.kind.eq(kind.rawValue) }
                         .where { $0.payload.eq(payload) }
                         .where { $0.processedAt.is(nil) }
+                        .where {
+                            $0.status.eq(IngestionJob.Status.queued.rawValue)
+                                || $0.status.eq(IngestionJob.Status.processing.rawValue)
+                        }
                         .fetchCount(db)
                     guard existing == 0 else { return }
                 }
@@ -541,11 +550,23 @@ extension StowerRepository {
 }
 
 private extension IngestionJob.Kind {
-    var isHydrationJob: Bool {
+    /// Kinds whose payload identifies the work, so re-enqueuing the same
+    /// payload while an earlier job is still unprocessed is a no-op.
+    ///
+    /// `.url` is included: when a share appears not to have worked, people
+    /// share the same link again (and again). Each attempt used to queue
+    /// another job, so one link became N captures of the same page — N × up to
+    /// 3 attempts of a 30s WebKit capture, all of them head-of-line blocking
+    /// every other pending import.
+    ///
+    /// `.pdf`/`.website` payloads are unique staging paths and `.text`/
+    /// `.markdown` payloads are user content that can legitimately repeat, so
+    /// those still enqueue unconditionally.
+    var isDeduplicated: Bool {
         switch self {
-        case .hydrate, .hydrateText, .hydrateWebsite:
+        case .hydrate, .hydrateText, .hydrateWebsite, .url:
             true
-        case .url, .pdf, .website, .text, .markdown:
+        case .pdf, .website, .text, .markdown:
             false
         }
     }

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Reads.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Reads.swift
@@ -6,6 +6,50 @@ extension StowerRepository {
     // StowerRepository+Filters.swift — every caller now routes through a
     // `LibraryFilter` so the repository can push the filter into SQL.
 
+    /// Non-trashed items that carry an http(s) source URL, oldest first.
+    ///
+    /// Backs the bulk re-extract action: only URL-backed items can be rebuilt,
+    /// because re-extraction re-fetches the page and runs it back through the
+    /// capture pipeline. PDFs, imported website zips and hand-written text
+    /// items have no upstream to re-read, so they are excluded.
+    ///
+    /// Oldest first so the progress counter advances through the library in a
+    /// stable order — a user who cancels and resumes covers new ground rather
+    /// than redoing the most recent saves.
+    static func _fetchReextractableItems(
+        database: any DatabaseWriter
+    ) -> @Sendable () async throws -> [SavedItem] {
+        {
+            try await database.read { db -> [SavedItem] in
+                let synced: [SavedItemSyncTable] = try SavedItemSyncTable
+                    .where { $0.deletedAt.is(nil) }
+                    .where { $0.sourceURL.isNot(nil) }
+                    .order { $0.createdAt }
+                    .fetchAll(db)
+
+                let candidates = synced.filter { row in
+                    guard let raw = row.sourceURL,
+                          let url = URL(string: raw),
+                          let scheme = url.scheme?.lowercased()
+                    else { return false }
+                    return scheme == "http" || scheme == "https"
+                }
+
+                let ids: [UUID] = candidates.map(\.id)
+                let locals: [SavedItemContentLocalTable] = ids.isEmpty
+                    ? []
+                    : try SavedItemContentLocalTable
+                        .where { $0.itemID.in(ids) }
+                        .fetchAll(db)
+                let localByID: [UUID: SavedItemContentLocalTable] = Dictionary(
+                    uniqueKeysWithValues: locals.map { ($0.itemID, $0) }
+                )
+
+                return candidates.map { toDomain(sync: $0, local: localByID[$0.id]) }
+            }
+        }
+    }
+
     static func _loadItem(database: any DatabaseWriter) -> @Sendable (UUID) async throws -> SavedItem? {
         { (id: UUID) async throws -> SavedItem? in
             try await database.read { db -> SavedItem? in

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository.swift
@@ -5,6 +5,9 @@ import SQLiteData
 
 public struct StowerRepository: Sendable {
     public var fetchLibrary: @Sendable (LibraryFilter) async throws -> [SavedItem]
+    /// Every non-trashed item that can be re-extracted from its source URL,
+    /// oldest first. Backs the bulk "re-extract library" maintenance action.
+    public var fetchReextractableItems: @Sendable () async throws -> [SavedItem]
     public var loadItem: @Sendable (UUID) async throws -> SavedItem?
     public var createItemFromIngestion: @Sendable (IngestionResult) async throws -> SavedItem
     public var updateItemFromIngestion: @Sendable (UUID, IngestionResult) async throws -> SavedItem?
@@ -132,6 +135,7 @@ extension StowerRepository {
     static let failing: StowerRepository = {
         StowerRepository(
             fetchLibrary: { _ in [] },
+            fetchReextractableItems: { [] },
             loadItem: { _ in nil },
             createItemFromIngestion: { _ in throw RepositoryError.notBootstrapped },
             updateItemFromIngestion: { _, _ in nil },
@@ -262,6 +266,7 @@ extension StowerRepository {
 
         return Self(
             fetchLibrary: _fetchLibraryFiltered(database: database),
+            fetchReextractableItems: _fetchReextractableItems(database: database),
             loadItem: _loadItem(database: database),
             createItemFromIngestion: cachedCreateFromIngestion,
             updateItemFromIngestion: cachedUpdateFromIngestion,

--- a/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
@@ -17,10 +17,12 @@ public struct AppFeature {
         @Presents public var reader: ReaderFeature.State?
         public var startupFinished = false
         public var startupErrorMessage: String?
-        public var failedImportCount = 0
+        public var failedImports = [FailedImport]()
         public var recentlyCompletedItem: SavedItem?
         public var cloudSyncStatus: CloudSyncStatus = .starting
         @Presents public var resetAlert: AlertState<Action.ResetAlert>?
+
+        public var failedImportCount: Int { failedImports.count }
 
         public var palette: FlexokiPalette { cachedAppearance.palette }
 
@@ -97,7 +99,7 @@ public struct AppFeature {
         case browserExtensionURLReceived(URL)
         case startupFinished
         case startupFailed(String)
-        case failedImportsLoaded(Int)
+        case failedImportsLoaded([FailedImport])
         case retryFailedImportsTapped
         case dismissFailedImportsTapped
         case readerAppearanceLoaded(ReaderAppearanceSettings)
@@ -232,7 +234,7 @@ public struct AppFeature {
                                 ) { date.now }
                             }
                             await send(.failedImportsLoaded(
-                                try await repository.fetchFailedIngestionJobs().count
+                                FailedImport.list(from: try await repository.fetchFailedIngestionJobs())
                             ))
                             try await cloudSyncClient.sendChanges()
                             await send(.startupFinished)
@@ -255,8 +257,8 @@ public struct AppFeature {
                 state.startupErrorMessage = message
                 return .none
 
-            case .failedImportsLoaded(let count):
-                state.failedImportCount = count
+            case .failedImportsLoaded(let imports):
+                state.failedImports = imports
                 return .none
 
             case .retryFailedImportsTapped:
@@ -266,7 +268,7 @@ public struct AppFeature {
                 let textIngestionClient = self.textIngestionClient
                 let date = self.date
                 let ingestionCoordinator = self.ingestionCoordinator
-                state.failedImportCount = 0
+                state.failedImports = []
                 return .run { send in
                     try? await repository.retryFailedIngestionJobs()
                     try? await ingestionCoordinator.run {
@@ -277,15 +279,15 @@ public struct AppFeature {
                             textIngestionClient: textIngestionClient
                         ) { date.now }
                     }
-                    let count = (try? await repository.fetchFailedIngestionJobs().count) ?? 0
-                    await send(.failedImportsLoaded(count))
+                    let jobs = (try? await repository.fetchFailedIngestionJobs()) ?? []
+                    await send(.failedImportsLoaded(FailedImport.list(from: jobs)))
                     await send(.library(.reload))
                 }
 
             case .dismissFailedImportsTapped:
                 let repository = self.repository
                 let now = date.now
-                state.failedImportCount = 0
+                state.failedImports = []
                 return .run { _ in
                     try? await repository.dismissFailedIngestionJobs(now)
                 }
@@ -297,10 +299,16 @@ public struct AppFeature {
                 // drain the queue and reload the library so newly-saved items
                 // show up immediately without requiring a cold launch.
                 //
-                // Startup already drains the queue once, so this is a no-op on
+                // Startup also drains the queue, so this is usually a no-op on
                 // the very first activation — `processIngestionJobs` marks
                 // jobs as processed and skips them on subsequent calls.
-                guard state.startupFinished else { return .none }
+                //
+                // This deliberately does NOT wait for startup to finish. When
+                // the user launches Stower straight from the share sheet, the
+                // activation can land while startup is still running; skipping
+                // the drain then left the just-shared URL sitting in the queue
+                // until some later launch. `ingestionCoordinator` serializes
+                // the two drains, so overlapping is safe.
                 let repository = self.repository
                 let ingestionClient = self.ingestionClient
                 let pdfIngestionClient = self.pdfIngestionClient
@@ -316,8 +324,8 @@ public struct AppFeature {
                             textIngestionClient: textIngestionClient
                         ) { date.now }
                     }
-                    let count = (try? await repository.fetchFailedIngestionJobs().count) ?? 0
-                    await send(.failedImportsLoaded(count))
+                    let jobs = (try? await repository.fetchFailedIngestionJobs()) ?? []
+                    await send(.failedImportsLoaded(FailedImport.list(from: jobs)))
                     await send(.library(.reload))
                     await send(.sidebar(.reload))
                 }
@@ -418,8 +426,8 @@ public struct AppFeature {
                                 textIngestionClient: textIngestionClient
                             ) { date.now }
                         }
-                        let count = (try? await repository.fetchFailedIngestionJobs().count) ?? 0
-                        await send(.failedImportsLoaded(count))
+                        let jobs = (try? await repository.fetchFailedIngestionJobs()) ?? []
+                        await send(.failedImportsLoaded(FailedImport.list(from: jobs)))
                         await send(.library(.reload))
                         await send(.sidebar(.reload))
                     }
@@ -584,7 +592,10 @@ private func processIngestionJobs(
             try? await repository.failIngestionJob(job.id, "Import cancelled.", now())
             throw CancellationError()
         } catch {
-            try await repository.failIngestionJob(job.id, error.localizedDescription, now())
+            // `try?`, not `try`: if recording the failure itself fails, the
+            // remaining queued imports must still be drained. Rethrowing here
+            // stranded every job that the failing one was ahead of.
+            try? await repository.failIngestionJob(job.id, error.localizedDescription, now())
         }
     }
 }

--- a/StowerPackage/Sources/StowerFeatureV2/ContentView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/ContentView.swift
@@ -109,8 +109,8 @@ public struct AppView: View {
                     if let completedItem = store.recentlyCompletedItem {
                         completedItemNotice(completedItem, palette: palette)
                     }
-                    if store.failedImportCount > 0 {
-                        importFailureNotice(count: store.failedImportCount, palette: palette)
+                    if !store.failedImports.isEmpty {
+                        importFailureNotice(imports: store.failedImports, palette: palette)
                     }
                 }
             }
@@ -141,15 +141,47 @@ public struct AppView: View {
     }
 
     private func importFailureNotice(
-        count: Int,
+        imports: [FailedImport],
         palette: FlexokiPalette
     ) -> some View {
-        HStack(spacing: 12) {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
             Image(systemName: "exclamationmark.arrow.trianglehead.2.clockwise.rotate.90")
                 .foregroundStyle(palette.warning)
                 .accessibilityHidden(true)
-            Text(count == 1 ? "1 import needs attention." : "\(count) imports need attention.")
+            VStack(alignment: .leading, spacing: 2) {
+                Text(
+                    imports.count == 1
+                        ? "1 import needs attention."
+                        : "\(imports.count) imports need attention."
+                )
                 .font(.callout.weight(.medium))
+
+                // Name the first failure outright. Knowing which link failed
+                // and why is what makes Retry a decision instead of a guess.
+                if let first = imports.first {
+                    Text(first.label)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    if let reason = first.reason {
+                        Text(reason)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                    if imports.count > 1 {
+                        Text(
+                            imports.count == 2
+                                ? "and 1 more"
+                                : "and \(imports.count - 1) more"
+                        )
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
             Spacer(minLength: 8)
             Button("Dismiss") {
                 store.send(.dismissFailedImportsTapped)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAppearanceSettings+Theme.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAppearanceSettings+Theme.swift
@@ -193,12 +193,36 @@ extension ReaderAppearanceSettings {
           padding: 20px 20px 60px 20px !important;
           box-sizing: border-box !important;
         }
-        .stower-article {
+        /* Two container shapes reach this stylesheet: `.stower-article` from
+           ReaderDocumentHTMLBuilder, and `#stower-reader-document` from a
+           native web capture. This CSS replaces whatever the page shipped
+           with, so a rule that names only one of them leaves the other with
+           no measure at all — captured articles ran the full width of the
+           window, which is unreadable on iPad and Mac and stretched every
+           image to match. */
+        .stower-article, #stower-reader-document {
           width: 100% !important;
           max-width: \(columnWidth)px !important;
           margin: 0 auto !important;
           overflow-x: clip !important;
+          box-sizing: border-box !important;
         }
+        /* Baseline media/figure treatment. The structured path layers its own
+           richer rules on top via the separate runtime stylesheet; captured
+           articles have only this. */
+        figure { margin: 1.6em 0 !important; }
+        figure img, figure video, figure picture { display: block; margin: 0 auto; }
+        figcaption {
+          font-size: 0.85em;
+          opacity: 0.72;
+          text-align: center;
+          margin-top: 0.5em;
+        }
+        video, picture { max-width: 100% !important; height: auto !important; }
+        /* Wide tables and long code lines scroll inside their own box rather
+           than forcing the whole document sideways. */
+        table { display: block; overflow-x: auto; }
+        pre { white-space: pre; }
         a { color: var(--stower-primary) !important; text-decoration-color: color-mix(in srgb, var(--stower-primary) 45%, transparent); }
         a:hover { color: var(--stower-primary-muted) !important; }
         pre, code { background: var(--stower-bg2) !important; color: var(--stower-tx) !important; border-radius: 6px; }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsFeature.swift
@@ -1,4 +1,55 @@
 import ComposableArchitecture
+import Foundation
+
+/// Progress of the bulk re-extract maintenance action.
+///
+/// Re-extraction rebuilds a saved article from its source URL through the
+/// current capture pipeline. Extraction fixes only apply at save time, so
+/// articles saved by an older build keep whatever structure that build
+/// produced until they are rebuilt.
+public enum LibraryReextractionState: Equatable, Sendable {
+    case idle
+    case running(Progress)
+    case finished(Summary)
+
+    public struct Progress: Equatable, Sendable {
+        public var completed: Int
+        public var total: Int
+        public var failed: Int
+        public var currentTitle: String?
+
+        public init(completed: Int = 0, total: Int = 0, failed: Int = 0, currentTitle: String? = nil) {
+            self.completed = completed
+            self.total = total
+            self.failed = failed
+            self.currentTitle = currentTitle
+        }
+
+        public var fraction: Double {
+            guard total > 0 else { return 0 }
+            return Double(completed) / Double(total)
+        }
+    }
+
+    public struct Summary: Equatable, Sendable {
+        public var succeeded: Int
+        public var failed: Int
+        public var wasCancelled: Bool
+
+        public init(succeeded: Int, failed: Int, wasCancelled: Bool) {
+            self.succeeded = succeeded
+            self.failed = failed
+            self.wasCancelled = wasCancelled
+        }
+    }
+
+    public var isRunning: Bool {
+        if case .running = self {
+            return true
+        }
+        return false
+    }
+}
 
 @Reducer
 public struct SettingsFeature {
@@ -10,6 +61,7 @@ public struct SettingsFeature {
         public var errorMessage: String?
         public var cloudSyncStatus: CloudSyncStatus = .starting
         public var diagnostics: SyncDiagnostics?
+        public var reextraction: LibraryReextractionState = .idle
 
         public init() {}
     }
@@ -25,12 +77,24 @@ public struct SettingsFeature {
         case saveFailed(String)
         case refreshDiagnostics
         case diagnosticsLoaded(SyncDiagnostics)
+
+        // MARK: Bulk re-extract
+        case reextractLibraryTapped
+        case reextractCancelTapped
+        case reextractStarted(total: Int)
+        case reextractItemFinished(title: String?, succeeded: Bool)
+        case reextractCompleted(wasCancelled: Bool)
+        case reextractDismissed
     }
 
     @Dependency(\.stowerRepository)
     var repository
     @Dependency(\.syncDiagnosticsClient)
     var syncDiagnosticsClient
+    @Dependency(\.articleSaveClient)
+    var articleSaveClient
+    @Dependency(\.ingestionCoordinator)
+    var ingestionCoordinator
 
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -99,7 +163,100 @@ public struct SettingsFeature {
             case .diagnosticsLoaded(let diagnostics):
                 state.diagnostics = diagnostics
                 return .none
+
+            // MARK: Bulk re-extract
+
+            case .reextractLibraryTapped:
+                guard !state.reextraction.isRunning else { return .none }
+                state.reextraction = .running(LibraryReextractionState.Progress())
+                state.errorMessage = nil
+
+                let repository = self.repository
+                let articleSaveClient = self.articleSaveClient
+                let ingestionCoordinator = self.ingestionCoordinator
+                return .run { send in
+                    let items = (try? await repository.fetchReextractableItems()) ?? []
+                    await send(.reextractStarted(total: items.count))
+                    guard !items.isEmpty else {
+                        await send(.reextractCompleted(wasCancelled: false))
+                        return
+                    }
+
+                    // Each refresh drives a WebKit capture. Running through
+                    // the ingestion coordinator keeps this from overlapping a
+                    // queue drain, so shared URLs and the rebuild never fight
+                    // over the same WebView and database writes.
+                    try? await ingestionCoordinator.run {
+                        for item in items {
+                            if Task.isCancelled {
+                                return
+                            }
+                            guard let source = item.sourceURL,
+                                  let url = URL(string: source)
+                            else {
+                                await send(.reextractItemFinished(title: item.title, succeeded: false))
+                                continue
+                            }
+                            do {
+                                _ = try await articleSaveClient.refresh(item.id, url)
+                                await send(.reextractItemFinished(title: item.title, succeeded: true))
+                            } catch is CancellationError {
+                                return
+                            } catch {
+                                // One unreachable or paywalled article must not
+                                // stop the rebuild — record it and carry on.
+                                await send(.reextractItemFinished(title: item.title, succeeded: false))
+                            }
+                        }
+                    }
+                    await send(.reextractCompleted(wasCancelled: Task.isCancelled))
+                }
+                .cancellable(id: CancelID.reextraction, cancelInFlight: true)
+
+            case .reextractStarted(let total):
+                guard case .running(var progress) = state.reextraction else { return .none }
+                progress.total = total
+                state.reextraction = .running(progress)
+                return .none
+
+            case let .reextractItemFinished(title, succeeded):
+                guard case .running(var progress) = state.reextraction else { return .none }
+                progress.completed += 1
+                if !succeeded { progress.failed += 1 }
+                progress.currentTitle = title
+                state.reextraction = .running(progress)
+                return .none
+
+            case .reextractCancelTapped:
+                guard case .running(let progress) = state.reextraction else { return .none }
+                state.reextraction = .finished(
+                    LibraryReextractionState.Summary(
+                        succeeded: progress.completed - progress.failed,
+                        failed: progress.failed,
+                        wasCancelled: true
+                    )
+                )
+                return .cancel(id: CancelID.reextraction)
+
+            case .reextractCompleted(let wasCancelled):
+                guard case .running(let progress) = state.reextraction else { return .none }
+                state.reextraction = .finished(
+                    LibraryReextractionState.Summary(
+                        succeeded: progress.completed - progress.failed,
+                        failed: progress.failed,
+                        wasCancelled: wasCancelled
+                    )
+                )
+                return .none
+
+            case .reextractDismissed:
+                state.reextraction = .idle
+                return .none
             }
         }
+    }
+
+    enum CancelID {
+        case reextraction
     }
 }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsScreen.swift
@@ -85,6 +85,23 @@ public struct SettingsScreen: View {
                 )
             }
 
+            Section {
+                reextractionRows
+            } header: {
+                Text("Reader")
+            } footer: {
+                Text(
+                    """
+                    Rebuilds saved articles from their source URLs using the \
+                    current reader. Use this if older articles show broken \
+                    tables, run-together code, or missing lists. Needs a \
+                    network connection, re-downloads every article, and can \
+                    take a while — you can stop at any point and pick it up \
+                    again later.
+                    """
+                )
+            }
+
             if let error = store.errorMessage {
                 Text(error)
                     .foregroundStyle(palette.error)
@@ -104,6 +121,87 @@ public struct SettingsScreen: View {
         .task {
             store.send(.load)
         }
+    }
+
+    @ViewBuilder private var reextractionRows: some View {
+        switch store.reextraction {
+        case .idle:
+            Button("Re-extract All Articles") {
+                store.send(.reextractLibraryTapped)
+            }
+
+        case .running(let progress):
+            VStack(alignment: .leading, spacing: 8) {
+                if progress.total > 0 {
+                    ProgressView(value: progress.fraction) {
+                        Text("Re-extracting \(progress.completed) of \(progress.total)")
+                            .font(.callout)
+                    }
+                } else {
+                    ProgressView {
+                        Text("Preparing…")
+                            .font(.callout)
+                    }
+                }
+
+                if let title = progress.currentTitle {
+                    Text(title)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+
+                if progress.failed > 0 {
+                    Text(
+                        progress.failed == 1
+                            ? "1 couldn't be rebuilt and was left as it was."
+                            : "\(progress.failed) couldn't be rebuilt and were left as they were."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(palette.warning)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button("Stop", role: .cancel) {
+                store.send(.reextractCancelTapped)
+            }
+
+        case .finished(let summary):
+            VStack(alignment: .leading, spacing: 4) {
+                Text(finishedHeadline(summary))
+                    .font(.callout)
+                if summary.failed > 0 {
+                    Text(
+                        summary.failed == 1
+                            ? "1 article kept its previous version."
+                            : "\(summary.failed) articles kept their previous version."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button("Done") {
+                store.send(.reextractDismissed)
+            }
+        }
+    }
+
+    private func finishedHeadline(_ summary: LibraryReextractionState.Summary) -> String {
+        if summary.wasCancelled {
+            return summary.succeeded == 1
+                ? "Stopped after rebuilding 1 article."
+                : "Stopped after rebuilding \(summary.succeeded) articles."
+        }
+        if summary.succeeded == 0 && summary.failed == 0 {
+            return "No articles to rebuild."
+        }
+        return summary.succeeded == 1
+            ? "Rebuilt 1 article."
+            : "Rebuilt \(summary.succeeded) articles."
     }
 
     private func syncSummary(_ status: CloudSyncStatus) -> String {

--- a/StowerPackage/Sources/StowerFeatureV2/Support/FailedImport.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/FailedImport.swift
@@ -1,0 +1,65 @@
+import Foundation
+import StowerData
+
+/// A queued import that gave up, in the shape the failure banner needs.
+///
+/// The banner used to show only a count ("2 imports need attention"), which
+/// told the user nothing about *what* failed or *why* — so a share that
+/// silently failed looked identical to one that never arrived, and the only
+/// available response was to share the link again and hope.
+public struct FailedImport: Equatable, Identifiable, Sendable {
+    public let id: UUID
+    /// What was being imported, in user terms — a host + path for URLs, a
+    /// filename for PDFs and website archives, an excerpt for text.
+    public let label: String
+    /// Why it gave up, taken from the job's last recorded error.
+    public let reason: String?
+
+    public init(id: UUID, label: String, reason: String?) {
+        self.id = id
+        self.label = label
+        self.reason = reason
+    }
+
+    public static func list(from jobs: [IngestionJob]) -> [FailedImport] {
+        jobs.map(FailedImport.init(job:))
+    }
+
+    public init(job: IngestionJob) {
+        self.id = job.id
+        self.label = Self.label(for: job)
+        let trimmed = job.lastError?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.reason = (trimmed?.isEmpty ?? true) ? nil : trimmed
+    }
+
+    private static func label(for job: IngestionJob) -> String {
+        switch job.kind {
+        case .url, .hydrate:
+            return displayURL(job.payload)
+        case .pdf, .website, .hydrateWebsite:
+            // Payloads are staging paths inside the App Group container.
+            let name = URL(fileURLWithPath: job.payload).lastPathComponent
+            return name.isEmpty ? "Imported file" : name
+        case .text, .markdown, .hydrateText:
+            // Payloads are JSON envelopes; the raw text is more confusing than
+            // helpful, so name the kind instead.
+            return job.kind == .markdown ? "Imported Markdown" : "Imported text"
+        }
+    }
+
+    /// `https://www.example.com/a/b?x=1` → `example.com/a/b`. Long paths are
+    /// truncated in the middle so both the site and the final path component
+    /// stay readable in a single banner line.
+    static func displayURL(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed), let host = url.host() else {
+            return trimmed
+        }
+        let site = host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
+        let path = url.path()
+        guard !path.isEmpty, path != "/" else { return site }
+        let combined = site + (path.hasSuffix("/") ? String(path.dropLast()) : path)
+        guard combined.count > 60 else { return combined }
+        return combined.prefix(34) + "…" + combined.suffix(20)
+    }
+}

--- a/StowerPackage/Sources/StowerFeatureV2/Support/HTMLBlockParser.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/HTMLBlockParser.swift
@@ -14,9 +14,24 @@ func parseBlocks(root: Element, baseURL: URL) throws -> ParsedBlocks {
     }
 
     let toRemove = try body.select(
-        "script, style, svg, canvas, template, nav, footer, header, aside, form, button, [aria-hidden=true], [hidden], .sr-only, .visually-hidden, .screen-reader-text, .sidebar, .related, .share, .comments"
+        "script, style, svg, canvas, template, nav, footer, form, button, [aria-hidden=true], [hidden], .sr-only, .visually-hidden, .screen-reader-text, .sidebar, .related, .share, .comments"
     )
     try toRemove.remove()
+
+    // `header` and `aside` used to be removed outright. That also deleted the
+    // article's own headline block (many sites wrap the h1 + standfirst in a
+    // `<header>` inside `<article>`) and every pull quote, sidenote and
+    // callout. Only drop the ones that are actually site chrome.
+    let chrome = try body.select(
+        """
+        header[role=banner], aside[role=navigation], aside[role=complementary], \
+        header[class*=site], header[class*=global], header[class*=masthead], \
+        header[class*=nav], aside[class*=nav], aside[class*=sidebar], \
+        aside[class*=related], aside[class*=promo], aside[class*=newsletter], \
+        aside[class*=subscribe], aside[class*=advert]
+        """
+    )
+    try chrome.remove()
 
     // Remove permalink/headerlink anchors commonly added next to headings by
     // static site generators (MkDocs, Sphinx, Hugo, Jekyll, Docusaurus, etc.).
@@ -67,32 +82,64 @@ func parseBlock(_ element: Element) throws -> ParsedBlocks {
         return ParsedBlocks(blocks: inlines.isEmpty ? [] : [.heading(level: level, inlines: inlines)], media: [], embeds: [])
 
     case "p":
-        let inlines = try parseInlines(element)
-        var blocks: [ReaderBlock] = inlines.isEmpty ? [] : [.paragraph(inlines)]
         var media = [MediaDescriptor]()
         var embeds = [EmbedDescriptor]()
+        var mediaBlocks = [ReaderBlock]()
 
         let mediaNodes = try element.select("img,picture,video,iframe,figure").array()
         for mediaNode in mediaNodes {
             let parsed = try parseBlock(mediaNode)
-            blocks.append(contentsOf: parsed.blocks)
+            mediaBlocks.append(contentsOf: parsed.blocks)
             media.append(contentsOf: parsed.media)
             embeds.append(contentsOf: parsed.embeds)
         }
 
+        // Parse the prose from a copy with the media subtrees removed. Parsing
+        // the original would pull each `<figcaption>` into the paragraph text
+        // *and* emit it again as the figure's caption, so every captioned
+        // image inside a paragraph printed its caption twice.
+        let inlines: [ReaderInline]
+        if mediaNodes.isEmpty {
+            inlines = try parseInlines(element)
+        } else {
+            let prose = element.copy() as! Element
+            try prose.select("img,picture,video,iframe,figure").remove()
+            inlines = try parseInlines(prose)
+        }
+
+        var blocks: [ReaderBlock] = inlines.isEmpty ? [] : [.paragraph(inlines)]
+        blocks.append(contentsOf: mediaBlocks)
+
         return ParsedBlocks(blocks: dedupeBlocks(blocks), media: dedupeMedia(media), embeds: dedupeEmbeds(embeds))
 
     case "ul", "ol":
-        let listItems = try element.select("> li").array().map { try parseInlines($0) }.filter { !$0.isEmpty }
+        let listItems = try parseListItems(element)
         return ParsedBlocks(blocks: listItems.isEmpty ? [] : [.list(ordered: tag == "ol", items: listItems)], media: [], embeds: [])
+
+    case "dl":
+        // Description lists render as a list of "term — definition" items.
+        // Without this case they fall through to `default`, which emits one
+        // paragraph per <dt>/<dd> and loses the pairing entirely.
+        let items = try parseDescriptionList(element)
+        return ParsedBlocks(blocks: items.isEmpty ? [] : [.list(ordered: false, items: items)], media: [], embeds: [])
+
+    case "table":
+        guard let markdown = try markdownTable(from: element) else {
+            return ParsedBlocks(blocks: [], media: [], embeds: [])
+        }
+        return ParsedBlocks(blocks: [.table(markdown: markdown)], media: [], embeds: [])
 
     case "blockquote":
         let inlines = try parseInlines(element)
         return ParsedBlocks(blocks: inlines.isEmpty ? [] : [.blockquote(inlines)], media: [], embeds: [])
 
     case "pre":
-        let language = nonEmpty(try? element.select("code").first()?.attr("class"))
-        let code = cleanText((try? element.text()) ?? "")
+        // Code must keep its line breaks and indentation. `cleanText` (and
+        // SwiftSoup's default `text()`) collapse every run of whitespace to a
+        // single space, which turned every code block in the reader into one
+        // unreadable line that had to be scrolled horizontally.
+        let language = codeLanguage(from: element)
+        let code = preformattedText(element)
         if code.isEmpty {
             return ParsedBlocks(blocks: [], media: [], embeds: [])
         }
@@ -253,7 +300,11 @@ func parseInlinesRaw(_ element: Element) throws -> [ReaderInline] {
             }
 
         case "br":
-            inlines.append(.text("\n"))
+            // `.text("\n")` renders as a literal newline in the generated
+            // HTML, which the browser collapses to a space — poetry, verse,
+            // addresses and lyrics all ran together. `.lineBreak` is rendered
+            // as a real `<br>` by `ReaderDocumentHTMLBuilder`.
+            inlines.append(.lineBreak)
 
         default:
             // Recurse through the *raw* worker so we don't strip the
@@ -355,12 +406,230 @@ func trimInlineEdges(_ inlines: [ReaderInline]) -> [ReaderInline] {
     return result
 }
 
+// MARK: - Lists
+
+func isListTag(_ tag: String) -> Bool {
+    let lowered = tag.lowercased()
+    return lowered == "ul" || lowered == "ol"
+}
+
+/// Parses the direct `<li>` children of a `<ul>`/`<ol>`.
+///
+/// Two things the naive `select("> li").map(parseInlines)` got wrong:
+///
+///  * A nested `<ul>`/`<ol>` inside an `<li>` was flattened into the parent
+///    item's inline run with no separator at all, so "Fruit / Apple / Pear"
+///    came out as the single item "FruitApplePear". Nested items are now
+///    lifted into the same list as their own entries, prefixed so the
+///    hierarchy is still legible.
+///  * An `<li>` containing several block children (`<p>`, `<div>`) had them
+///    concatenated with no space, fusing the last word of one paragraph to
+///    the first word of the next.
+func parseListItems(_ element: Element) throws -> [[ReaderInline]] {
+    var items = [[ReaderInline]]()
+
+    for item in try element.select("> li").array() {
+        // Nested lists are extracted first so the parent's own text can be
+        // parsed without them.
+        let nestedLists = item.children().array().filter { isListTag($0.tagName()) }
+
+        let own = item.copy() as! Element
+        for nested in own.children().array() where isListTag(nested.tagName()) {
+            try nested.remove()
+        }
+        let ownInlines = try trimInlineEdges(parseBlockishInlines(own))
+        if !ownInlines.isEmpty {
+            items.append(ownInlines)
+        }
+
+        for nested in nestedLists {
+            for nestedItem in try parseListItems(nested) {
+                items.append([.text("— ")] + nestedItem)
+            }
+        }
+    }
+
+    return items
+}
+
+/// Parses `<dl>` into "term — definition" rows. Each `<dt>` starts a new row;
+/// the `<dd>`s that follow are appended to it.
+func parseDescriptionList(_ element: Element) throws -> [[ReaderInline]] {
+    var items = [[ReaderInline]]()
+    var current: [ReaderInline]?
+
+    for child in element.getChildNodes() {
+        guard let child = child as? Element else { continue }
+        switch child.tagName().lowercased() {
+        case "dt":
+            if let current, !current.isEmpty { items.append(current) }
+            let term = try trimInlineEdges(parseBlockishInlines(child))
+            current = term.isEmpty ? nil : [.strong(inlineText(term))]
+        case "dd":
+            let definition = try trimInlineEdges(parseBlockishInlines(child))
+            guard !definition.isEmpty else { continue }
+            if current == nil {
+                current = definition
+            } else {
+                current?.append(.text(" — "))
+                current?.append(contentsOf: definition)
+            }
+        default:
+            continue
+        }
+    }
+
+    if let current, !current.isEmpty { items.append(current) }
+    return items
+}
+
+/// Parses an element whose children may mix inline content with block-level
+/// children (`<li>`, `<dd>`, `<blockquote>`, table cells). Block children are
+/// joined with a space so their text doesn't fuse together.
+func parseBlockishInlines(_ element: Element) throws -> [ReaderInline] {
+    let blockTags: Set<String> = ["p", "div", "section", "blockquote"]
+    let hasBlockChildren = element.children().array().contains { blockTags.contains($0.tagName().lowercased()) }
+    guard hasBlockChildren else {
+        return try parseInlinesRaw(element)
+    }
+
+    var inlines = [ReaderInline]()
+    for node in element.getChildNodes() {
+        if let textNode = node as? TextNode {
+            let text = cleanInlineText(textNode.text())
+            if !text.isEmpty { inlines.append(.text(text)) }
+            continue
+        }
+        guard let child = node as? Element else { continue }
+        let parsed = try parseInlinesRaw(child)
+        guard !parsed.isEmpty else { continue }
+        if !inlines.isEmpty { inlines.append(.text(" ")) }
+        inlines.append(contentsOf: parsed)
+    }
+    return mergeTextInlines(inlines)
+}
+
+// MARK: - Tables
+
+/// Converts a `<table>` into the GFM pipe-table string that
+/// `ReaderDocumentHTMLBuilder.renderMarkdownTable` already knows how to render
+/// as a real `<table>`.
+///
+/// Without this, `<table>` fell through to `parseBlock`'s `default` case,
+/// which recursed into `<tr>`/`<td>` and emitted **one paragraph per cell** —
+/// any article containing a comparison table became an unreadable column of
+/// orphaned fragments.
+func markdownTable(from element: Element) throws -> String? {
+    let rowElements = try element.select("tr").array()
+    guard !rowElements.isEmpty else { return nil }
+
+    var rows = [[String]]()
+    for rowElement in rowElements {
+        let cells = rowElement.children().array().filter {
+            let tag = $0.tagName().lowercased()
+            return tag == "th" || tag == "td"
+        }
+        guard !cells.isEmpty else { continue }
+        rows.append(cells.map { cell in
+            // Pipes would break the row encoding, and newlines would split a
+            // single cell across rows.
+            cleanText((try? cell.text()) ?? "")
+                .replacingOccurrences(of: "|", with: "\\|")
+        })
+    }
+
+    guard !rows.isEmpty else { return nil }
+    guard rows.contains(where: { $0.contains { !$0.isEmpty } }) else { return nil }
+
+    // Layout tables (a single row, or a single column) read better as prose
+    // than as a one-cell grid, so leave them to the default block handling.
+    let columnCount = rows.map(\.count).max() ?? 0
+    guard columnCount >= 2, rows.count >= 2 else { return nil }
+
+    func line(_ cells: [String]) -> String {
+        var padded = cells
+        while padded.count < columnCount { padded.append("") }
+        return "| " + padded.joined(separator: " | ") + " |"
+    }
+
+    let header = rows.removeFirst()
+    var markdown = line(header)
+    markdown += "\n| " + Array(repeating: "---", count: columnCount).joined(separator: " | ") + " |"
+    for row in rows {
+        markdown += "\n" + line(row)
+    }
+    return markdown
+}
+
+// MARK: - Code
+
+/// Text content of a `<pre>` with line breaks and indentation intact, and the
+/// common leading indentation stripped so the reader isn't scrolled sideways
+/// by the source document's nesting.
+func preformattedText(_ element: Element) -> String {
+    let raw = (try? element.text(trimAndNormaliseWhitespace: false)) ?? ""
+    let unescaped = (try? Entities.unescape(raw)) ?? raw
+    let normalized = unescaped
+        .replacingOccurrences(of: "\r\n", with: "\n")
+        .replacingOccurrences(of: "\r", with: "\n")
+        .replacingOccurrences(of: "\u{00A0}", with: " ")
+        .replacingOccurrences(of: "\u{200B}", with: "")
+        .replacingOccurrences(of: "\u{FEFF}", with: "")
+
+    var lines = normalized.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    while let first = lines.first, first.trimmingCharacters(in: .whitespaces).isEmpty {
+        lines.removeFirst()
+    }
+    while let last = lines.last, last.trimmingCharacters(in: .whitespaces).isEmpty {
+        lines.removeLast()
+    }
+    guard !lines.isEmpty else { return "" }
+
+    let indents = lines
+        .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        .map { $0.prefix { $0 == " " || $0 == "\t" }.count }
+    let commonIndent = indents.min() ?? 0
+    if commonIndent > 0 {
+        lines = lines.map { String($0.dropFirst(min(commonIndent, $0.count))) }
+    }
+
+    return lines
+        .joined(separator: "\n")
+        .replacingOccurrences(of: "[ \t]+$", with: "", options: .regularExpression)
+}
+
+/// Extracts a bare language name from a highlighter's class list, e.g.
+/// `"language-swift hljs"` → `"swift"`. Passing the raw class through
+/// produced `class="language-language-swift hljs"` in the rendered HTML.
+func codeLanguage(from element: Element) -> String? {
+    let classes = ((try? element.select("code").first()?.className()) ?? "")
+        .split(whereSeparator: \.isWhitespace)
+        .map(String.init)
+    for name in classes {
+        for prefix in ["language-", "lang-", "highlight-"] where name.hasPrefix(prefix) {
+            return nonEmpty(String(name.dropFirst(prefix.count)))
+        }
+    }
+    // A single non-decorative class is very likely the language itself.
+    let decorative: Set<String> = ["hljs", "highlight", "code", "prettyprint", "sourcecode"]
+    let candidates = classes.filter { !decorative.contains($0.lowercased()) }
+    return candidates.count == 1 ? nonEmpty(candidates[0]) : nil
+}
+
 func parseFallbackDescendants(_ body: Element) throws -> ParsedBlocks {
     var blocks = [ReaderBlock]()
     var media = [MediaDescriptor]()
     var embeds = [EmbedDescriptor]()
 
-    let candidates = try body.select("h1,h2,h3,h4,h5,h6,p,blockquote,pre,ul,ol,img,video,iframe,figure").array()
+    let candidates = try body
+        .select("h1,h2,h3,h4,h5,h6,p,blockquote,pre,ul,ol,dl,table,img,video,iframe,figure")
+        .array()
+        // A nested list/table is already emitted as part of its ancestor, and
+        // media inside a <figure> is emitted with the figure's caption. Taking
+        // them again here would duplicate the content.
+        .filter { element in
+            !element.hasAncestor(matching: ["li", "figure", "table", "pre", "blockquote"])
+        }
     for element in candidates {
         let parsed = try parseBlock(element)
         blocks.append(contentsOf: parsed.blocks)
@@ -373,6 +642,20 @@ func parseFallbackDescendants(_ body: Element) throws -> ParsedBlocks {
         media: dedupeMedia(media),
         embeds: dedupeEmbeds(embeds)
     )
+}
+
+extension Element {
+    /// True when any ancestor of this element has one of `tagNames`.
+    func hasAncestor(matching tagNames: [String]) -> Bool {
+        var node = parent()
+        while let current = node {
+            if tagNames.contains(current.tagName().lowercased()) {
+                return true
+            }
+            node = current.parent()
+        }
+        return false
+    }
 }
 
 func splitLongParagraph(_ text: String) -> [String] {

--- a/StowerPackage/Sources/StowerFeatureV2/Support/HTMLSanitizer.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/HTMLSanitizer.swift
@@ -16,11 +16,54 @@ func sanitizeBlocks(_ input: [ReaderBlock]) -> [ReaderBlock] {
             }
             continue
         }
-        if isLikelyBoilerplateText(text) { continue }
+        if isLikelyBoilerplate(block, text: text) { continue }
         output.append(block)
     }
 
     return dedupeBlocks(output)
+}
+
+/// Drops a leading heading that just repeats the article title.
+///
+/// The reader renders its own header (title, site, author, date) above the
+/// body, so a `<h1>` in the content saying the same thing shows the title
+/// twice. Container-level removal handles the platforms whose header block is
+/// recognisable by class; this is the catch-all for everything else.
+///
+/// Only the *first* heading is considered, and only when it matches the title —
+/// a later section heading that happens to echo the title is left alone.
+func removeLeadingTitleRepeat(_ blocks: [ReaderBlock], title: String) -> [ReaderBlock] {
+    let normalizedTitle = comparableHeadingText(title)
+    guard !normalizedTitle.isEmpty else { return blocks }
+
+    guard let index = blocks.firstIndex(where: { block in
+        switch block {
+        case .heading, .paragraph:
+            return !blockText(block).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        default:
+            // Skip over a hero figure sitting above the headline.
+            return false
+        }
+    }) else { return blocks }
+
+    guard case .heading(_, let inlines) = blocks[index] else { return blocks }
+    guard comparableHeadingText(inlineText(inlines)) == normalizedTitle else { return blocks }
+
+    var output = blocks
+    output.remove(at: index)
+    return output
+}
+
+/// Lowercased, punctuation- and whitespace-insensitive form used to decide
+/// whether a heading and the article title are "the same". Titles routinely
+/// differ between `<title>`/og:title and the on-page `<h1>` by a trailing
+/// site name, smart quotes, or an em dash.
+private func comparableHeadingText(_ value: String) -> String {
+    cleanText(value)
+        .lowercased()
+        .replacingOccurrences(of: "[\\p{Pd}]", with: "-", options: .regularExpression)
+        .replacingOccurrences(of: "[\u{2018}\u{2019}\u{201C}\u{201D}]", with: "'", options: .regularExpression)
+        .replacingOccurrences(of: "[^a-z0-9]+", with: "", options: .regularExpression)
 }
 
 func shouldAlwaysKeepBlock(_ block: ReaderBlock) -> Bool {
@@ -59,7 +102,33 @@ func blockText(_ block: ReaderBlock) -> String {
     }
 }
 
-func isLikelyBoilerplateText(_ rawText: String) -> Bool {
+/// Applies the boilerplate heuristics with the block's own shape in mind.
+///
+/// The heuristics were written for paragraphs but were being applied to the
+/// concatenation of a list's items, which is a completely different shape: a
+/// bulleted list of eight short phrases trips "22+ tokens and no punctuation"
+/// and the whole list disappeared from the article. Lists are judged per item
+/// instead, and only discarded when *every* item looks like chrome. Headings
+/// are short by nature and legitimately unpunctuated, so the word-count rule
+/// does not apply to them at all.
+func isLikelyBoilerplate(_ block: ReaderBlock, text: String) -> Bool {
+    switch block {
+    case .list(_, let items):
+        let itemTexts = items.map(inlineText).filter { !$0.isEmpty }
+        guard !itemTexts.isEmpty else { return true }
+        return itemTexts.allSatisfy { isLikelyBoilerplateText($0) }
+    case .heading:
+        return isLikelyBoilerplateText(text, allowsUnpunctuatedProse: true)
+    case .code:
+        // Code is dense with digits, camelCase and no prose punctuation —
+        // every one of these heuristics fires on a healthy code block.
+        return false
+    default:
+        return isLikelyBoilerplateText(text)
+    }
+}
+
+func isLikelyBoilerplateText(_ rawText: String, allowsUnpunctuatedProse: Bool = false) -> Bool {
     let text = cleanText(rawText)
     guard !text.isEmpty else { return true }
 
@@ -74,7 +143,7 @@ func isLikelyBoilerplateText(_ rawText: String) -> Bool {
 
     // Long runs with zero punctuation are likely navigation menus or tag lists.
     // Raised threshold from 14 to 22 to avoid false positives on real article text.
-    if tokenCount >= 22 && punctuationCount == 0 {
+    if !allowsUnpunctuatedProse && tokenCount >= 22 && punctuationCount == 0 {
         return true
     }
     // High digit-to-letter ratio suggests hashes, IDs, or machine-generated text.
@@ -94,13 +163,26 @@ func isLikelyBoilerplateText(_ rawText: String) -> Bool {
     return false
 }
 
+/// Removes duplicate blocks.
+///
+/// Media blocks are deduplicated across the whole document — the same image
+/// genuinely can be emitted twice by different parse paths. Text blocks are
+/// only collapsed when they repeat *consecutively*: deduplicating those
+/// globally deleted legitimately repeated prose (refrains, recurring section
+/// labels, repeated short answers such as "Yes." / "No."), which left holes in
+/// the article.
 func dedupeBlocks(_ input: [ReaderBlock]) -> [ReaderBlock] {
-    var seen: Set<String> = []
+    var seenMedia: Set<String> = []
     var output = [ReaderBlock]()
     for block in input {
         let fingerprint = String(describing: block)
-        if seen.contains(fingerprint) { continue }
-        seen.insert(fingerprint)
+        switch block {
+        case .figure, .video, .embed:
+            if seenMedia.contains(fingerprint) { continue }
+            seenMedia.insert(fingerprint)
+        default:
+            if let previous = output.last, String(describing: previous) == fingerprint { continue }
+        }
         output.append(block)
     }
     return output

--- a/StowerPackage/Sources/StowerFeatureV2/Support/IngestionCoordinator.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/IngestionCoordinator.swift
@@ -14,22 +14,35 @@ public struct IngestionCoordinator: Sendable {
     }
 }
 
+/// Serializes ingestion drains so two of them never claim jobs concurrently.
+///
+/// The previous implementation awaited the in-flight drain and then returned
+/// *without running the new operation at all*. That silently dropped imports:
+/// a URL shared while an earlier capture was still running (captures can take
+/// 30s+ per article) would sit in the queue untouched, because the drain that
+/// was already running had passed its last `claimNextIngestionJob` scan before
+/// the new job existed. The user saw "Saved to Stower" and then nothing in the
+/// library.
+///
+/// Requests now wait for the in-flight drain and then run, instead of being
+/// discarded.
 private actor IngestionGate {
     private var inFlight: Task<Void, Error>?
 
     func run(
         _ operation: @escaping @Sendable () async throws -> Void
     ) async throws {
-        if let inFlight {
-            try await inFlight.value
-            return
-        }
-
+        let previous = inFlight
         let task = Task {
+            // A failed predecessor must not cancel this drain — each drain
+            // reports its own outcome.
+            _ = try? await previous?.value
             try await operation()
         }
         inFlight = task
-        defer { inFlight = nil }
+        defer {
+            if inFlight == task { inFlight = nil }
+        }
         try await task.value
     }
 }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/RenderedArticleExtractor.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/RenderedArticleExtractor.swift
@@ -50,6 +50,31 @@ enum RenderedArticleExtractor {
         "[class*=recommend]", "[id*=recommend]", "[class*=related]", "[id*=related]",
         "[class*=comment]", "[id*=comment]", "[class*=share]", "[id*=share]",
         "[class*=social]", "[id*=social]", "[class*=cookie]", "[id*=cookie]",
+
+        // The article's own title/subtitle/byline/date block. The reader
+        // renders its own header from the extracted metadata, so leaving this
+        // in printed the title twice, followed by a stray byline and date.
+        //
+        // Deliberately matched on *container* names only. Broader patterns
+        // like `[class*=headline]` or `[class*=paywall]` are not safe here:
+        // substring class matching would also hit body wrappers such as
+        // `story-headline-and-body` or `paywall-content` and delete the
+        // article itself.
+        ".post-header", ".entry-header", ".article-header", "[aria-label='Post header']",
+
+        // Engagement / call-to-action furniture that sits inside the article
+        // element on newsletter platforms: like + restack bars with their
+        // reader-avatar facepiles, "Listen to this post" players, and
+        // standalone CTA buttons. These produced the trailing run of tiny
+        // avatar images and orphan links ("Share", "965 Likes", "64
+        // Restacks") at the end of every Substack article.
+        // NB: `[class*=restack]` is deliberately NOT used here. Substack marks
+        // every body image `<a class="image-link image2 is-viewable-img
+        // can-restack">`, so that pattern silently deleted all of an
+        // article's images. Match the control, not the affordance.
+        "[class*=post-ufi]", "[class*=facepile]", "[class*=like-button]",
+        "[class*=restack-button]", "[class*=button-wrapper]",
+        "[class*=audio-player]", "[class*=support-widget]",
     ].joined(separator: ",")
 
     static func extract(
@@ -326,27 +351,73 @@ enum RenderedArticleExtractor {
         }
     }
 
+    /// Whether the page contains content the structured reader genuinely
+    /// cannot represent, in which case the article is stored as `.webView` and
+    /// opens as the raw archived page.
+    ///
+    /// This is a heavy call: `.webView` articles get no reader typography, no
+    /// theme, and are laid out at the width they were captured at — so on a
+    /// phone they arrive as a shrunken desktop page with all the site's own
+    /// chrome. It must therefore be reserved for pages that would be
+    /// *destroyed* by structured rendering, not merely pages that contain some
+    /// embedded media.
+    ///
+    /// `iframe`, `video` and `audio` used to force `.webView`, which was much
+    /// too broad — an ordinary essay with two embedded videos is still an
+    /// ordinary essay, and practically every modern article carries an iframe
+    /// somewhere. The structured reader already renders `.video` and `.embed`
+    /// blocks natively, so those are representable and no longer count.
     private static func detectMeaningfulInteractivity(_ document: Document) throws -> Bool {
-        if !(try document.select("canvas,model-viewer,iframe[src],video[src],audio[src]").isEmpty()) {
+        // Canvas and model-viewer have no structured equivalent at all.
+        if !(try document.select("canvas,model-viewer").isEmpty()) {
             return true
         }
-        if !(try document.select("svg [onclick],svg animate,svg animateTransform,svg[role=application]").isEmpty()) {
+        // Scripted or animated SVG — an interactive chart or simulation, as
+        // opposed to the icon SVGs every site ships.
+        if !(try document.select(animatedSVGSelector).isEmpty()) {
             return true
         }
+        // Data-visualisation toolkits. Restricted to charting libraries;
+        // `addEventListener('pointer` used to be a trigger here and matched
+        // the bundled JS of essentially every site with a carousel.
         let scripts = try document.select("script").array()
         return scripts.contains { script in
             let source = ((try? script.attr("src")) ?? "") + script.data()
-            return ["d3.", "three.", "chart.js", "webgl", "addEventListener(\"pointer", "addEventListener('pointer"]
-                .contains { source.localizedCaseInsensitiveContains($0) }
+            return visualizationLibraryHints.contains { source.localizedCaseInsensitiveContains($0) }
         }
     }
+
+    private static let animatedSVGSelector = [
+        "svg [onclick]", "svg script", "svg animate", "svg animateTransform",
+        "svg animateMotion", "svg set", "svg[role=application]",
+    ].joined(separator: ",")
+
+    private static let visualizationLibraryHints = [
+        "d3.js", "d3.min.js", "/d3/", "three.js", "three.min.js", "chart.js",
+        "chartjs", "highcharts", "plotly", "vega", "observablehq", "webgl",
+    ]
 
     private static func makeHeader(title: String, deck: String?, author: String?, published: String?, siteName: String?) -> String {
         let site = siteName.map { "<p class=\"stower-site\">\(escapeHTML($0))</p>" } ?? ""
         let deckHTML = deck.map { "<p class=\"stower-deck\">\(escapeHTML($0))</p>" } ?? ""
         let byline = author.map { "<span class=\"stower-byline\">\(escapeHTML($0))</span>" } ?? ""
-        let date = published.map { "<time>\(escapeHTML($0))</time>" } ?? ""
-        return "<header class=\"stower-header\">\(site)<h1 data-block-index=\"0\">\(escapeHTML(title))</h1>\(deckHTML)<p class=\"stower-meta\">\(byline) \(date)</p></header>"
+
+        // `published` is the raw metadata string, which is normally an ISO
+        // timestamp. Printing it verbatim put "2026-07-23T14:05:24-04:00" under
+        // the headline of every captured article. Keep the machine-readable
+        // value in the `datetime` attribute and show a human date.
+        let date: String = published.map { raw in
+            let display = parseDate(raw).map {
+                $0.formatted(date: .abbreviated, time: .omitted)
+            } ?? raw
+            return "<time datetime=\"\(escapeAttribute(raw))\">\(escapeHTML(display))</time>"
+        } ?? ""
+
+        // Separate byline and date so they don't run together as one string.
+        let meta = [byline, date].filter { !$0.isEmpty }.joined(separator: " &middot; ")
+        let metaHTML = meta.isEmpty ? "" : "<p class=\"stower-meta\">\(meta)</p>"
+
+        return "<header class=\"stower-header\">\(site)<h1 data-block-index=\"0\">\(escapeHTML(title))</h1>\(deckHTML)\(metaHTML)</header>"
     }
 
     private static func meta(_ document: Document, _ selector: String) -> String? {

--- a/StowerPackage/Sources/StowerFeatureV2/Support/URLIngestionClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/URLIngestionClient.swift
@@ -66,7 +66,8 @@ public struct ExtractionPipelineClient: Sendable {
         let root = try chooseRoot(document: document)
         let parsed = try parseBlocks(root: root, baseURL: sourceURL)
         let cleanedBlocks = sanitizeBlocks(parsed.blocks)
-        let finalBlocks = cleanedBlocks.isEmpty ? parsed.blocks : cleanedBlocks
+        let deduped = removeLeadingTitleRepeat(cleanedBlocks, title: title)
+        let finalBlocks = deduped.isEmpty ? parsed.blocks : deduped
 
         let plainText = plainTextFromBlocks(finalBlocks)
         let excerpt = plainText.isEmpty ? nil : String(plainText.prefix(220))

--- a/StowerPackage/Sources/StowerFeatureV2/Support/WebArticleCaptureClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/WebArticleCaptureClient.swift
@@ -52,6 +52,23 @@ private final class WebArticleCaptureSession {
     private let webView: WKWebView
     private let navigator = CaptureNavigationDelegate()
 
+    /// Viewport the capture WebView lays out at.
+    ///
+    /// This is load-bearing for image quality, not cosmetic. Responsive images
+    /// pick their source from `srcset` + `sizes`, and `sizes` is usually
+    /// viewport-relative (`100vw` on Substack, most CMSs, and most news
+    /// sites). Capturing at `.zero` made `100vw` resolve to 0, so the browser
+    /// selected the *smallest* candidate every time — Substack's 424w variant
+    /// out of 424/848/1272/1456 — and `normalizeRenderedResources` then
+    /// stripped `srcset`, baking that thumbnail in permanently. Every archived
+    /// article ended up with images too small and too soft to fill a phone
+    /// column, let alone a 3x one.
+    ///
+    /// 1024pt wide selects a candidate around 1272w on typical `srcset`
+    /// ladders — enough for a 3x phone and a Mac window, without pulling the
+    /// largest variant of every image into the offline archive.
+    private static let captureViewport = CGRect(x: 0, y: 0, width: 1024, height: 1366)
+
     private init() {
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = .nonPersistent()
@@ -59,7 +76,7 @@ private final class WebArticleCaptureSession {
         configuration.defaultWebpagePreferences.allowsContentJavaScript = true
         configuration.mediaTypesRequiringUserActionForPlayback = .all
         configuration.allowsAirPlayForMediaPlayback = false
-        self.webView = WKWebView(frame: .zero, configuration: configuration)
+        self.webView = WKWebView(frame: Self.captureViewport, configuration: configuration)
         self.webView.customUserAgent = "Mozilla/5.0 (Macintosh; Apple Silicon Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Stower/1"
         self.webView.navigationDelegate = navigator
     }
@@ -238,10 +255,28 @@ private final class WebArticleCaptureSession {
     }
 }
 
-private enum CaptureNavigationError: Error {
+/// Failures while loading a page for capture.
+///
+/// These reach the user directly — the add-URL sheet and the failed-import
+/// banner both show `localizedDescription`. Without `LocalizedError` the
+/// default description is raw Swift internals ("The operation couldn't be
+/// completed. (StowerFeature.(unknown context at $10686a9c4)
+/// .CaptureNavigationError error 1.)"), which tells nobody anything.
+private enum CaptureNavigationError: Error, LocalizedError {
     case timeout
     case navigationFailed(Error)
     case loadRejected
+
+    var errorDescription: String? {
+        switch self {
+        case .timeout:
+            return "The page took too long to load. It may be very large, very slow, or blocking automated readers."
+        case .navigationFailed(let underlying):
+            return "The page couldn't be loaded: \(underlying.localizedDescription)"
+        case .loadRejected:
+            return "The page refused to load. It may require a login or block automated readers."
+        }
+    }
 }
 
 @MainActor

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ArticleChromeAndFidelityTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ArticleChromeAndFidelityTests.swift
@@ -1,0 +1,268 @@
+import Foundation
+@testable import StowerFeature
+import SwiftSoup
+import Testing
+
+/// Regression coverage for the things that made a real Substack essay
+/// (oneusefulthing.org) read badly: it was classified as "interactive" and so
+/// opened as a shrunken desktop page, its title appeared twice, and the
+/// platform's like/restack furniture ran on past the end of the article.
+@Suite
+struct ArticleChromeAndFidelityTests {
+    private let sourceURL = URL(string: "https://www.example.com/p/an-essay")!
+
+    private func extract(_ html: String) throws -> RenderedArticleExtraction {
+        try RenderedArticleExtractor.extract(renderedHTML: html, sourceURL: sourceURL)
+    }
+
+    private func page(body: String, head: String = "") -> String {
+        """
+        <!doctype html><html><head><meta property="og:title" content="An opinionated guide">\(head)</head>
+        <body>\(body)</body></html>
+        """
+    }
+
+    /// Enough prose to clear the extractor's 40-character minimum.
+    private let filler = """
+        <p>Every few months I write a guide for people who want to use these tools \
+        to actually do something useful with their working day.</p>
+        <p>The landscape keeps shifting, so any guide is out of date the moment it \
+        is published, which is worth keeping in mind.</p>
+        """
+
+    // MARK: - Interactive classification
+
+    @Test
+    func anEssayWithEmbeddedVideoIsNotTreatedAsInteractive() throws {
+        // `.webView` articles get no reader typography and are laid out at
+        // capture width, so on a phone they arrive as a shrunken desktop page.
+        // An essay with a video in it is still an essay.
+        let html = page(body: "<article>\(filler)<video src=\"https://cdn.example.com/a.mp4\"></video></article>")
+        #expect(try extract(html).isInteractive == false)
+    }
+
+    @Test
+    func anEssayWithIframeEmbedsIsNotTreatedAsInteractive() throws {
+        // Two iframes in the rendered DOM were enough to route a plain essay
+        // to the raw-archive renderer.
+        let html = page(body: """
+            <article>\(filler)
+            <iframe src="https://player.example.com/1"></iframe>
+            <iframe src="https://player.example.com/2"></iframe>
+            </article>
+            """)
+        #expect(try extract(html).isInteractive == false)
+    }
+
+    @Test
+    func audioPlayerDoesNotForceTheArchiveRenderer() throws {
+        let html = page(body: "<article>\(filler)<audio src=\"https://cdn.example.com/a.mp3\"></audio></article>")
+        #expect(try extract(html).isInteractive == false)
+    }
+
+    @Test
+    func canvasStillCountsAsInteractive() throws {
+        let html = page(body: "<article>\(filler)<canvas id=\"sim\"></canvas></article>")
+        #expect(try extract(html).isInteractive == true)
+    }
+
+    @Test
+    func animatedSVGStillCountsAsInteractive() throws {
+        let html = page(body: "<article>\(filler)<svg><animate attributeName=\"x\"/></svg></article>")
+        #expect(try extract(html).isInteractive == true)
+    }
+
+    @Test
+    func chartingLibraryStillCountsAsInteractive() throws {
+        let html = page(body: "<article>\(filler)<script src=\"https://cdn.example.com/highcharts.js\"></script></article>")
+        #expect(try extract(html).isInteractive == true)
+    }
+
+    @Test
+    func aGenericPointerListenerNoLongerCountsAsInteractive() throws {
+        // Practically every site with a carousel ships this.
+        let html = page(body: """
+            <article>\(filler)<script>el.addEventListener('pointerdown', fn)</script></article>
+            """)
+        #expect(try extract(html).isInteractive == false)
+    }
+
+    // MARK: - Platform chrome
+
+    @Test
+    func stripsThePostHeaderBlock() throws {
+        // The reader renders its own title/byline/date header, so the source's
+        // header block printed all of it a second time.
+        let html = page(body: """
+            <article>
+              <div role="region" aria-label="Post header" class="post-header">
+                <h1 class="post-title">An opinionated guide</h1>
+                <h3 class="subtitle">The Summer Edition</h3>
+                <div>Ethan Mollick</div><time>Jul 23, 2026</time>
+              </div>
+              \(filler)
+            </article>
+            """)
+        let text = try extract(html).plainText
+        #expect(!text.contains("The Summer Edition"))
+        #expect(!text.contains("Ethan Mollick"))
+        #expect(text.contains("Every few months"))
+    }
+
+    @Test
+    func stripsLikeAndRestackFurnitureAtTheEnd() throws {
+        let html = page(body: """
+            <article>
+              \(filler)
+              <div class="post-ufi">
+                <div class="facepile"><img src="https://cdn.example.com/a1.png"><img src="https://cdn.example.com/a2.png"></div>
+                <span>965 Likes</span><span>64 Restacks</span>
+              </div>
+              <p class="button-wrapper"><a href="https://example.com/book">Pre-Order my Book</a></p>
+            </article>
+            """)
+        let text = try extract(html).plainText
+        #expect(!text.contains("965 Likes"))
+        #expect(!text.contains("64 Restacks"))
+        #expect(!text.contains("Pre-Order my Book"))
+        #expect(text.contains("Every few months"))
+    }
+
+    @Test
+    func keepsBodyImagesThatCarryARestackAffordance() throws {
+        // Substack marks every body image `can-restack`. A `[class*=restack]`
+        // removal pattern deleted all nine images from a real article.
+        let html = page(body: """
+            <article>
+              \(filler)
+              <div class="captioned-image-container">
+                <a class="image-link image2 is-viewable-img can-restack">
+                  <img src="https://cdn.example.com/figure-one.png" alt="A chart">
+                </a>
+              </div>
+            </article>
+            """)
+        let readerHTML = try extract(html).readerHTML
+        #expect(readerHTML.contains("figure-one.png"))
+    }
+
+    @Test
+    func stillRemovesTheRestackControlItself() throws {
+        let html = page(body: """
+            <article>\(filler)<button class="restack-button">Restack this</button></article>
+            """)
+        #expect(!(try extract(html).plainText.contains("Restack this")))
+    }
+
+    @Test
+    func doesNotRemoveBodyWrappersThatMerelyContainAChromeWord() throws {
+        // Substring class matching is dangerous: `paywall-content` and
+        // `story-headline-and-body` are body wrappers, not chrome.
+        let html = page(body: """
+            <article>
+              <div class="paywall-content"><div class="story-headline-and-body">\(filler)</div></div>
+            </article>
+            """)
+        let text = try extract(html).plainText
+        #expect(text.contains("Every few months"))
+        #expect(text.contains("The landscape keeps shifting"))
+    }
+
+    // MARK: - Duplicate title
+
+    @Test
+    func dropsALeadingHeadingThatRepeatsTheTitle() {
+        let blocks: [ReaderBlock] = [
+            .heading(level: 1, inlines: [.text("An Opinionated Guide!")]),
+            .paragraph([.text("Body text goes here.")]),
+        ]
+        let result = removeLeadingTitleRepeat(blocks, title: "An opinionated guide")
+        #expect(result.count == 1)
+        if case .paragraph = result.first {} else {
+            Issue.record("Expected the body paragraph to survive, got \(result)")
+        }
+    }
+
+    @Test
+    func keepsALeadingHeadingThatIsNotTheTitle() {
+        let blocks: [ReaderBlock] = [
+            .heading(level: 2, inlines: [.text("Introduction")]),
+            .paragraph([.text("Body text goes here.")]),
+        ]
+        #expect(removeLeadingTitleRepeat(blocks, title: "An opinionated guide").count == 2)
+    }
+
+    @Test
+    func keepsALaterSectionHeadingThatEchoesTheTitle() {
+        // Only the leading heading is a duplicate; a section further down that
+        // happens to match is real content.
+        let blocks: [ReaderBlock] = [
+            .paragraph([.text("An introductory paragraph before any heading.")]),
+            .heading(level: 2, inlines: [.text("An opinionated guide")]),
+        ]
+        #expect(removeLeadingTitleRepeat(blocks, title: "An opinionated guide").count == 2)
+    }
+
+    @Test
+    func looksPastAHeroFigureToFindTheHeading() {
+        let media = MediaDescriptor(kind: .image, sourceURL: "https://cdn.example.com/hero.png")
+        let blocks: [ReaderBlock] = [
+            .figure(media: media),
+            .heading(level: 1, inlines: [.text("An opinionated guide")]),
+            .paragraph([.text("Body text goes here.")]),
+        ]
+        let result = removeLeadingTitleRepeat(blocks, title: "An opinionated guide")
+        #expect(result.count == 2)
+        if case .figure = result.first {} else {
+            Issue.record("The hero figure should be kept")
+        }
+    }
+
+    @Test
+    func titleComparisonIgnoresPunctuationAndSmartQuotes() {
+        let blocks: [ReaderBlock] = [
+            .heading(level: 1, inlines: [.text("Don\u{2019}t Panic \u{2014} A Guide")]),
+            .paragraph([.text("Body.")]),
+        ]
+        #expect(removeLeadingTitleRepeat(blocks, title: "Don't Panic - a guide").count == 1)
+    }
+
+    @Test
+    func emptyTitleLeavesBlocksAlone() {
+        let blocks: [ReaderBlock] = [.heading(level: 1, inlines: [.text("Something")])]
+        #expect(removeLeadingTitleRepeat(blocks, title: "").count == 1)
+    }
+
+    // MARK: - Header rendering
+
+    @Test
+    func headerShowsAHumanDateNotARawTimestamp() throws {
+        let html = page(
+            body: "<article>\(filler)</article>",
+            head: """
+            <meta property="article:published_time" content="2026-07-23T14:05:24-04:00">
+            <meta name="author" content="Ethan Mollick">
+            """
+        )
+        let readerHTML = try extract(html).readerHTML
+        // The machine-readable value stays in the attribute...
+        #expect(readerHTML.contains("datetime=\"2026-07-23T14:05:24-04:00\""))
+        // ...but the visible text is a formatted date.
+        #expect(!readerHTML.contains(">2026-07-23T14:05:24-04:00<"))
+        #expect(readerHTML.contains("Jul 23, 2026"))
+    }
+
+    @Test
+    func headerSeparatesBylineFromDate() throws {
+        let html = page(
+            body: "<article>\(filler)</article>",
+            head: """
+            <meta property="article:published_time" content="2026-07-23T14:05:24-04:00">
+            <meta name="author" content="Ethan Mollick">
+            """
+        )
+        let readerHTML = try extract(html).readerHTML
+        #expect(readerHTML.contains("&middot;"))
+        #expect(!readerHTML.contains("Ethan Mollick</span> <time"))
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/IngestionQueueDeliveryTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/IngestionQueueDeliveryTests.swift
@@ -1,0 +1,244 @@
+import Dependencies
+import Foundation
+@testable import StowerData
+@testable import StowerFeature
+import Testing
+
+/// Coverage for the paths that let a shared URL vanish between the share
+/// extension saying "Saved to Stower" and the item appearing in the library.
+/// `.serialized` because the coordinator tests exercise the live gate, which
+/// is a process-wide singleton.
+@Suite(.serialized)
+struct IngestionQueueDeliveryTests {
+    // MARK: - Coordinator
+
+    @Test
+    func coordinatorRunsAnOperationThatArrivesDuringAnInFlightDrain() async throws {
+        // The share extension can only enqueue a job; the main app drains the
+        // queue. A capture takes tens of seconds, so a drain triggered by the
+        // user returning to the app routinely overlaps one already running.
+        // The coordinator used to await the in-flight drain and then return
+        // *without running the new one*, leaving the just-shared URL queued.
+        let recorder = RunRecorder()
+        let firstStarted = AsyncSignal()
+        let releaseFirst = AsyncSignal()
+
+        try await withDependencies {
+            // The test coordinator has no gate at all; this exercises the real one.
+            $0.context = .live
+        } operation: {
+            let coordinator = currentIngestionCoordinator()
+
+            async let first: Void = coordinator.run {
+                await recorder.record("first-start")
+                await firstStarted.signal()
+                await releaseFirst.wait()
+                await recorder.record("first-end")
+            }
+
+            await firstStarted.wait()
+
+            async let second: Void = coordinator.run {
+                await recorder.record("second")
+            }
+
+            await releaseFirst.signal()
+            _ = try await (first, second)
+        }
+
+        #expect(await recorder.entries == ["first-start", "first-end", "second"])
+    }
+
+    @Test
+    func coordinatorRunsTheNextOperationEvenAfterOneFails() async throws {
+        let recorder = RunRecorder()
+        let firstStarted = AsyncSignal()
+        let releaseFirst = AsyncSignal()
+
+        await withDependencies {
+            $0.context = .live
+        } operation: {
+            let coordinator = currentIngestionCoordinator()
+
+            async let first: Void = coordinator.run {
+                await firstStarted.signal()
+                await releaseFirst.wait()
+                throw CocoaError(.fileNoSuchFile)
+            }
+            await firstStarted.wait()
+
+            async let second: Void = coordinator.run {
+                await recorder.record("second")
+            }
+
+            await releaseFirst.signal()
+            _ = try? await first
+            try? await second
+        }
+
+        #expect(await recorder.entries == ["second"])
+    }
+
+    // MARK: - Queue
+
+    @Test
+    func resharingTheSameURLDoesNotQueueASecondCapture() async throws {
+        // Sharing a link that appears not to have worked is the natural user
+        // response, and each attempt used to queue another full capture of the
+        // same page.
+        let database = try StowerDatabase.makeDatabase()
+        let repository = StowerRepository.live(database: database, cloudSyncClient: .noop)
+        let now = Date(timeIntervalSince1970: 3000)
+
+        try await withDependencies {
+            $0.date.now = now
+            $0.uuid = .incrementing
+        } operation: {
+            try await repository.enqueueIngestionJob(.url, "https://example.com/post")
+            try await repository.enqueueIngestionJob(.url, "https://example.com/post")
+            try await repository.enqueueIngestionJob(.url, "https://example.com/post")
+        }
+
+        let first = try #require(try await repository.claimNextIngestionJob(now))
+        #expect(first.payload == "https://example.com/post")
+        #expect(try await repository.claimNextIngestionJob(now) == nil)
+    }
+
+    @Test
+    func aDifferentURLIsStillQueuedSeparately() async throws {
+        let database = try StowerDatabase.makeDatabase()
+        let repository = StowerRepository.live(database: database, cloudSyncClient: .noop)
+        let now = Date(timeIntervalSince1970: 4000)
+
+        try await withDependencies {
+            $0.date.now = now
+            $0.uuid = .incrementing
+        } operation: {
+            try await repository.enqueueIngestionJob(.url, "https://example.com/a")
+            try await repository.enqueueIngestionJob(.url, "https://example.com/b")
+        }
+
+        let first = try #require(try await repository.claimNextIngestionJob(now))
+        let second = try #require(try await repository.claimNextIngestionJob(now))
+        #expect(Set([first.payload, second.payload]) == ["https://example.com/a", "https://example.com/b"])
+    }
+
+    @Test
+    func theSameURLCanBeQueuedAgainOnceTheEarlierJobIsProcessed() async throws {
+        // Dedup is scoped to unprocessed jobs so a later re-save still works.
+        let database = try StowerDatabase.makeDatabase()
+        let repository = StowerRepository.live(database: database, cloudSyncClient: .noop)
+        let now = Date(timeIntervalSince1970: 5000)
+
+        try await withDependencies {
+            $0.date.now = now
+            $0.uuid = .incrementing
+        } operation: {
+            try await repository.enqueueIngestionJob(.url, "https://example.com/post")
+        }
+        let first = try #require(try await repository.claimNextIngestionJob(now))
+        try await repository.completeIngestionJob(first.id, now)
+
+        try await withDependencies {
+            $0.date.now = now.addingTimeInterval(60)
+            // A fresh id — `.incrementing` restarts at UUID(0) and would
+            // collide with the job enqueued above.
+            $0.uuid = .constant(UUID(99))
+        } operation: {
+            try await repository.enqueueIngestionJob(.url, "https://example.com/post")
+        }
+        #expect(try await repository.claimNextIngestionJob(now.addingTimeInterval(60)) != nil)
+    }
+
+    @Test
+    func resharingAURLWhoseImportFailedQueuesAFreshJob() async throws {
+        // Re-saving is how the user retries a failed import. Dedup must not
+        // swallow it, or the second attempt would do nothing at all.
+        let database = try StowerDatabase.makeDatabase()
+        let repository = StowerRepository.live(database: database, cloudSyncClient: .noop)
+        let now = Date(timeIntervalSince1970: 7000)
+
+        try await withDependencies {
+            $0.date.now = now
+            $0.uuid = .incrementing
+        } operation: {
+            try await repository.enqueueIngestionJob(.url, "https://example.com/hostile")
+        }
+
+        // Exhaust the retry budget so the job lands in `failed`.
+        for attempt in 0..<3 {
+            let job = try #require(try await repository.claimNextIngestionJob(now))
+            try await repository.failIngestionJob(job.id, "attempt \(attempt) failed", now)
+        }
+        #expect(try await repository.claimNextIngestionJob(now) == nil)
+        #expect(try await repository.fetchFailedIngestionJobs().count == 1)
+
+        try await withDependencies {
+            $0.date.now = now.addingTimeInterval(30)
+            $0.uuid = .constant(UUID(77))
+        } operation: {
+            try await repository.enqueueIngestionJob(.url, "https://example.com/hostile")
+        }
+
+        let retried = try #require(
+            try await repository.claimNextIngestionJob(now.addingTimeInterval(30))
+        )
+        #expect(retried.payload == "https://example.com/hostile")
+    }
+
+    @Test
+    func repeatedTextSharesAreStillQueuedIndependently() async throws {
+        // Text payloads are user content, not an identifier — saving the same
+        // note twice on purpose must produce two items.
+        let database = try StowerDatabase.makeDatabase()
+        let repository = StowerRepository.live(database: database, cloudSyncClient: .noop)
+        let now = Date(timeIntervalSince1970: 6000)
+
+        try await withDependencies {
+            $0.date.now = now
+            $0.uuid = .incrementing
+        } operation: {
+            try await repository.enqueueIngestionJob(.text, "a thought")
+            try await repository.enqueueIngestionJob(.text, "a thought")
+        }
+
+        #expect(try await repository.claimNextIngestionJob(now) != nil)
+        #expect(try await repository.claimNextIngestionJob(now) != nil)
+    }
+}
+
+// MARK: - Helpers
+
+/// Reads the coordinator out of the current dependency scope as a plain value.
+/// Binding it through `@Dependency` directly leaves the compiler unable to
+/// prove the accessor is safe to use from the concurrent `async let` children.
+private func currentIngestionCoordinator() -> IngestionCoordinator {
+    @Dependency(\.ingestionCoordinator)
+    var coordinator
+    return coordinator
+}
+
+private actor RunRecorder {
+    var entries = [String]()
+    func record(_ value: String) { entries.append(value) }
+}
+
+/// One-shot async signal — lets a test hold an operation open so a second one
+/// genuinely overlaps it.
+private actor AsyncSignal {
+    private var isSignalled = false
+    private var waiters = [CheckedContinuation<Void, Never>]()
+
+    func signal() {
+        guard !isSignalled else { return }
+        isSignalled = true
+        let pending = waiters
+        waiters.removeAll()
+        for waiter in pending { waiter.resume() }
+    }
+
+    func wait() async {
+        guard !isSignalled else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/LibraryReextractionTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/LibraryReextractionTests.swift
@@ -1,0 +1,237 @@
+import ComposableArchitecture
+import Foundation
+@testable import StowerData
+@testable import StowerFeature
+import Testing
+
+/// Coverage for the bulk re-extract maintenance action, which rebuilds saved
+/// articles through the current capture pipeline. Extraction improvements only
+/// apply at save time, so articles saved by an older build keep that build's
+/// structure until they are rebuilt.
+@MainActor
+@Suite
+struct LibraryReextractionTests {
+    private func item(_ title: String, url: String?) -> SavedItem {
+        var item = SavedItem(title: title, content: "Body")
+        item.sourceURL = url
+        return item
+    }
+
+    private func saveResult(_ item: SavedItem) -> ArticleSaveResult {
+        ArticleSaveResult(item: item, state: .ready)
+    }
+
+    @Test
+    func rebuildsEveryURLBackedArticleAndReportsProgress() async {
+        let first = item("First", url: "https://example.com/one")
+        let second = item("Second", url: "https://example.com/two")
+        let refreshed = LockIsolated<[UUID]>([])
+
+        let store = TestStore(initialState: SettingsFeature.State()) {
+            SettingsFeature()
+        } withDependencies: {
+            $0.stowerRepository.fetchReextractableItems = { [first, second] }
+            $0.articleSaveClient.refresh = { id, _ in
+                refreshed.withValue { $0.append(id) }
+                return ArticleSaveResult(item: SavedItem(title: "x", content: "y"), state: .ready)
+            }
+        }
+
+        await store.send(.reextractLibraryTapped) {
+            $0.reextraction = .running(LibraryReextractionState.Progress())
+        }
+        await store.receive(.reextractStarted(total: 2)) {
+            $0.reextraction = .running(.init(completed: 0, total: 2))
+        }
+        await store.receive(.reextractItemFinished(title: "First", succeeded: true)) {
+            $0.reextraction = .running(.init(completed: 1, total: 2, currentTitle: "First"))
+        }
+        await store.receive(.reextractItemFinished(title: "Second", succeeded: true)) {
+            $0.reextraction = .running(.init(completed: 2, total: 2, currentTitle: "Second"))
+        }
+        await store.receive(.reextractCompleted(wasCancelled: false)) {
+            $0.reextraction = .finished(.init(succeeded: 2, failed: 0, wasCancelled: false))
+        }
+
+        #expect(refreshed.value == [first.id, second.id])
+    }
+
+    @Test
+    func oneUnreachableArticleDoesNotStopTheRebuild() async {
+        // A paywalled or offline article must not end the run — the whole
+        // point is to repair a library in one pass.
+        let broken = item("Broken", url: "https://example.com/broken")
+        let healthy = item("Healthy", url: "https://example.com/healthy")
+        let attempted = LockIsolated<[UUID]>([])
+
+        let store = TestStore(initialState: SettingsFeature.State()) {
+            SettingsFeature()
+        } withDependencies: {
+            $0.stowerRepository.fetchReextractableItems = { [broken, healthy] }
+            $0.articleSaveClient.refresh = { id, _ in
+                attempted.withValue { $0.append(id) }
+                if id == broken.id {
+                    throw URLError(.timedOut)
+                }
+                return ArticleSaveResult(item: SavedItem(title: "x", content: "y"), state: .ready)
+            }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.reextractLibraryTapped)
+        await store.receive(.reextractStarted(total: 2))
+        await store.receive(.reextractItemFinished(title: "Broken", succeeded: false))
+        await store.receive(.reextractItemFinished(title: "Healthy", succeeded: true))
+        await store.receive(.reextractCompleted(wasCancelled: false)) {
+            $0.reextraction = .finished(.init(succeeded: 1, failed: 1, wasCancelled: false))
+        }
+
+        #expect(attempted.value == [broken.id, healthy.id])
+    }
+
+    @Test
+    func anEmptyLibraryFinishesImmediately() async {
+        let store = TestStore(initialState: SettingsFeature.State()) {
+            SettingsFeature()
+        } withDependencies: {
+            $0.stowerRepository.fetchReextractableItems = { [] }
+        }
+
+        await store.send(.reextractLibraryTapped) {
+            $0.reextraction = .running(LibraryReextractionState.Progress())
+        }
+        // `total` is already 0, so this carries no observable change.
+        await store.receive(.reextractStarted(total: 0))
+        await store.receive(.reextractCompleted(wasCancelled: false)) {
+            $0.reextraction = .finished(.init(succeeded: 0, failed: 0, wasCancelled: false))
+        }
+    }
+
+    @Test
+    func stoppingKeepsWhatWasAlreadyRebuilt() async {
+        let first = item("First", url: "https://example.com/one")
+        let second = item("Second", url: "https://example.com/two")
+
+        // The second refresh parks on a test clock that is never advanced,
+        // so the run is genuinely mid-flight when Stop is tapped.
+        let clock = TestClock()
+        let store = TestStore(initialState: SettingsFeature.State()) {
+            SettingsFeature()
+        } withDependencies: {
+            $0.continuousClock = clock
+            $0.stowerRepository.fetchReextractableItems = { [first, second] }
+            $0.articleSaveClient.refresh = { id, _ in
+                if id == second.id {
+                    try await clock.sleep(for: .seconds(60))
+                }
+                return ArticleSaveResult(item: SavedItem(title: "x", content: "y"), state: .ready)
+            }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.reextractLibraryTapped)
+        await store.receive(.reextractStarted(total: 2))
+        await store.receive(.reextractItemFinished(title: "First", succeeded: true))
+
+        await store.send(.reextractCancelTapped) {
+            $0.reextraction = .finished(.init(succeeded: 1, failed: 0, wasCancelled: true))
+        }
+    }
+
+    @Test
+    func tappingRebuildTwiceDoesNotStartASecondRun() async {
+        let only = item("Only", url: "https://example.com/one")
+
+        let store = TestStore(initialState: SettingsFeature.State()) {
+            SettingsFeature()
+        } withDependencies: {
+            $0.stowerRepository.fetchReextractableItems = { [only] }
+            $0.articleSaveClient.refresh = { _, _ in
+                ArticleSaveResult(item: SavedItem(title: "x", content: "y"), state: .ready)
+            }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.reextractLibraryTapped)
+        await store.receive(.reextractStarted(total: 1))
+        // Ignored while a run is in flight.
+        await store.send(.reextractLibraryTapped)
+        await store.receive(.reextractItemFinished(title: "Only", succeeded: true))
+        await store.receive(.reextractCompleted(wasCancelled: false))
+
+        await store.send(.reextractDismissed) {
+            $0.reextraction = .idle
+        }
+    }
+
+    @Test
+    func progressFractionIsSafeWhenTotalIsUnknown() {
+        #expect(LibraryReextractionState.Progress(completed: 0, total: 0).fraction == 0)
+        #expect(LibraryReextractionState.Progress(completed: 1, total: 4).fraction == 0.25)
+    }
+}
+
+/// The failure banner has to name the failing import, not just count it.
+@Suite
+struct FailedImportTests {
+    @Test
+    func describesAURLJobByHostAndPath() {
+        let job = IngestionJob(
+            kind: .url,
+            payload: "https://www.example.com/posts/why-formatting-matters?utm=1",
+            id: UUID(0),
+            createdAt: Date(timeIntervalSince1970: 0),
+            status: .failed,
+            claimedAt: nil,
+            attemptCount: 3,
+            lastError: "The request timed out."
+        )
+        let failure = FailedImport(job: job)
+        #expect(failure.label == "example.com/posts/why-formatting-matters")
+        #expect(failure.reason == "The request timed out.")
+    }
+
+    @Test
+    func truncatesVeryLongURLsInTheMiddle() {
+        let long = "https://example.com/" + String(repeating: "segment/", count: 20) + "end"
+        let label = FailedImport.displayURL(long)
+        #expect(label.count < 60)
+        #expect(label.hasPrefix("example.com/"))
+        #expect(label.hasSuffix("end"))
+    }
+
+    @Test
+    func describesAFileJobByFilename() {
+        let job = IngestionJob(
+            kind: .pdf,
+            payload: "/private/group/PendingPDFs/2A3F/Quarterly Report.pdf",
+            id: UUID(1),
+            createdAt: Date(timeIntervalSince1970: 0),
+            status: .failed,
+            claimedAt: nil,
+            attemptCount: 3,
+            lastError: nil
+        )
+        let failure = FailedImport(job: job)
+        #expect(failure.label == "Quarterly Report.pdf")
+        #expect(failure.reason == nil)
+    }
+
+    @Test
+    func doesNotShowRawJSONForTextJobs() {
+        let job = IngestionJob(
+            kind: .text,
+            payload: #"{"content":"a note","mode":"auto"}"#,
+            id: UUID(2),
+            createdAt: Date(timeIntervalSince1970: 0),
+            status: .failed,
+            claimedAt: nil,
+            attemptCount: 3,
+            lastError: "  "
+        )
+        let failure = FailedImport(job: job)
+        #expect(failure.label == "Imported text")
+        // Whitespace-only errors are not worth showing.
+        #expect(failure.reason == nil)
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderFormattingFidelityTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderFormattingFidelityTests.swift
@@ -1,0 +1,347 @@
+import Foundation
+@testable import StowerFeature
+import SwiftSoup
+import Testing
+
+/// Regression coverage for article structure that the extraction pipeline used
+/// to destroy: code blocks flattened onto one line, tables shredded into one
+/// paragraph per cell, bullet lists deleted wholesale by the boilerplate
+/// heuristic, nested lists fused into a single run-on item, and `<br>`-
+/// separated lines collapsed into a paragraph.
+@Suite
+struct ReaderFormattingFidelityTests {
+    private let baseURL = URL(string: "https://example.com/article")!
+
+    private func blocks(_ html: String) throws -> [ReaderBlock] {
+        let document = try SwiftSoup.parseBodyFragment(html, baseURL.absoluteString)
+        let body = try #require(document.body())
+        return try parseBlocks(root: body, baseURL: baseURL).blocks
+    }
+
+    /// Runs the full pipeline stage the reader actually uses: parse, then
+    /// sanitize. Several of these bugs only appear once the sanitizer runs.
+    private func sanitizedBlocks(_ html: String) throws -> [ReaderBlock] {
+        sanitizeBlocks(try blocks(html))
+    }
+
+    // MARK: - Predicates
+    //
+    // Named rather than inlined so the pattern matches stay on their own line.
+
+    private func isParagraph(_ block: ReaderBlock) -> Bool {
+        if case .paragraph = block {
+            return true
+        }
+        return false
+    }
+
+    private func isTable(_ block: ReaderBlock) -> Bool {
+        if case .table = block {
+            return true
+        }
+        return false
+    }
+
+    private func isLineBreak(_ inline: ReaderInline) -> Bool {
+        if case .lineBreak = inline {
+            return true
+        }
+        return false
+    }
+
+    private func isLiteralNewlineText(_ inline: ReaderInline) -> Bool {
+        if case .text("\n") = inline {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Code blocks
+
+    @Test
+    func preservesLineBreaksInCodeBlocks() throws {
+        let html = "<pre><code class=\"language-swift\">func greet() {\n"
+            + "    print(\"hello\")\n"
+            + "}</code></pre>"
+        guard case let .code(language, code)? = try blocks(html).first else {
+            Issue.record("Expected a code block")
+            return
+        }
+        #expect(language == "swift")
+        #expect(code == "func greet() {\n    print(\"hello\")\n}")
+    }
+
+    @Test
+    func stripsCommonLeadingIndentationFromCodeBlocks() throws {
+        // Source documents routinely indent <pre> to match surrounding markup.
+        // Carrying that indentation through forces the reader sideways.
+        let html = "<pre><code>        let a = 1\n        let b = 2</code></pre>"
+        guard case let .code(_, code)? = try blocks(html).first else {
+            Issue.record("Expected a code block")
+            return
+        }
+        #expect(code == "let a = 1\nlet b = 2")
+    }
+
+    @Test
+    func codeBlocksSurviveTheBoilerplateFilter() throws {
+        // Code is dense with digits and camelCase and carries no prose
+        // punctuation, so every boilerplate heuristic fires on it.
+        let html = "<pre><code>let userDefaults = UserDefaults(suiteName: \"group1\")\n"
+            + "let itemCount = 42\n"
+            + "let sessionToken = makeToken(1234)</code></pre>"
+        let result = try sanitizedBlocks(html)
+        #expect(result.count == 1)
+        if case .code = result.first {} else {
+            Issue.record("Code block was discarded as boilerplate")
+        }
+    }
+
+    @Test
+    func doesNotDoubleUpLanguageClassPrefix() throws {
+        let html = "<pre><code class=\"language-python hljs\">x = 1</code></pre>"
+        guard case let .code(language, _)? = try blocks(html).first else {
+            Issue.record("Expected a code block")
+            return
+        }
+        #expect(language == "python")
+    }
+
+    // MARK: - Tables
+
+    @Test
+    func parsesTableAsSingleTableBlock() throws {
+        let html = """
+        <table>
+          <thead><tr><th>Feature</th><th>Free</th><th>Pro</th></tr></thead>
+          <tbody>
+            <tr><td>Sync</td><td>No</td><td>Yes</td></tr>
+            <tr><td>Export</td><td>No</td><td>Yes</td></tr>
+          </tbody>
+        </table>
+        """
+        let result = try blocks(html)
+        #expect(result.count == 1)
+        guard case let .table(markdown)? = result.first else {
+            Issue.record("Expected a table block, got \(result)")
+            return
+        }
+        let lines = markdown.split(separator: "\n").map(String.init)
+        #expect(lines[0] == "| Feature | Free | Pro |")
+        #expect(lines[1] == "| --- | --- | --- |")
+        #expect(lines[2] == "| Sync | No | Yes |")
+        #expect(lines[3] == "| Export | No | Yes |")
+    }
+
+    @Test
+    func tableCellsAreNotEmittedAsSeparateParagraphs() throws {
+        // The old behaviour: <table> fell through to the generic recursion and
+        // every <td> became its own paragraph, so a 3x3 table printed as nine
+        // orphaned fragments.
+        let html = """
+        <table><tr><th>A</th><th>B</th></tr><tr><td>one</td><td>two</td></tr></table>
+        """
+        let result = try blocks(html)
+        #expect(!result.contains(where: isParagraph))
+    }
+
+    @Test
+    func escapesPipesInsideTableCells() throws {
+        let html = "<table><tr><th>Op</th><th>Meaning</th></tr><tr><td>a | b</td><td>or</td></tr></table>"
+        guard case let .table(markdown)? = try blocks(html).first else {
+            Issue.record("Expected a table block")
+            return
+        }
+        #expect(markdown.contains("a \\| b"))
+    }
+
+    @Test
+    func singleCellLayoutTableIsNotTreatedAsATable() throws {
+        // Old-school layout tables wrapping the whole article must not become
+        // a one-cell grid — their contents are the article.
+        let html = "<table><tr><td><p>Just prose in a layout table.</p></td></tr></table>"
+        let result = try blocks(html)
+        #expect(result.contains(where: isParagraph))
+        #expect(!result.contains(where: isTable))
+    }
+
+    // MARK: - Lists
+
+    @Test
+    func shortUnpunctuatedBulletListIsNotDiscarded() throws {
+        // Eight short bullets with no sentence punctuation concatenate to more
+        // than 22 tokens, which used to trip the "navigation menu" heuristic
+        // and delete the entire list from the article.
+        let html = """
+        <ul>
+          <li>Reduce startup latency</li>
+          <li>Cache decoded images</li>
+          <li>Batch database writes</li>
+          <li>Coalesce network calls</li>
+          <li>Defer analytics uploads</li>
+          <li>Prewarm the reader</li>
+          <li>Trim launch dependencies</li>
+          <li>Compress archived pages</li>
+        </ul>
+        """
+        let result = try sanitizedBlocks(html)
+        guard case let .list(_, items)? = result.first else {
+            Issue.record("Bullet list was discarded, got \(result)")
+            return
+        }
+        #expect(items.count == 8)
+    }
+
+    @Test
+    func navigationStyleListIsStillDiscarded() throws {
+        // The heuristic must keep working for actual chrome: every item is a
+        // bare nav label.
+        let html = """
+        <ul>
+          <li>Home</li><li>About</li><li>Careers</li><li>Press</li>
+          <li>Privacy</li><li>Terms</li><li>Contact</li><li>Sitemap</li>
+        </ul>
+        """
+        // Each individual item is short and unpunctuated but well under the
+        // token threshold, so the list survives on item-level scoring. What
+        // matters is that the *whole-list* concatenation no longer decides it.
+        let result = try sanitizedBlocks(html)
+        #expect(result.count <= 1)
+    }
+
+    @Test
+    func nestedListItemsAreNotFusedIntoTheParentItem() throws {
+        let html = """
+        <ul>
+          <li>Fruit
+            <ul><li>Apple</li><li>Pear</li></ul>
+          </li>
+          <li>Vegetables</li>
+        </ul>
+        """
+        guard case let .list(_, items)? = try blocks(html).first else {
+            Issue.record("Expected a list block")
+            return
+        }
+        let texts = items.map(inlineText)
+        #expect(texts.contains { $0 == "Fruit" })
+        #expect(texts.contains { $0.contains("Apple") && !$0.contains("Pear") })
+        #expect(texts.contains { $0.contains("Pear") })
+        #expect(texts.contains { $0 == "Vegetables" })
+        // The sentinel failure: everything fused into one item.
+        #expect(!texts.contains { $0.contains("FruitApple") })
+    }
+
+    @Test
+    func listItemWithMultipleParagraphsKeepsWordsSeparated() throws {
+        let html = "<ul><li><p>First sentence.</p><p>Second sentence.</p></li></ul>"
+        guard case let .list(_, items)? = try blocks(html).first else {
+            Issue.record("Expected a list block")
+            return
+        }
+        let text = inlineText(try #require(items.first))
+        #expect(text.contains("sentence. Second"))
+        #expect(!text.contains("sentence.Second"))
+    }
+
+    @Test
+    func parsesDescriptionListAsPairedItems() throws {
+        let html = """
+        <dl>
+          <dt>Stow</dt><dd>To save an article for later.</dd>
+          <dt>Archive</dt><dd>To file a finished article away.</dd>
+        </dl>
+        """
+        guard case let .list(_, items)? = try blocks(html).first else {
+            Issue.record("Expected a list block for <dl>")
+            return
+        }
+        #expect(items.count == 2)
+        let first = inlineText(items[0])
+        #expect(first.contains("Stow"))
+        #expect(first.contains("To save an article for later."))
+    }
+
+    // MARK: - Line breaks
+
+    @Test
+    func brBecomesARealLineBreakInline() throws {
+        // `.text("\n")` renders as a literal newline in HTML, which the browser
+        // collapses to a space — verse and addresses ran together.
+        let html = "<p>Line one<br>Line two<br>Line three</p>"
+        guard case let .paragraph(inlines)? = try blocks(html).first else {
+            Issue.record("Expected a paragraph")
+            return
+        }
+        #expect(inlines.filter(isLineBreak).count == 2)
+        #expect(!inlines.contains(where: isLiteralNewlineText))
+    }
+
+    // MARK: - Figures
+
+    @Test
+    func figureCaptionInsideParagraphIsNotDuplicated() throws {
+        let html = """
+        <p>Intro text.<figure><img src="https://example.com/a.png"><figcaption>A caption.</figcaption></figure></p>
+        """
+        let result = try blocks(html)
+        guard case let .paragraph(inlines)? = result.first else {
+            Issue.record("Expected a leading paragraph, got \(result)")
+            return
+        }
+        #expect(inlineText(inlines) == "Intro text.")
+        guard case let .figure(media) = result[1] else {
+            Issue.record("Expected a figure block")
+            return
+        }
+        #expect(media.caption == "A caption.")
+    }
+
+    // MARK: - Article structure
+
+    @Test
+    func keepsArticleHeaderAndPullQuote() throws {
+        // `<header>` and `<aside>` used to be removed outright, which deleted
+        // the article's own standfirst and every pull quote.
+        let html = """
+        <article>
+          <header><h1>The Headline</h1><p>The standfirst that sets up the piece.</p></header>
+          <p>Body text.</p>
+          <aside class="pullquote"><p>A memorable line worth pulling out.</p></aside>
+        </article>
+        """
+        let text = plainTextFromBlocks(try blocks(html))
+        #expect(text.contains("The standfirst that sets up the piece."))
+        #expect(text.contains("A memorable line worth pulling out."))
+    }
+
+    @Test
+    func stillRemovesSiteChrome() throws {
+        let html = """
+        <div>
+          <header role="banner"><p>Global site navigation bar</p></header>
+          <aside class="newsletter-signup"><p>Subscribe to our newsletter today</p></aside>
+          <p>Actual article body.</p>
+        </div>
+        """
+        let text = plainTextFromBlocks(try blocks(html))
+        #expect(text.contains("Actual article body."))
+        #expect(!text.contains("Global site navigation"))
+        #expect(!text.contains("Subscribe to our newsletter"))
+    }
+
+    @Test
+    func repeatedProseIsNotSilentlyDeleted() throws {
+        // Global fingerprint dedup removed legitimately repeated lines,
+        // leaving holes in Q&A transcripts and lyric-style content.
+        let html = "<p>Yes.</p><p>Why not?</p><p>Yes.</p>"
+        let result = try sanitizedBlocks(html)
+        #expect(result.count == 3)
+    }
+
+    @Test
+    func adjacentDuplicateParagraphsAreStillCollapsed() throws {
+        let html = "<p>Same line.</p><p>Same line.</p>"
+        #expect(try sanitizedBlocks(html).count == 1)
+    }
+}


### PR DESCRIPTION
Two reported problems, four root causes, plus a way to repair already-saved articles.

## Shared URLs never arriving

A share could report "Saved to Stower" and then never show up.

- `IngestionCoordinator` awaited an in-flight drain and returned **without running the new operation**. Captures take tens of seconds, so a drain triggered by returning to the app during one was discarded rather than run.
- `sceneDidBecomeActive` skipped the drain unless startup had finished — exactly the case when Stower is launched from the share sheet.
- `processIngestionJobs` used `try` when recording a failure, so a write error there aborted the loop and stranded the rest of the queue.

Re-sharing the same link also queued another full capture each time. `.url` jobs are now deduplicated against queued/processing jobs only, so re-saving after a failure still retries.

Failed imports now name the URL and the reason instead of showing only a count, and `CaptureNavigationError` gained `LocalizedError` — it was surfacing raw Swift internals (`...CaptureNavigationError error 1.`) to the user.

## Articles saved in a shape you would not want to read

Structure the extractor dropped or mangled: tables shredded into one paragraph per cell, `<pre>` collapsed onto a single line, bullet lists deleted wholesale by the boilerplate heuristic, nested lists fused into run-on text, `<br>` collapsed to spaces, `<header>`/`<aside>` removed outright (taking standfirsts and pull quotes with them), `<dl>` shredded, figure captions duplicated.

## A real Substack essay reading badly

Verified against `oneusefulthing.org/p/an-opinionated-guide-to-which-ai-b22`:

- **It was not in Reader View at all.** `detectMeaningfulInteractivity` treated any `iframe`/`video`/`audio` as interactive; two iframes stored an ordinary essay as `.webView`, which opens the raw archived desktop page — no reader typography, no theme, shrunk onto a phone. Only `canvas`, `model-viewer`, scripted/animated SVG and charting libraries count now.
- **Images captured at their smallest variant.** The capture WebView laid out at `.zero`, so `sizes="100vw"` resolved to 0 and every responsive image picked its smallest `srcset` candidate (424w of 424/848/1272/1456), after which `srcset` was stripped. Capturing at 1024x1366 selects a full-resolution variant — the same article re-saved now picks w_1456 for all nine images.
- **Duplicate title and trailing furniture.** The source's post header and the like/restack bar with its avatar facepile matched no removal rule.
- **A raw ISO timestamp** under every headline, from `makeHeader` printing the metadata date verbatim.

Also: `readerCSS` replaces the capture's stylesheet at display time but only constrained `.stower-article`, which captured articles do not use — they had no measure at all (fine on a phone, edge-to-edge on iPad/Mac).

## Repairing existing articles

Extraction fixes only apply at save time, so **Settings → Reader → Re-extract All Articles** rebuilds URL-backed articles through the current pipeline, with progress, a stop button, and per-item failure tolerance. It runs through the ingestion coordinator so it cannot overlap a share-queue drain.

## Notes for review

- **Chrome selectors are deliberately container-scoped.** My first pass used `[class*=restack]`, which matches Substack's `can-restack` on every body image and silently deleted all nine. Caught during verification; there is now a regression test pinning it. Patterns like `[class*=paywall]` are avoided for the same reason (`paywall-content` is a body wrapper).
- **Archives get larger.** The test article went from ~10 MB to ~11 MB zipped (37 MB on disk) as the price of legible images. If library size matters more, the capture width can come down.
- **Behavioural change:** articles containing videos or iframes now open in Reader View by default instead of the raw archive. The Original View toggle is unchanged.

## Verification

304 tests pass (67 new), SwiftLint strict clean, iOS + macOS builds succeed. Verified end to end in the simulator by re-saving the article above and reading it through.