### PR TITLE
Apply gallery and duplicate handling to the rendered reader HTML

### DIFF
--- a/StowerPackage/Sources/StowerFeatureV2/Support/RenderedArticleExtractor.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/RenderedArticleExtractor.swift
@@ -101,6 +101,13 @@ enum RenderedArticleExtractor {
         "[class*=thumbnail]", "[class*=thumbs-]", "[class*=-thumbs]",
         "[class*=splide__pagination]", "[class*=splide__arrows]",
 
+        // Sidebars and end-of-article rails. On CMSs that wrap the whole page
+        // in a single `<article>` these sit inside the extraction root, so a
+        // How-To Geek piece ended with a tabbed "more reading" panel and six
+        // thumbnails of unrelated posts.
+        "[class*=sidebar]", "[class*=pinned-listing]", "[class*=display-card]",
+        "[class*=article-tags]", "[class*=article-footer]", "[class*=article-credit]",
+
         // Interactive UI landmarks: menus, tab bars, toolbars and search.
         // `label` belongs with the already-removed form controls — CSS-only
         // widgets drive themselves with labels rather than buttons.
@@ -375,6 +382,83 @@ enum RenderedArticleExtractor {
             }
         }
         try root.select("img[width=1],img[height=1]").remove()
+        try unwrapMediaOnlyLists(root)
+        try removeDuplicateImages(root)
+    }
+
+    /// Replaces `<ul>`/`<ol>` galleries with their media, in place.
+    ///
+    /// This mirrors `mediaGalleryBlocks` in the block parser, and has to exist
+    /// separately because the two feed different things: the parser builds the
+    /// `ReaderDocument` used for listening, search and AI, while *this* HTML is
+    /// what the reader actually renders for a captured article. Fixing only the
+    /// parser left galleries still displaying as bulleted lists of photo
+    /// credits, which is what the reader shows on screen.
+    private static func unwrapMediaOnlyLists(_ root: Element) throws {
+        for list in try root.select("ul, ol").array() {
+            let items = try list.select("> li").array()
+            guard !items.isEmpty else { continue }
+
+            var mediaNodes = [Element]()
+            var isGallery = true
+            for item in items {
+                let media = try item.select("figure, picture, img, video").array()
+                let prose = item.copy() as! Element
+                try prose.select("figure, picture, img, video, figcaption, small, cite").remove()
+                let proseText = cleanText((try? prose.text()) ?? "")
+
+                if media.isEmpty {
+                    if !proseText.isEmpty {
+                        isGallery = false
+                        break
+                    }
+                    continue
+                }
+                if proseText.count > 40 {
+                    isGallery = false
+                    break
+                }
+                for node in media where !node.hasAncestor(matching: ["figure", "picture"]) {
+                    mediaNodes.append(node)
+                }
+            }
+
+            guard isGallery, !mediaNodes.isEmpty else { continue }
+            for node in mediaNodes {
+                try list.before(try node.outerHtml())
+            }
+            try list.remove()
+        }
+    }
+
+    /// Drops repeats of an image already present earlier in the article.
+    ///
+    /// Galleries emit each photo twice — once in the carousel and once in the
+    /// thumbnail rail — differing only by the resize parameters in the query
+    /// string, so the reader showed every gallery twice: full size, then
+    /// postage-stamp size.
+    private static func removeDuplicateImages(_ root: Element) throws {
+        var seen = Set<String>()
+        for image in try root.select("img").array() {
+            let absolute = (try? image.attr("abs:src")) ?? ""
+            let source = absolute.isEmpty ? ((try? image.attr("src")) ?? "") : absolute
+            guard !source.isEmpty else { continue }
+
+            let key = mediaIdentity(source)
+            if seen.contains(key) {
+                // Take the enclosing figure/picture with it so no empty
+                // wrapper (or orphaned caption) is left on the page.
+                var target: Element = image
+                var ancestor = image.parent()
+                while let current = ancestor, ["figure", "picture"].contains(current.tagName().lowercased()) {
+                    target = current
+                    ancestor = current.parent()
+                }
+                try target.remove()
+            } else {
+                seen.insert(key)
+            }
+        }
     }
 
     /// Removes quiz / poll / survey widgets whole, rather than leaving their

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ArticleWidgetAndGalleryTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ArticleWidgetAndGalleryTests.swift
@@ -303,4 +303,75 @@ struct ArticleWidgetAndGalleryTests {
         ]
         #expect(removeLeadingTitleRepeat(blocks, title: "T", siteName: "How-To Geek").count == 2)
     }
