### PR TITLE
Strip site widgets and render galleries as galleries

### DIFF
--- a/StowerPackage/Sources/StowerFeatureV2/Support/HTMLBlockParser.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/HTMLBlockParser.swift
@@ -113,6 +113,13 @@ func parseBlock(_ element: Element) throws -> ParsedBlocks {
         return ParsedBlocks(blocks: dedupeBlocks(blocks), media: dedupeMedia(media), embeds: dedupeEmbeds(embeds))
 
     case "ul", "ol":
+        // Image carousels and galleries are marked up as a list of slides
+        // (Splide, Swiper, Flickity and friends all use `<ul><li>`), so a
+        // gallery came out as a bulleted list — one bullet per photo, with the
+        // photo credit as the bullet's text.
+        if let gallery = try mediaGalleryBlocks(element) {
+            return gallery
+        }
         let listItems = try parseListItems(element)
         return ParsedBlocks(blocks: listItems.isEmpty ? [] : [.list(ordered: tag == "ol", items: listItems)], media: [], embeds: [])
 
@@ -450,6 +457,60 @@ func parseListItems(_ element: Element) throws -> [[ReaderInline]] {
     }
 
     return items
+}
+
+/// Recognises a `<ul>`/`<ol>` that is really an image gallery and returns its
+/// media as figure/video blocks instead of list items.
+///
+/// Every mainstream carousel library (Splide, Swiper, Flickity, slick) builds
+/// its track as `<ul><li class="…slide">`, so galleries reached the reader as
+/// bulleted lists: a bullet per photo, whose text was the photo credit.
+///
+/// Returns nil — leaving normal list handling in place — unless *every*
+/// non-empty item carries media and none of them carry real prose. A list of
+/// paragraphs that happen to contain an inline icon stays a list.
+func mediaGalleryBlocks(_ element: Element) throws -> ParsedBlocks? {
+    let items = try element.select("> li").array()
+    guard items.count >= 1 else { return nil }
+
+    var mediaItems = 0
+    var combined = ParsedBlocks(blocks: [], media: [], embeds: [])
+
+    for item in items {
+        let mediaNodes = try item.select("figure, picture, img, video").array()
+        // Prose the item carries in its own right, ignoring captions and the
+        // small-print credit lines that sit alongside gallery images.
+        let prose = item.copy() as! Element
+        try prose.select("figure, picture, img, video, figcaption, small, cite").remove()
+        let proseText = cleanText((try? prose.text()) ?? "")
+
+        if mediaNodes.isEmpty {
+            // An empty spacer item is tolerated; anything with words is not.
+            guard proseText.isEmpty else { return nil }
+            continue
+        }
+        // Captions and credits are excluded above, so a genuine slide has
+        // essentially no prose left. Anything more is a list item that merely
+        // happens to carry an image — a step list with inline icons, say.
+        guard proseText.count <= 40 else { return nil }
+        mediaItems += 1
+
+        // Parse the outermost media node per item so a <figure> keeps its
+        // caption rather than being split from it.
+        for node in mediaNodes where !node.hasAncestor(matching: ["figure", "picture"]) {
+            let parsed = try parseBlock(node)
+            combined.blocks.append(contentsOf: parsed.blocks)
+            combined.media.append(contentsOf: parsed.media)
+            combined.embeds.append(contentsOf: parsed.embeds)
+        }
+    }
+
+    guard mediaItems > 0, !combined.blocks.isEmpty else { return nil }
+    return ParsedBlocks(
+        blocks: dedupeBlocks(combined.blocks),
+        media: dedupeMedia(combined.media),
+        embeds: dedupeEmbeds(combined.embeds)
+    )
 }
 
 /// Parses `<dl>` into "term — definition" rows. Each `<dt>` starts a new row;

