### PR TITLE
Align archive block indices with document blocks

### DIFF
--- a/StowerPackage/Sources/StowerFeatureV2/Support/RenderedArticleExtractor.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/RenderedArticleExtractor.swift
@@ -509,10 +509,55 @@ enum RenderedArticleExtractor {
         }
     }
 
+    /// Block-level elements that correspond one-to-one with `ReaderBlock`
+    /// cases produced by the block parser.
+    ///
+    /// `li` is deliberately absent and `ul`/`ol` present: the parser emits a
+    /// single `.list` block per list, so indexing each item made every index
+    /// after a list disagree with the document by the item count. `svg`,
+    /// `details` and `math` are absent because the parser emits nothing for
+    /// them, which shifted things the other way.
+    private static let blockIndexSelector = [
+        "h1", "h2", "h3", "h4", "h5", "h6", "p", "ul", "ol", "dl",
+        "blockquote", "pre", "figure", "table", "video", "audio",
+        ".stower-embed-launcher",
+    ].joined(separator: ",")
+
+    /// Numbers the article's blocks so the reader can highlight and scroll to
+    /// them by index.
+    ///
+    /// This index space has to agree with the order of `ReaderDocument.blocks`,
+    /// because listening highlights by document block position while the page
+    /// on screen is this HTML. Two rules keep them in step:
+    ///
+    ///   * Only the outermost element of a nested run is numbered. A
+    ///     `<blockquote>` containing `<p>` is one block, not two, and a `<ul>`
+    ///     is one block, not one per `<li>`.
+    ///   * Elements with neither text nor media are skipped, matching the
+    ///     parser dropping empty blocks.
     private static func addBlockIndices(_ root: Element) throws {
-        let blocks = try root.select("h1,h2,h3,h4,h5,h6,p,li,blockquote,pre,figure,table,dl,details,math,svg,video,audio,.stower-embed-launcher")
-        for (index, element) in blocks.array().enumerated() {
+        let candidates = try root.select(blockIndexSelector).array()
+        let candidateIDs = Set(candidates.map(ObjectIdentifier.init))
+
+        var index = 0
+        for element in candidates {
+            var ancestor = element.parent()
+            var isNested = false
+            while let current = ancestor, current !== root {
+                if candidateIDs.contains(ObjectIdentifier(current)) {
+                    isNested = true
+                    break
+                }
+                ancestor = current.parent()
+            }
+            if isNested { continue }
+
+            let hasText = !(((try? element.text()) ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            let hasMedia = !((try? element.select("img,picture,video,audio,iframe").isEmpty()) ?? true)
+            guard hasText || hasMedia else { continue }
+
             try element.attr("data-block-index", String(index))
+            index += 1
         }
     }
 
@@ -582,7 +627,13 @@ enum RenderedArticleExtractor {
         let meta = [byline, date].filter { !$0.isEmpty }.joined(separator: " &middot; ")
         let metaHTML = meta.isEmpty ? "" : "<p class=\"stower-meta\">\(meta)</p>"
 
-        return "<header class=\"stower-header\">\(site)<h1 data-block-index=\"0\">\(escapeHTML(title))</h1>\(deckHTML)\(metaHTML)</header>"
+        // `-1`, not `0`: the body's first block is also index 0, and
+        // `querySelector` returns the first match in document order — so
+        // highlighting or restoring to block 0 landed on the title instead of
+        // the opening paragraph. The reader runtime already treats negative
+        // indices as "not a body block", and the structured builder uses the
+        // same convention for its header.
+        return "<header class=\"stower-header\">\(site)<h1 data-block-index=\"-1\">\(escapeHTML(title))</h1>\(deckHTML)\(metaHTML)</header>"
     }
 
     private static func meta(_ document: Document, _ selector: String) -> String? {

--- a/StowerPackage/Sources/StowerFeatureV2/Support/URLIngestionClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/URLIngestionClient.swift
@@ -63,7 +63,14 @@ public struct ExtractionPipelineClient: Sendable {
         // Detect interactive content BEFORE stripping SVGs/scripts.
         let hasInteractiveContent = detectInteractiveContent(document: document)
 
-        let root = try chooseRoot(document: document)
+        // When the input is our own reader HTML the root is already known, and
+        // re-deriving it is actively harmful: `chooseRoot` requires 300+
+        // characters before it will accept an `<article>`, so a short piece
+        // fell back to `<main>` and swallowed the reader's own header — the
+        // site name and headline then appeared as body blocks, and every block
+        // index shifted out of step with the rendered page.
+        let root = try document.select("#stower-reader-article").first()
+            ?? chooseRoot(document: document)
         let parsed = try parseBlocks(root: root, baseURL: sourceURL)
         let cleanedBlocks = sanitizeBlocks(parsed.blocks)
         let siteNameHint = nonEmpty(try? document.select("meta[property=og:site_name]").first()?.attr("content"))

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ReaderBlockIndexAlignmentTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ReaderBlockIndexAlignmentTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+@testable import StowerFeature
+import SwiftSoup
+import Testing
+
+/// The reader highlights and scrolls by block index, but the two sides of that
+/// contract are produced independently: listening counts positions in
+/// `ReaderDocument.blocks`, while the page on screen for a captured article is
+/// the extractor's HTML, numbered by `addBlockIndices`. These tests pin the two
+/// index spaces together.
+@Suite
+struct ReaderBlockIndexAlignmentTests {
+    private let sourceURL = URL(string: "https://www.example.com/an-article")!
+
+    private func page(_ body: String) -> String {
+        """
+        <!doctype html><html><head><meta property="og:title" content="An article">
+        <meta property="og:site_name" content="Example"></head>
+        <body>\(body)</body></html>
+        """
+    }
+
+    private func indexedElements(_ readerHTML: String) throws -> [(index: Int, tag: String, text: String)] {
+        let document = try SwiftSoup.parse(readerHTML, sourceURL.absoluteString)
+        return try document.select("[data-block-index]").array().compactMap { element in
+            guard let index = Int((try? element.attr("data-block-index")) ?? "") else { return nil }
+            return (index, element.tagName(), cleanText((try? element.text()) ?? ""))
+        }
+    }
+
+    // MARK: - The header must not occupy a body index
+
+    @Test
+    func headerIsNotBlockZero() throws {
+        // `querySelector` returns the first match in document order, so a
+        // header sharing index 0 with the opening paragraph meant every
+        // highlight or restore of block 0 landed on the title.
+        let html = page("<article><p>The opening paragraph of the article body goes here.</p></article>")
+        let readerHTML = try RenderedArticleExtractor.extract(renderedHTML: html, sourceURL: sourceURL).readerHTML
+
+        let elements = try indexedElements(readerHTML)
+        let header = try #require(elements.first { $0.tag == "h1" })
+        #expect(header.index == -1)
+
+        let zero = try #require(elements.first { $0.index == 0 })
+        #expect(zero.tag == "p")
+        #expect(zero.text.hasPrefix("The opening paragraph"))
+    }
+
+    // MARK: - Granularity must match the block parser
+
+    @Test
+    func aListIsOneIndexNotOnePerItem() throws {
+        let html = page("""
+            <article>
+              <p>An opening paragraph long enough to clear the extractor minimum.</p>
+              <ul><li>First step</li><li>Second step</li><li>Third step</li></ul>
+              <p>A closing paragraph that has to line up in both index spaces.</p>
+            </article>
+            """)
+        let readerHTML = try RenderedArticleExtractor.extract(renderedHTML: html, sourceURL: sourceURL).readerHTML
+        let body = try indexedElements(readerHTML).filter { $0.index >= 0 }
+
+        #expect(body.map(\.tag) == ["p", "ul", "p"])
+        // The block after the list is what used to drift, by the item count.
+        #expect(body.last?.index == 2)
+        #expect(body.last?.text.hasPrefix("A closing paragraph") == true)
+    }
+
+    @Test
+    func aBlockquoteContainingParagraphsIsOneIndex() throws {
+        let html = page("""
+            <article>
+              <p>An opening paragraph long enough to clear the extractor minimum.</p>
+              <blockquote><p>A quoted sentence.</p><p>And a second quoted sentence.</p></blockquote>
+              <p>A closing paragraph after the quotation block.</p>
+            </article>
+            """)
+        let body = try indexedElements(
+            try RenderedArticleExtractor.extract(renderedHTML: html, sourceURL: sourceURL).readerHTML
+        ).filter { $0.index >= 0 }
+        #expect(body.map(\.tag) == ["p", "blockquote", "p"])
+    }
+
+    @Test
+    func elementsWithNothingInThemAreSkipped() throws {
+        let html = page("""
+            <article>
+              <p>An opening paragraph long enough to clear the extractor minimum.</p>
+              <p></p>
+              <p>A closing paragraph that should be index one, not index two.</p>
+            </article>
+            """)
+        let body = try indexedElements(
+            try RenderedArticleExtractor.extract(renderedHTML: html, sourceURL: sourceURL).readerHTML
+        ).filter { $0.index >= 0 }
+        #expect(body.count == 2)
+        #expect(body.last?.index == 1)
+    }
+
+    // MARK: - End-to-end canary
+
+    @Test
+    func archiveIndicesLineUpWithDocumentBlocks() async throws {
+        // Runs the real capture pipeline: extract, then build the ReaderDocument
+        // from the extractor's HTML exactly as WebArticleCaptureSession does.
+        let html = page("""
+            <article>
+              <p>An opening paragraph with enough words in it to survive extraction.</p>
+              <h2>A section heading</h2>
+              <p>A second paragraph of ordinary prose following the heading.</p>
+              <ul><li>First step</li><li>Second step</li><li>Third step</li></ul>
+              <blockquote><p>A quotation that spans a couple of sentences here.</p></blockquote>
+              <figure><img src="https://cdn.example.com/photo.jpg"><figcaption>A caption.</figcaption></figure>
+              <p>A closing paragraph rounding the whole thing off nicely.</p>
+            </article>
+            """)
+        let extraction = try RenderedArticleExtractor.extract(renderedHTML: html, sourceURL: sourceURL)
+        let indexed = try await ExtractionPipelineClient.live.extract(extraction.readerHTML, sourceURL)
+
+        let body = try indexedElements(extraction.readerHTML).filter { $0.index >= 0 }
+        #expect(body.count == indexed.document.blocks.count)
+
+        // Indices must be a gap-free 0..<n so position and index coincide.
+        #expect(body.map(\.index) == Array(0..<body.count))
+
+        // Spot-check that the same index names the same content on both sides.
+        for (position, block) in indexed.document.blocks.enumerated() {
+            guard position < body.count else { break }
+            let documentText = blockText(block).prefix(24)
+            guard !documentText.isEmpty else { continue }
+            #expect(
+                body[position].text.hasPrefix(String(documentText)),
+                "index \(position): archive has \(body[position].text.prefix(40)), document has \(documentText)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #37. Comes out of the architecture question about the two rendering paths — this is the part that was a live bug rather than a maintenance smell.

## The contract that was broken

The reader highlights and scrolls by block index. Both sides of that contract were produced independently:

- **Listening** counts positions in `ReaderDocument.blocks` (`ReaderSpeechTextBuilder` uses `document.blocks.enumerated()`), and `ReaderScreen` passes that straight through as `highlightedBlockIndex`.
- **The page on screen** for a captured article is the extractor's HTML, numbered separately by `addBlockIndices`, and `stowerHighlight(i)` resolves `[data-block-index="i"]` against it.

Nothing kept the two in step. Three concrete divergences, all reproduced against the real How-To Geek and Substack articles:

**1. Block 0 always highlighted the title.** `makeHeader` stamped the header `<h1>` with `data-block-index="0"`, which the body's first block also uses. `querySelector` returns the first match in document order, so *every* highlight or position-restore of block 0 landed on the headline. The header now uses `-1` — already the convention the reader runtime treats as "not a body block", and already what the structured builder uses for its own header.

**2. One list threw everything after it out by the item count.** `addBlockIndices` numbered each `<li>`; the parser emits a single `.list` block per list. A three-item list desynced the remainder of the article by two. It now numbers `ul`/`ol` rather than `li`, drops `svg`/`details`/`math` (the parser emits nothing for them), numbers only the outermost element of a nested run (a `<blockquote>` of paragraphs is one block, not three), and skips elements with neither text nor media to match the parser dropping empties.

**3. Short articles pulled the reader's own header into the body.** The block parser re-derived a root from our own reader HTML, and `chooseRoot` requires 300+ characters before it will accept an `<article>` — so a short piece fell back to `<main>`, swallowed the header, and turned the site name and headline into body blocks, shifting every index. It now uses `#stower-reader-article` directly when present.

That third one is also the first small step toward not re-deciding downstream what the extractor has already decided.

## Canary

The end-to-end test runs the real capture pipeline — `RenderedArticleExtractor.extract` then `ExtractionPipelineClient.live.extract` over its output, exactly as `WebArticleCaptureSession` does — and asserts the archive's indices are a gap-free `0..<n` matching the document's blocks one for one, with the same text at the same index. It caught divergence #3 while I was writing it.

## Not in scope

Boilerplate filtering in `sanitizeBlocks` can still drop a block the archive keeps, so alignment is enforced by the canary rather than guaranteed structurally. The durable fix is the larger refactor discussed separately: make the extractor the single authority on what content exists and demote the block parser to a pure translator. Deliberately not folded in here.

## Verification

330 tests pass (5 new), SwiftLint strict clean, iOS + macOS builds succeed. The three divergences were each demonstrated on real captured article HTML before being fixed.