+
+    // MARK: - The HTML the reader actually renders
+    //
+    // Captured articles are displayed from `readerHTML` (archived as
+    // reader.webarchive), NOT from the ReaderDocument. Gallery and duplicate
+    // handling therefore has to exist in the extractor as well as the block
+    // parser — fixing only the parser left the reader still showing galleries
+    // as bulleted lists.
+
+    @Test
+    func readerHTMLUnwrapsGalleryListsIntoFigures() throws {
+        let html = page("""
+            <article>
+              \(filler)
+              <ul class="splide__list">
+                <li class="splide__slide"><figure><img src="https://cdn.example.com/one.jpg">
+                  <small>Credit: Someone</small></figure></li>
+                <li class="splide__slide"><figure><img src="https://cdn.example.com/two.jpg">
+                  <small>Credit: Someone</small></figure></li>
+              </ul>
+            </article>
+            """)
+        let readerHTML = try extract(html).readerHTML
+        #expect(!readerHTML.contains("<li"))
+        #expect(readerHTML.contains("one.jpg"))
+        #expect(readerHTML.contains("two.jpg"))
+    }
+
+    @Test
+    func readerHTMLKeepsAGenuineProseList() throws {
+        let html = page("""
+            <article>\(filler)
+              <ul><li>Open the Shortcuts app and switch to the Automations tab at the bottom.</li>
+                  <li>Scroll down until you find the CarPlay option, underneath NFC.</li></ul>
+            </article>
+            """)
+        let readerHTML = try extract(html).readerHTML
+        #expect(readerHTML.contains("<li"))
+        #expect(readerHTML.contains("Automations tab"))
+    }
+
+    @Test
+    func readerHTMLDropsRepeatedImages() throws {
+        let html = page("""
+            <article>
+              \(filler)
+              <figure><img src="https://cdn.example.com/wp/shot.jpeg?w=1736&h=1157"></figure>
+              <figure><img src="https://cdn.example.com/wp/shot.jpeg?w=750&h=422"></figure>
+            </article>
+            """)
+        let readerHTML = try extract(html).readerHTML
+        #expect(readerHTML.components(separatedBy: "shot.jpeg").count - 1 == 1)
+    }
+
+    @Test
+    func readerHTMLDropsTheRelatedArticlesRail() throws {
+        let html = page("""
+            <article>
+              \(filler)
+              <div class="sidebar-el-content">
+                <div class="display-card"><img src="https://cdn.example.com/other.jpg?w=120&h=80">
+                  <span>Some unrelated post</span></div>
+              </div>
+              <div class="article-tags"><span>CarPlay</span></div>
+            </article>
+            """)
+        let readerHTML = try extract(html).readerHTML
+        #expect(!readerHTML.contains("other.jpg"))
+        #expect(!readerHTML.contains("Some unrelated post"))
+        #expect(readerHTML.contains("Setting this up looks harder"))
+    }
 }


### PR DESCRIPTION
Fixes the "I don't see any difference" report after #36. The build was correct; the fix was in the wrong place.

## What I got wrong in #36

Stower has two rendering paths, and I fixed the one that isn't on screen.

- `ReaderDocumentHTMLBuilder` renders the `ReaderDocument` — used for PDFs, text/markdown items, and as the index for listening, search and AI.
- **Captured web articles are rendered from `reader.webarchive`**, built from `RenderedArticleExtractor`'s `readerHTML`. `ReaderWebView` loads it whenever `captureVersion > 0`, which is every natively captured article.

The gallery-unwrapping and duplicate-image fixes in #36 went into `HTMLBlockParser`/`HTMLSanitizer`, so they only ever touched the ReaderDocument. The chrome removal in #36 *did* land (it lives in the extractor), which is why the quiz and author bio went away — but the two most visually dominant problems were untouched.

Measured on the reported article's `readerHTML` before this change: **2 `splide__list` carousels, 12 `<li>`, 21 `<img>`** — galleries still rendering as bulleted lists of photo credits, every gallery image still present twice.

## This change

The same two transformations now run over the sanitized article HTML:

- A `<ul>`/`<ol>` whose items carry media and no prose is replaced by its figures. A genuine prose list is untouched.
- An image whose identity (host + path, ignoring CDN resize parameters) has already appeared is dropped, along with its figure wrapper.

Plus sidebars and end-of-article rails — on CMSs that wrap the whole page in one `<article>` these sit inside the extraction root, so the piece ended with a tabbed "more reading" panel and six `w=120` thumbnails of unrelated posts.

| readerHTML | before | after |
|---|---|---|
| bytes | 40,428 | 22,132 |
| `<li>` | 12 | 0 |
| `<img>` | 21 | 10 |
| sidebar thumbnails | 6 | 0 |

## A rejected approach, recorded

I tried tightening the extraction root — pick the smallest element still holding ~all of Readability's text — to solve the sidebar problem generically. It works on text and **silently dropped every image in the article**, because the tightest text-bearing container excludes the galleries. Reverted in favour of the targeted selectors above. Worth knowing if anyone tries it again.

## Verification

325 tests pass (4 new, covering the `readerHTML` path specifically rather than only the parser), SwiftLint strict clean, iOS + macOS builds succeed. Verified by extracting the real fetched article and inspecting the generated `readerHTML` directly.

Existing saved copies still need a re-extract to pick this up.