--- a/StowerPackage/Sources/StowerFeatureV2/Support/HTMLSanitizer.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/HTMLSanitizer.swift
@@ -32,25 +32,42 @@ func sanitizeBlocks(_ input: [ReaderBlock]) -> [ReaderBlock] {
 ///
 /// Only the *first* heading is considered, and only when it matches the title —
 /// a later section heading that happens to echo the title is left alone.
-func removeLeadingTitleRepeat(_ blocks: [ReaderBlock], title: String) -> [ReaderBlock] {
-    let normalizedTitle = comparableHeadingText(title)
-    guard !normalizedTitle.isEmpty else { return blocks }
-
-    guard let index = blocks.firstIndex(where: { block in
-        switch block {
-        case .heading, .paragraph:
-            return !blockText(block).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        default:
-            // Skip over a hero figure sitting above the headline.
-            return false
-        }
-    }) else { return blocks }
-
-    guard case .heading(_, let inlines) = blocks[index] else { return blocks }
-    guard comparableHeadingText(inlineText(inlines)) == normalizedTitle else { return blocks }
+func removeLeadingTitleRepeat(
+    _ blocks: [ReaderBlock],
+    title: String,
+    siteName: String? = nil,
+    author: String? = nil
+) -> [ReaderBlock] {
+    // Everything the reader already prints in its own header. A leading block
+    // that only restates one of these is furniture the page leaked, not prose:
+    // the site name next to a logo, a bare byline, the headline again.
+    let echoes = Set(
+        ([title, siteName, author].compactMap { $0 })
+            .map(comparableHeadingText)
+            .filter { !$0.isEmpty }
+    )
+    guard !echoes.isEmpty else { return blocks }
 
     var output = blocks
-    output.remove(at: index)
+    var index = 0
+    // Only the run at the very top is considered, and only short blocks — a
+    // real paragraph that happens to open with the site's name is kept.
+    while index < output.count {
+        switch output[index] {
+        case .figure, .video:
+            // A hero image may sit above the headline.
+            index += 1
+            continue
+        case .heading(_, let inlines), .paragraph(let inlines):
+            let text = inlineText(inlines)
+            guard text.count <= 120, echoes.contains(comparableHeadingText(text)) else {
+                return output
+            }
+            output.remove(at: index)
+        default:
+            return output
+        }
+    }
     return output
 }
 
@@ -177,7 +194,14 @@ func dedupeBlocks(_ input: [ReaderBlock]) -> [ReaderBlock] {
     for block in input {
         let fingerprint = String(describing: block)
         switch block {
-        case .figure, .video, .embed:
+        case .figure(let media), .video(let media):
+            // Keyed on image identity rather than the whole block, so the same
+            // photo at two CDN sizes (main carousel + thumbnail rail) collapses
+            // to one figure instead of appearing large and then small.
+            let key = mediaIdentity(media.sourceURL)
+            if seenMedia.contains(key) { continue }
+            seenMedia.insert(key)
+        case .embed:
             if seenMedia.contains(fingerprint) { continue }
             seenMedia.insert(fingerprint)
         default:
@@ -191,12 +215,28 @@ func dedupeBlocks(_ input: [ReaderBlock]) -> [ReaderBlock] {
 func dedupeMedia(_ input: [MediaDescriptor]) -> [MediaDescriptor] {
     var seen: Set<String> = []
     return input.filter {
-        if seen.contains($0.sourceURL) {
+        let key = mediaIdentity($0.sourceURL)
+        if seen.contains(key) {
             return false
         }
-        seen.insert($0.sourceURL)
+        seen.insert(key)
         return true
     }
+}
+
+/// Identity of an image for duplicate detection, ignoring the resize/format
+/// parameters image CDNs carry in the query string.
+///
+/// Galleries routinely emit the same photo twice — once in the main carousel
+/// and once in the thumbnail rail — differing only by `?w=750` versus
+/// `?w=1736`. Keying on the full URL treated those as two photos, so every
+/// gallery appeared twice: once large, once small.
+func mediaIdentity(_ sourceURL: String) -> String {
+    guard let components = URLComponents(string: sourceURL) else { return sourceURL }
+    guard let host = components.host, !components.path.isEmpty else { return sourceURL }
+    // Some CDNs (Substack, Cloudinary) encode the original URL *inside* the
+    // path, so the path alone still identifies the image uniquely.
+    return host.lowercased() + components.path
 }
 
 func dedupeEmbeds(_ input: [EmbedDescriptor]) -> [EmbedDescriptor] {

--- a/StowerPackage/Sources/StowerFeatureV2/Support/RenderedArticleExtractor.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/RenderedArticleExtractor.swift
@@ -55,12 +55,17 @@ enum RenderedArticleExtractor {
         // renders its own header from the extracted metadata, so leaving this
         // in printed the title twice, followed by a stray byline and date.
         //
-        // Deliberately matched on *container* names only. Broader patterns
-        // like `[class*=headline]` or `[class*=paywall]` are not safe here:
-        // substring class matching would also hit body wrappers such as
-        // `story-headline-and-body` or `paywall-content` and delete the
+        // Substrings are used, but only of *header/meta container* names,
+        // which read unambiguously as furniture. Publishers split the block
+        // across several wrappers (`article-header-bg`, `article-header-data`,
+        // `article-meta`), so exact class matching missed most of them and
+        // left "Published" and the site name stranded above the first
+        // paragraph. Broader words are still avoided here: `[class*=headline]`
+        // and `[class*=paywall]` would also hit body wrappers such as
+        // `story-headline-and-body` and `paywall-content`, deleting the
         // article itself.
-        ".post-header", ".entry-header", ".article-header", "[aria-label='Post header']",
+        "[class*=post-header]", "[class*=entry-header]", "[class*=article-header]",
+        "[class*=article-meta]", "[aria-label='Post header']",
 
         // Engagement / call-to-action furniture that sits inside the article
         // element on newsletter platforms: like + restack bars with their
@@ -75,6 +80,33 @@ enum RenderedArticleExtractor {
         "[class*=post-ufi]", "[class*=facepile]", "[class*=like-button]",
         "[class*=restack-button]", "[class*=button-wrapper]",
         "[class*=audio-player]", "[class*=support-widget]",
+
+        // Elements the page renders but does not show. `annotateHiddenContent`
+        // resolves this in the capture WebView, where computed styles exist.
+        "[data-stower-hidden]",
+
+        // Publishers mark non-article furniture with `data-nosnippet` so search
+        // engines skip it — the same signal works here. It reliably covers
+        // author bios, subscription pitches and "related" rails.
+        "[data-nosnippet]",
+
+        // Author bio blocks. The reader already shows the byline in its own
+        // header, so a paragraph-length biography ahead of the first sentence
+        // is pure obstruction.
+        "[class*=author-bio]", "[class*=author-box]", "[class*=author-card]",
+        "[class*=contributor-bio]", "[class*=about-the-author]",
+
+        // Carousel thumbnail rails, which restate every image in the gallery at
+        // postage-stamp size directly below the gallery itself.
+        "[class*=thumbnail]", "[class*=thumbs-]", "[class*=-thumbs]",
+        "[class*=splide__pagination]", "[class*=splide__arrows]",
+
+        // Interactive UI landmarks: menus, tab bars, toolbars and search.
+        // `label` belongs with the already-removed form controls — CSS-only
+        // widgets drive themselves with labels rather than buttons.
+        "label", "[role=menu]", "[role=menuitem]", "[role=menubar]",
+        "[role=tablist]", "[role=tab]", "[role=toolbar]", "[role=search]",
+        "[role=alert]", "[role=status]", "[role=progressbar]",
     ].joined(separator: ",")
 
     static func extract(
@@ -301,6 +333,7 @@ enum RenderedArticleExtractor {
     }
 
     private static func sanitize(_ root: Element, sourceURL: URL) throws {
+        try removeFormDrivenWidgets(root)
         try root.select(removalSelector).remove()
         try root.select("script,style,link,meta,base,object,embed,canvas,noscript,template").remove()
         try root.select("svg script,svg foreignObject,svg animate,svg set").remove()
@@ -342,6 +375,54 @@ enum RenderedArticleExtractor {
             }
         }
         try root.select("img[width=1],img[height=1]").remove()
+    }
+
+    /// Removes quiz / poll / survey widgets whole, rather than leaving their
+    /// contents stranded once the form controls are stripped.
+    ///
+    /// These are commonly built as pure CSS: a bank of `<input type="radio">`
+    /// plus one `display:none` panel per state, revealed with `:checked`
+    /// sibling selectors. Removing just the inputs (as the generic form
+    /// cleanup does) stranded every panel — on one How-To Geek article that
+    /// meant all eight questions, each followed by *both* its "Correct!" and
+    /// its "Not quite" explanation, dumped into the middle of the piece.
+    ///
+    /// A radio/checkbox group is a reliable marker because article prose does
+    /// not contain one. The widget root is the lowest ancestor holding the
+    /// whole group, and it is only removed when it is a minority of the
+    /// article — so a page that legitimately *is* a form is left intact rather
+    /// than emptied.
+    private static func removeFormDrivenWidgets(_ root: Element) throws {
+        let controls = try root.select("input[type=radio], input[type=checkbox]").array()
+        guard controls.count >= 4 else { return }
+
+        let rootTextLength = ((try? root.text().count) ?? 0)
+        var removed = Set<String>()
+
+        for control in controls {
+            var node = control.parent()
+            var widget: Element?
+            while let current = node, current !== root {
+                let count = ((try? current.select("input[type=radio], input[type=checkbox]").count) ?? 0)
+                if count >= 4 {
+                    widget = current
+                    break
+                }
+                node = current.parent()
+            }
+            guard let widget else { continue }
+
+            let identifier = ObjectIdentifier(widget).debugDescription
+            guard !removed.contains(identifier) else { continue }
+
+            // Never let this eat the article itself.
+            let widgetTextLength = ((try? widget.text().count) ?? 0)
+            guard rootTextLength == 0 || Double(widgetTextLength) < Double(rootTextLength) * 0.6 else {
+                continue
+            }
+            removed.insert(identifier)
+            try widget.remove()
+        }
     }
 
     private static func addBlockIndices(_ root: Element) throws {

--- a/StowerPackage/Sources/StowerFeatureV2/Support/URLIngestionClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/URLIngestionClient.swift
@@ -66,7 +66,15 @@ public struct ExtractionPipelineClient: Sendable {
         let root = try chooseRoot(document: document)
         let parsed = try parseBlocks(root: root, baseURL: sourceURL)
         let cleanedBlocks = sanitizeBlocks(parsed.blocks)
-        let deduped = removeLeadingTitleRepeat(cleanedBlocks, title: title)
+        let siteNameHint = nonEmpty(try? document.select("meta[property=og:site_name]").first()?.attr("content"))
+            ?? sourceURL.host
+        let authorHint = nonEmpty(try? document.select("meta[name=author]").first()?.attr("content"))
+        let deduped = removeLeadingTitleRepeat(
+            cleanedBlocks,
+            title: title,
+            siteName: siteNameHint,
+            author: authorHint
+        )
         let finalBlocks = deduped.isEmpty ? parsed.blocks : deduped
 
         let plainText = plainTextFromBlocks(finalBlocks)

--- a/StowerPackage/Sources/StowerFeatureV2/Support/WebArticleCaptureClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/WebArticleCaptureClient.swift
@@ -108,6 +108,7 @@ private final class WebArticleCaptureSession {
             warnings.append("The page kept changing while it was saved; late-loading media may be missing.")
         }
         try await normalizeRenderedResources()
+        try await annotateHiddenContent()
 
         let finalURL = webView.url ?? sourceURL
         let readability = try await runMozillaReadability()
@@ -178,6 +179,74 @@ private final class WebArticleCaptureSession {
               }
               for (const media of document.querySelectorAll('[poster]')) {
                 media.poster = new URL(media.poster, document.baseURI).href;
+              }
+              return true;
+            })()
+            """)
+    }
+
+    /// Marks elements the page is not actually showing, so extraction can drop
+    /// them.
+    ///
+    /// Extraction runs on the serialized DOM with SwiftSoup, which has no CSS
+    /// engine — so anything a page keeps in the DOM but hides with CSS gets
+    /// read as article text. Quiz widgets that stack every question and *both*
+    /// the "correct" and "incorrect" explanations as `display:none` panels,
+    /// inactive tabs, collapsed accordions and off-screen menus all came
+    /// through as walls of nonsense.
+    ///
+    /// The capture WebView does have a CSS engine, so the visibility question
+    /// is answered here, where it can actually be answered, and the result is
+    /// recorded as an attribute for `RenderedArticleExtractor` to act on.
+    ///
+    /// Marking (not removing) keeps the Original View archive faithful — the
+    /// elements are invisible there anyway.
+    ///
+    /// Deliberately conservative:
+    ///   * Only `display:none` / `visibility:hidden|collapse` count. Zero-size
+    ///     and off-viewport elements are left alone, because that is also what
+    ///     lazy-loaded and not-yet-scrolled-to content looks like.
+    ///   * Anything containing media is left alone. Carousels legitimately
+    ///     hide every slide but the active one, so marking on visibility alone
+    ///     deleted whole galleries — on a How-To Geek article, 20 of its 26
+    ///     images sat inside a `display:none` wrapper.
+    ///   * If marking would hide nearly all of the page's text the whole pass
+    ///     is abandoned, so a page still mid-hydration is never gutted.
+    private func annotateHiddenContent() async throws {
+        try await javascriptVoid("""
+            (() => {
+              const body = document.body;
+              if (!body) return true;
+
+              const totalText = (body.textContent || '').trim().length;
+              const MEDIA = 'img, picture, video, audio, figure, iframe, svg';
+              const candidates = [];
+              for (const el of body.querySelectorAll('*')) {
+                if (el.closest('[data-stower-hidden]')) continue;
+                const style = window.getComputedStyle(el);
+                if (style.display !== 'none'
+                    && style.visibility !== 'hidden'
+                    && style.visibility !== 'collapse') {
+                  continue;
+                }
+                // Hidden media is usually an off-screen carousel slide, which
+                // is content worth keeping. Only hidden *text* is dropped.
+                if (el.matches(MEDIA) || el.querySelector(MEDIA)) continue;
+                if (!(el.textContent || '').trim()) continue;
+                candidates.push(el);
+              }
+
+              // Bail out if what is left would be too thin to be the article.
+              let hiddenText = 0;
+              for (const el of candidates) {
+                hiddenText += (el.textContent || '').trim().length;
+              }
+              if (totalText > 0 && (totalText - hiddenText) < Math.max(400, totalText * 0.15)) {
+                return true;
+              }
+
+              for (const el of candidates) {
+                el.setAttribute('data-stower-hidden', '1');
               }
               return true;
             })()

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ArticleWidgetAndGalleryTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ArticleWidgetAndGalleryTests.swift
@@ -1,0 +1,306 @@
+import Foundation
+@testable import StowerFeature
+import SwiftSoup
+import Testing
+
+/// Regression coverage for a How-To Geek article that opened with an author
+/// biography and site furniture, then ran a gallery as a bulleted list of
+/// photo credits — twice, once large and once small — and finally dumped an
+/// eight-question quiz including every answer's "correct" *and* "incorrect"
+/// explanation into the middle of the piece.
+@Suite
+struct ArticleWidgetAndGalleryTests {
+    private let sourceURL = URL(string: "https://www.example.com/how-to-do-a-thing/")!
+
+    private func extract(_ html: String) throws -> RenderedArticleExtraction {
+        try RenderedArticleExtractor.extract(renderedHTML: html, sourceURL: sourceURL)
+    }
+
+    private func page(_ body: String) -> String {
+        """
+        <!doctype html><html><head><meta property="og:title" content="How to do a thing"></head>
+        <body>\(body)</body></html>
+        """
+    }
+
+    private let filler = """
+        <p>Setting this up looks harder than it is, and the whole thing takes \
+        about five minutes from start to finish.</p>
+        <p>The steps below walk through it in order, with a screenshot for each \
+        stage so nothing is ambiguous.</p>
+        """
+
+    private func blocks(_ html: String) throws -> [ReaderBlock] {
+        let document = try SwiftSoup.parseBodyFragment(html, sourceURL.absoluteString)
+        let body = try #require(document.body())
+        return try parseBlocks(root: body, baseURL: sourceURL).blocks
+    }
+
+    // MARK: - Predicates
+    //
+    // Named so the pattern matches stay on their own line.
+
+    private func isList(_ block: ReaderBlock) -> Bool {
+        if case .list = block {
+            return true
+        }
+        return false
+    }
+
+    private func isFigure(_ block: ReaderBlock) -> Bool {
+        if case .figure = block {
+            return true
+        }
+        return false
+    }
+
+    private func paragraphInlines(_ block: ReaderBlock) -> [ReaderInline] {
+        if case .paragraph(let inlines) = block {
+            return inlines
+        }
+        return []
+    }
+
+    // MARK: - Galleries as lists
+
+    @Test
+    func carouselListBecomesFiguresNotBullets() throws {
+        // Splide, Swiper, Flickity and slick all build their track as
+        // <ul><li>, so a gallery arrived as one bullet per photo whose text
+        // was the photo credit.
+        let html = """
+        <ul class="splide__list">
+          <li class="splide__slide"><figure><img src="https://cdn.example.com/one.jpg" alt="One">
+            <figcaption>Creating a new automation</figcaption></figure></li>
+          <li class="splide__slide"><figure><img src="https://cdn.example.com/two.jpg" alt="Two">
+            <figcaption>Selecting the CarPlay option</figcaption></figure></li>
+        </ul>
+        """
+        let result = try blocks(html)
+        #expect(!result.contains(where: isList))
+        let figures: [MediaDescriptor] = result.compactMap { block in
+            if case .figure(let media) = block {
+                return media
+            }
+            return nil
+        }
+        #expect(figures.count == 2)
+        #expect(figures.first?.caption == "Creating a new automation")
+    }
+
+    @Test
+    func anOrdinaryListStaysAList() throws {
+        let html = """
+        <ul>
+          <li>Open the Shortcuts app and switch to the Automations tab.</li>
+          <li>Scroll down until you find the CarPlay option under NFC.</li>
+        </ul>
+        """
+        let result = try blocks(html)
+        guard case .list(_, let items)? = result.first else {
+            Issue.record("Expected a list, got \(result)")
+            return
+        }
+        #expect(items.count == 2)
+    }
+
+    @Test
+    func aListOfProseWithInlineIconsStaysAList() throws {
+        // Media presence alone must not turn a list into a gallery.
+        let html = """
+        <ul>
+          <li><img src="https://cdn.example.com/icon.png"> Open the Shortcuts app and switch to the
+              Automations tab at the bottom of the screen, then tap the plus button.</li>
+          <li><img src="https://cdn.example.com/icon2.png"> Scroll down until you find the CarPlay
+              option, which sits underneath NFC in the list of triggers.</li>
+        </ul>
+        """
+        let result = try blocks(html)
+        #expect(result.contains(where: isList))
+    }
+
+    // MARK: - Duplicate images at different CDN sizes
+
+    @Test
+    func sameImageAtTwoSizesAppearsOnce() throws {
+        // A gallery emits each photo twice: once in the carousel and once in
+        // the thumbnail rail, differing only by resize parameters.
+        let html = """
+        <div>
+          <figure><img src="https://cdn.example.com/wp/img_5030.jpeg?w=1736&h=1157"></figure>
+          <figure><img src="https://cdn.example.com/wp/img_5030.jpeg?w=750&h=422"></figure>
+        </div>
+        """
+        let figures = sanitizeBlocks(try blocks(html)).filter(isFigure)
+        #expect(figures.count == 1)
+    }
+
+    @Test
+    func differentImagesAreBothKept() throws {
+        let html = """
+        <div>
+          <figure><img src="https://cdn.example.com/wp/img_5030.jpeg?w=750"></figure>
+          <figure><img src="https://cdn.example.com/wp/img_5031.jpeg?w=750"></figure>
+        </div>
+        """
+        let figures = sanitizeBlocks(try blocks(html)).filter(isFigure)
+        #expect(figures.count == 2)
+    }
+
+    @Test
+    func mediaIdentityIgnoresResizeParametersOnly() {
+        #expect(mediaIdentity("https://cdn.example.com/a/b.jpg?w=100") == mediaIdentity("https://cdn.example.com/a/b.jpg?w=900"))
+        #expect(mediaIdentity("https://cdn.example.com/a/b.jpg") != mediaIdentity("https://cdn.example.com/a/c.jpg"))
+        // A CDN that encodes the original URL in the path stays distinguishable.
+        #expect(
+            mediaIdentity("https://cdn.example.com/fetch/w_424/https%3A%2F%2Fx.com%2F1.png")
+                != mediaIdentity("https://cdn.example.com/fetch/w_424/https%3A%2F%2Fx.com%2F2.png")
+        )
+    }
+
+    // MARK: - Form-driven widgets
+
+    @Test
+    func radioDrivenQuizIsRemovedWhole() throws {
+        // Pure-CSS quizzes stack every panel in the DOM and reveal one with
+        // :checked. Stripping the inputs alone left all eight questions and
+        // both explanations for each.
+        let html = page("""
+            <article>
+              \(filler)
+              <div class="vq">
+                <input type="radio" name="q1"><input type="radio" name="q1">
+                <input type="radio" name="q2"><input type="radio" name="q2">
+                <section class="vq-panel"><p>What is planned obsolescence?</p>
+                  <p>Correct! Planned obsolescence is a deliberate strategy.</p>
+                  <p>Not quite. Planned obsolescence limits a product's lifespan.</p>
+                </section>
+              </div>
+            </article>
+            """)
+        let text = try extract(html).plainText
+        #expect(!text.contains("Correct!"))
+        #expect(!text.contains("Not quite"))
+        #expect(!text.contains("planned obsolescence"))
+        #expect(text.contains("Setting this up looks harder"))
+    }
+
+    @Test
+    func aPageThatIsMostlyAFormIsNotEmptied() throws {
+        // The guard: if the control group dominates the document it is the
+        // content, so removing it would leave nothing.
+        let html = page("""
+            <article>
+              <div class="survey">
+                <input type="radio" name="a"><input type="radio" name="a">
+                <input type="radio" name="b"><input type="radio" name="b">
+                <p>Question one of our reader survey, which is the whole point of this page.</p>
+                <p>Question two of our reader survey, also central to why the page exists.</p>
+                <p>Question three, rounding out a page that is genuinely a questionnaire.</p>
+              </div>
+            </article>
+            """)
+        #expect(try extract(html).plainText.contains("reader survey"))
+    }
+
+    @Test
+    func aCoupleOfCheckboxesDoNotTriggerWidgetRemoval() throws {
+        let html = page("""
+            <article>\(filler)<div><input type="checkbox"> <span>Remember me</span></div></article>
+            """)
+        #expect(try extract(html).plainText.contains("Setting this up looks harder"))
+    }
+
+    // MARK: - Hidden content and publisher markers
+
+    @Test
+    func contentTheBrowserReportedAsHiddenIsDropped() throws {
+        // annotateHiddenContent resolves computed styles in the capture
+        // WebView and marks what the page is not showing.
+        let html = page("""
+            <article>
+              \(filler)
+              <section data-stower-hidden="1"><p>Panel three of eight, never on screen.</p></section>
+            </article>
+            """)
+        #expect(!(try extract(html).plainText.contains("Panel three")))
+    }
+
+    @Test
+    func dataNosnippetFurnitureIsDropped() throws {
+        let html = page("""
+            <article>
+              <div data-nosnippet><p>Nathaniel is a tech enthusiast who dives deep into Apple's world.</p></div>
+              \(filler)
+            </article>
+            """)
+        let text = try extract(html).plainText
+        #expect(!text.contains("tech enthusiast"))
+        #expect(text.contains("Setting this up looks harder"))
+    }
+
+    @Test
+    func authorBioBlockIsDropped() throws {
+        let html = page("""
+            <article>
+              <div class="author-bio"><p>Nathaniel writes about Apple hardware and software.</p></div>
+              \(filler)
+            </article>
+            """)
+        #expect(!(try extract(html).plainText.contains("writes about Apple")))
+    }
+
+    @Test
+    func menuAndTabChromeIsDropped() throws {
+        let html = page("""
+            <article>
+              \(filler)
+              <div role="menu"><span role="menuitem">Preferred Source</span></div>
+              <div role="tablist"><span role="tab">Summary</span></div>
+            </article>
+            """)
+        let text = try extract(html).plainText
+        #expect(!text.contains("Preferred Source"))
+        #expect(!text.contains("Summary"))
+    }
+
+    // MARK: - Leading metadata echoes
+
+    @Test
+    func dropsALeadingSiteNameEcho() {
+        let blocks: [ReaderBlock] = [
+            .paragraph([.text("How-To Geek")]),
+            .paragraph([.text("When you use CarPlay, you probably just start some music.")]),
+        ]
+        let result = removeLeadingTitleRepeat(blocks, title: "Some title", siteName: "How-To Geek")
+        #expect(result.count == 1)
+    }
+
+    @Test
+    func dropsALeadingBylineEcho() {
+        let blocks: [ReaderBlock] = [
+            .paragraph([.text("Nate Pangaro")]),
+            .paragraph([.text("When you use CarPlay, you probably just start some music.")]),
+        ]
+        let result = removeLeadingTitleRepeat(blocks, title: "T", siteName: nil, author: "Nate Pangaro")
+        #expect(result.count == 1)
+    }
+
+    @Test
+    func keepsARealParagraphThatMentionsTheSiteName() {
+        let body = "How-To Geek has covered CarPlay for years, and this trick is one of the best."
+        let blocks: [ReaderBlock] = [.paragraph([.text(body)])]
+        let result = removeLeadingTitleRepeat(blocks, title: "T", siteName: "How-To Geek")
+        #expect(result.count == 1)
+        #expect(inlineText(paragraphInlines(result[0])) == body)
+    }
+
+    @Test
+    func onlyStripsEchoesAtTheVeryTop() {
+        let blocks: [ReaderBlock] = [
+            .paragraph([.text("Real opening paragraph of the article goes here.")]),
+            .paragraph([.text("How-To Geek")]),
+        ]
+        #expect(removeLeadingTitleRepeat(blocks, title: "T", siteName: "How-To Geek").count == 2)
+    }
+}


### PR DESCRIPTION
Follow-up to #35, from reading [this How-To Geek article](https://www.howtogeek.com/try-this-carplay-customization-trick-that-no-one-talks-about/). It opened with an author biography and site furniture, ran its photo galleries as bulleted lists of image credits — twice, once large and once small — and dumped an eight-question quiz, including both the "correct" **and** "incorrect" explanation for every answer, into the middle of the piece.

Four separate causes, each fixed generally rather than for this one site.

## Hidden content was being read as article text

Extraction runs on the serialized DOM with SwiftSoup, which has no CSS engine — so anything a page keeps in the DOM but hides with CSS came through as prose. That quiz stacks every question and both explanations as `display:none` panels and reveals one with `:checked`.

The capture WebView *does* have a CSS engine, so visibility is now answered there and recorded as an attribute for the extractor to act on. Marking rather than removing keeps the Original View archive faithful.

**Elements containing media are exempt.** Carousels legitimately hide every slide but the active one — my first version marked on visibility alone and removed **20 of that article's 26 images**. Caught by checking the real page in a browser before committing.

## Galleries rendered as bulleted lists

Splide, Swiper, Flickity and slick all build their track as `<ul><li>`, so a gallery arrived as one bullet per photo whose text was the credit line. A list whose items carry media and no prose now yields figure blocks. A list of steps with inline icons stays a list.

## Every gallery image appeared twice

Once from the carousel and once from the thumbnail rail, differing only by resize parameters (`?w=1736` vs `?w=750`). Media identity now ignores the query string, so the pair collapses to one figure instead of appearing large and then small.

## Quiz/poll widgets

These are commonly pure CSS: a bank of radio inputs plus one panel per state. The generic form cleanup removed the inputs and stranded every panel. The whole widget is now removed, guarded so a page that genuinely *is* a form is left intact rather than emptied.

Plus author bio blocks, `[data-nosnippet]` furniture, menu/tab chrome, and leading paragraphs that only echo the site name or byline — all of which the reader already shows in its own header.

## Effect on the reported article

| | before | after |
|---|---|---|
| blocks | 109 | 49 |
| plain text | 13,568 chars | 6,915 |
| images | 20 (10 duplicated) | 10 |
| first block | "Published" | the article's first sentence |

No regression on the Substack article from #35: still 9 images, no chrome leakage.

## Verification

321 tests pass (17 new), SwiftLint strict clean, iOS + macOS builds succeed. The hidden-content pass was validated against the live How-To Geek page in a real browser: 133 elements marked, all 26 images surviving, every "Correct!"/"Not quite" explanation gone, article text intact, and the safety bail-out comfortably not triggered (49k chars remaining against a 24k threshold).

Note: the simulator was shut down partway through, so this round was verified against the real page's DOM rather than by reading it in the app.