### PR TITLE
Make error and diagnostic text selectable and copyable

### DIFF
--- a/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
@@ -102,6 +102,7 @@ public struct AppFeature {
         case failedImportsLoaded([FailedImport])
         case retryFailedImportsTapped
         case dismissFailedImportsTapped
+        case dismissStartupErrorTapped
         case readerAppearanceLoaded(ReaderAppearanceSettings)
         case readerAppearanceFailed(String)
         case readerFocusButtonTapped
@@ -259,6 +260,10 @@ public struct AppFeature {
 
             case .failedImportsLoaded(let imports):
                 state.failedImports = imports
+                return .none
+
+            case .dismissStartupErrorTapped:
+                state.startupErrorMessage = nil
                 return .none
 
             case .retryFailedImportsTapped:

--- a/StowerPackage/Sources/StowerFeatureV2/ContentView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/ContentView.swift
@@ -112,6 +112,9 @@ public struct AppView: View {
                     if !store.failedImports.isEmpty {
                         importFailureNotice(imports: store.failedImports, palette: palette)
                     }
+                    if let message = store.startupErrorMessage {
+                        startupFailureNotice(message: message, palette: palette)
+                    }
                 }
             }
             .onChange(of: store.reader?.itemID) { _, itemID in
@@ -183,11 +186,55 @@ public struct AppView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             Spacer(minLength: 8)
+            // The banner stays deliberately bounded — one failure, truncated.
+            // Copy is the escape hatch that yields all of them in full.
+            CopyButton(
+                text: FailedImport.diagnosticReport(from: imports),
+                style: .compact
+            )
             Button("Dismiss") {
                 store.send(.dismissFailedImportsTapped)
             }
             Button("Retry") {
                 store.send(.retryFailedImportsTapped)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.regularMaterial)
+        .overlay(alignment: .top) { Divider() }
+    }
+
+    /// Startup failures were previously invisible: `startupErrorMessage` was
+    /// set on `.startupFailed` and read by no view, while `startupFinished`
+    /// was also set — so a failed bootstrap presented a fully navigable app
+    /// with a silently empty library and no indication anything was wrong.
+    private func startupFailureNotice(
+        message: String,
+        palette: FlexokiPalette
+    ) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(palette.error)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Stower didn't finish starting up.")
+                    .font(.callout.weight(.medium))
+                Text(message)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .lineLimit(3)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            Spacer(minLength: 8)
+            CopyButton(text: message, style: .compact)
+            Button("Dismiss") {
+                store.send(.dismissStartupErrorTapped)
+            }
+            Button("Retry") {
+                store.send(.onAppear)
             }
             .buttonStyle(.borderedProminent)
         }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
@@ -48,15 +48,12 @@ public struct LibraryScreen: View {
                 urlComposer
                     .listRowBackground(Color.clear)
                 if store.saveState == .failed, let error = store.errorMessage {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(palette.error)
+                    CopyableText(text: error, textColor: palette.error)
                         .listRowBackground(Color.clear)
                 }
             }
             if let error = store.errorMessage, store.saveState != .failed {
-                Text(error)
-                    .foregroundStyle(palette.error)
+                CopyableText(text: error, font: .body, textColor: palette.error)
                     .listRowBackground(Color.clear)
             }
             #endif
@@ -132,7 +129,7 @@ public struct LibraryScreen: View {
                             openURL(sourceURL)
                         }
                         Button("Copy Original URL") {
-                            copyToClipboard(sourceURLString)
+                            ClipboardSupport.copy(sourceURLString)
                         }
                     }
                     if store.filter == .recentlyDeleted {
@@ -319,17 +316,6 @@ public struct LibraryScreen: View {
         .task {
             store.send(.onAppear)
         }
-    }
-
-    /// Writes a plain-text string to the system clipboard. Cross-platform
-    /// wrapper around `UIPasteboard` (iOS) and `NSPasteboard` (macOS).
-    private func copyToClipboard(_ value: String) {
-        #if canImport(UIKit)
-        UIPasteboard.general.string = value
-        #elseif canImport(AppKit)
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(value, forType: .string)
-        #endif
     }
 
     private func presentAddURLSheet() {
@@ -594,14 +580,17 @@ public struct LibraryScreen: View {
                     .keyboardType(.URL)
                     .submitLabel(.go)
                     .onSubmit { store.send(.saveURLTapped) }
+                    if store.saveState == .failed, let error = store.errorMessage {
+                        // Deliberately a row, not the section footer: a footer
+                        // renders interactive controls at footnote size outside
+                        // the grouped inset, so the copy button would be almost
+                        // untappable and read as decoration.
+                        CopyableText(text: error, textColor: palette.error)
+                    }
                 } header: {
                     Text("URL")
                 } footer: {
-                    if store.saveState == .failed, let error = store.errorMessage {
-                        Text(error).foregroundStyle(palette.error)
-                    } else {
-                        Text("Paste any article URL. Stower will fetch and archive it for offline reading.")
-                    }
+                    Text("Paste any article URL. Stower will fetch and archive it for offline reading.")
                 }
             }
             .navigationTitle("Add URL")

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAIControls.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderAIControls.swift
@@ -107,10 +107,7 @@ struct ReaderAIControls: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title)
                 .font(.headline)
-            Text(message)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            CopyableText(text: message, font: .subheadline)
             Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -136,6 +133,7 @@ struct ReaderAIControls: View {
                 HStack {
                     summaryFootnote
                     Spacer()
+                    CopyButton(text: store.summaryText, style: .compact)
                     Button {
                         store.send(.summarizeRequested(document: document, plainText: plainText))
                     } label: {
@@ -172,10 +170,7 @@ struct ReaderAIControls: View {
             }
 
             if let error = store.summaryError {
-                Text(error)
-                    .font(.caption)
-                    .foregroundStyle(palette.error)
-                    .fixedSize(horizontal: false, vertical: true)
+                CopyableText(text: error, textColor: palette.error)
             }
         }
     }
@@ -237,10 +232,7 @@ struct ReaderAIControls: View {
             }
 
             if let error = store.askError {
-                Text(error)
-                    .font(.caption)
-                    .foregroundStyle(palette.error)
-                    .fixedSize(horizontal: false, vertical: true)
+                CopyableText(text: error, textColor: palette.error)
             }
 
             HStack(spacing: 8) {
@@ -298,6 +290,14 @@ struct ReaderAIControls: View {
                     .textSelection(.enabled)
                     .foregroundStyle(.primary)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    // A context menu rather than a visible button: a Copy
+                    // control on every bubble is noise in a scrolling
+                    // transcript, and selection already works here.
+                    .contextMenu {
+                        Button("Copy") {
+                            ClipboardSupport.copy(answer)
+                        }
+                    }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderListenControls.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderListenControls.swift
@@ -258,9 +258,7 @@ struct ReaderListenControls: View {
 
     @ViewBuilder private var footerMessages: some View {
         if let error = speech.errorMessage {
-            Text(error)
-                .font(.caption)
-                .foregroundStyle(palette.error)
+            CopyableText(text: error, textColor: palette.error)
         } else if speechBlocks.isEmpty {
             Text("No readable text found.")
                 .font(.caption)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
@@ -418,7 +418,8 @@ public struct ReaderScreen: View {
             ProgressView()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let error = store.errorMessage {
-            Text(error).foregroundStyle(store.appearance.palette.error)
+            CopyableText(text: error, font: .body, textColor: store.appearance.palette.error)
+                .padding()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             Text("Item not found")
@@ -463,7 +464,9 @@ public struct ReaderScreen: View {
             Text(partialCaptureWarning(for: item))
                 .font(.footnote)
                 .foregroundStyle(store.appearance.secondaryTextColor)
+                .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
+            CopyButton(text: partialCaptureWarning(for: item), style: .compact)
             Button("Refresh") {
                 store.send(.retryExtractionTapped)
             }
@@ -606,10 +609,11 @@ public struct ReaderScreen: View {
             }
 
             if let error = store.errorMessage {
-                Text(error)
-                    .font(.footnote)
-                    .foregroundStyle(store.appearance.palette.error)
-                    .fixedSize(horizontal: false, vertical: true)
+                CopyableText(
+                    text: error,
+                    font: .footnote,
+                    textColor: store.appearance.palette.error
+                )
             }
         }
         .padding(20)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsScreen.swift
@@ -19,10 +19,7 @@ public struct SettingsScreen: View {
                 }
 
                 if let detail = syncDetail(store.cloudSyncStatus) {
-                    Text(detail)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    CopyableText(text: detail, font: .caption)
                 }
             }
 
@@ -70,6 +67,16 @@ public struct SettingsScreen: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                         }
                     }
+
+                    // One button producing a full pasteable dump, rather than a
+                    // copy control on every row. The rows stay elided; the
+                    // report carries the untruncated URLs.
+                    CopyButton(
+                        text: SyncDiagnosticsReport.text(
+                            diagnostics: diagnostics,
+                            status: store.cloudSyncStatus
+                        )
+                    )
                 }
             }
 #endif
@@ -103,9 +110,7 @@ public struct SettingsScreen: View {
             }
 
             if let error = store.errorMessage {
-                Text(error)
-                    .foregroundStyle(palette.error)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                CopyableText(text: error, font: .body, textColor: palette.error)
             }
         }
         .formStyle(.grouped)

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ClipboardSupport.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ClipboardSupport.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+/// The single place the app writes to the system clipboard.
+///
+/// Kept as one namespace so a copy affordance can be added anywhere without
+/// each screen growing its own private pasteboard helper — which is how the
+/// only previous copy action ended up locked inside `LibraryScreen`, out of
+/// reach of every error message in the app.
+enum ClipboardSupport {
+    static func copy(_ value: String) {
+        #if canImport(UIKit)
+        UIPasteboard.general.string = value
+        #elseif canImport(AppKit)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
+        #endif
+    }
+}

--- a/StowerPackage/Sources/StowerFeatureV2/Support/CopyableText.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/CopyableText.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+/// A button that copies a string and briefly confirms it did.
+///
+/// Exists as its own type because the banners already own a row of buttons —
+/// dropping a whole `CopyableText` into one of those would nest a second stack
+/// in the label column and put the button in the wrong place. Those sites take
+/// the button alone; everything else takes `CopyableText`.
+struct CopyButton: View {
+    enum Style {
+        case compact
+        case labeled
+    }
+
+    let text: String
+    var style: Style = .labeled
+
+    @State private var didCopy = false
+
+    var body: some View {
+        Button {
+            ClipboardSupport.copy(text)
+            didCopy = true
+            #if canImport(UIKit)
+            AccessibilityNotification.Announcement("Copied").post()
+            #endif
+        } label: {
+            Label(
+                didCopy ? "Copied" : "Copy",
+                systemImage: didCopy ? "checkmark" : "doc.on.doc"
+            )
+        }
+        .modifier(CopyButtonStyle(style: style))
+        .accessibilityLabel(didCopy ? "Copied" : "Copy")
+        // `.task(id:)` rather than a detached `Task`: SwiftUI cancels it when
+        // the view goes away, which matters because the banners this sits in
+        // can be dismissed while the confirmation is still showing.
+        .task(id: didCopy) {
+            guard didCopy else { return }
+            try? await Task.sleep(for: .seconds(2))
+            didCopy = false
+        }
+        .animation(.default, value: didCopy)
+    }
+}
+
+/// Applies the size/prominence treatment for a `CopyButton`.
+///
+/// A modifier rather than a branch in `body` so both cases share one button
+/// identity — branching would rebuild the button on style change and drop the
+/// in-flight "Copied" confirmation.
+private struct CopyButtonStyle: ViewModifier {
+    let style: CopyButton.Style
+
+    func body(content: Content) -> some View {
+        switch style {
+        case .compact:
+            content
+                .labelStyle(.iconOnly)
+                .buttonStyle(.borderless)
+                .font(.caption)
+                .contentShape(.rect)
+        case .labeled:
+            content
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+        }
+    }
+}
+
+/// A diagnostic string the user can select *and* copy.
+///
+/// Every error and diagnostic in the app used to be a plain `Text`: not
+/// selectable, sometimes truncated, and impossible to get out of the app
+/// except by retyping it from a screenshot.
+///
+/// `copyText` is the escape hatch for the sites that must stay visually
+/// bounded — the displayed string can be elided while the copied one stays
+/// whole.
+struct CopyableText: View {
+    enum Layout {
+        case belowText
+        case trailingButton
+    }
+
+    private let text: String
+    private let copyText: String?
+    private let layout: Layout
+    private let font: Font
+    private let textColor: Color?
+    private let lineLimit: Int?
+    private let truncationMode: Text.TruncationMode
+    private let buttonStyle: CopyButton.Style
+
+    init(
+        text: String,
+        copyText: String? = nil,
+        layout: Layout = .belowText,
+        font: Font = .caption,
+        textColor: Color? = nil,
+        lineLimit: Int? = nil,
+        truncationMode: Text.TruncationMode = .tail,
+        buttonStyle: CopyButton.Style = .labeled
+    ) {
+        self.text = text
+        self.copyText = copyText
+        self.layout = layout
+        self.font = font
+        self.textColor = textColor
+        self.lineLimit = lineLimit
+        self.truncationMode = truncationMode
+        self.buttonStyle = buttonStyle
+    }
+
+    /// What actually reaches the clipboard. Always the full string, even when
+    /// the visible one is truncated.
+    var payload: String {
+        copyText ?? text
+    }
+
+    var body: some View {
+        switch layout {
+        case .belowText:
+            VStack(alignment: .leading, spacing: 6) {
+                label
+                CopyButton(text: payload, style: buttonStyle)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        case .trailingButton:
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                label
+                CopyButton(text: payload, style: buttonStyle)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var label: some View {
+        Text(text)
+            .font(font)
+            .foregroundStyle(textColor ?? Color.secondary)
+            .textSelection(.enabled)
+            .lineLimit(lineLimit)
+            .truncationMode(truncationMode)
+            .fixedSize(horizontal: false, vertical: lineLimit == nil)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/StowerPackage/Sources/StowerFeatureV2/Support/FailedImport.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/FailedImport.swift
@@ -14,11 +14,18 @@ public struct FailedImport: Equatable, Identifiable, Sendable {
     public let label: String
     /// Why it gave up, taken from the job's last recorded error.
     public let reason: String?
+    /// The job's payload exactly as recorded — the full URL or path.
+    ///
+    /// `label` is elided for the banner (`displayURL` inserts a literal "…"
+    /// and discards the rest), so it cannot be used to reconstruct what was
+    /// actually being imported. Copying has to reach for this instead.
+    public let rawPayload: String
 
-    public init(id: UUID, label: String, reason: String?) {
+    public init(id: UUID, label: String, reason: String?, rawPayload: String = "") {
         self.id = id
         self.label = label
         self.reason = reason
+        self.rawPayload = rawPayload
     }
 
     public static func list(from jobs: [IngestionJob]) -> [FailedImport] {
@@ -28,8 +35,27 @@ public struct FailedImport: Equatable, Identifiable, Sendable {
     public init(job: IngestionJob) {
         self.id = job.id
         self.label = Self.label(for: job)
+        self.rawPayload = job.payload
         let trimmed = job.lastError?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.reason = (trimmed?.isEmpty ?? true) ? nil : trimmed
+    }
+
+    /// Every failed import as pasteable text.
+    ///
+    /// The banner only ever shows the first failure, truncated to two lines,
+    /// and says "and N more" — so what is on screen is never enough to act on.
+    /// Copying yields all of them, with untruncated payloads.
+    public static func diagnosticReport(from imports: [FailedImport]) -> String {
+        guard !imports.isEmpty else { return "" }
+        let header = imports.count == 1
+            ? "1 Stower import failed"
+            : "\(imports.count) Stower imports failed"
+        let entries = imports.map { entry -> String in
+            let target = entry.rawPayload.isEmpty ? entry.label : entry.rawPayload
+            let reason = entry.reason ?? "No reason recorded."
+            return "• \(target)\n  \(reason)"
+        }
+        return ([header, ""] + entries).joined(separator: "\n")
     }
 
     private static func label(for job: IngestionJob) -> String {

--- a/StowerPackage/Sources/StowerFeatureV2/Support/SyncDiagnosticsReport.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/SyncDiagnosticsReport.swift
@@ -1,0 +1,74 @@
+import Foundation
+import StowerData
+
+/// Renders sync state as pasteable text.
+///
+/// The Sync Diagnostics section shows each figure in its own row and elides the
+/// sample items' URLs to one line, which is fine to read and useless to report:
+/// there is no way to get any of it out of the app. One button producing this
+/// string is worth more than a copy control on every row — and unlike the rows,
+/// it carries the full URLs.
+///
+/// Lives in the feature module rather than `StowerData` so user-facing wording
+/// stays out of the data layer.
+enum SyncDiagnosticsReport {
+    static func text(diagnostics: SyncDiagnostics, status: CloudSyncStatus) -> String {
+        var lines = ["Stower sync diagnostics", ""]
+
+        lines.append("State: \(stateDescription(status.state))")
+        if let detail = stateDetail(status.state) {
+            lines.append("Detail: \(detail)")
+        }
+        lines.append("Last attempt: \(timestamp(status.lastSyncAttempt))")
+        lines.append("Last success: \(timestamp(status.lastSyncSuccess))")
+        lines.append("")
+
+        lines.append("Synced rows: \(diagnostics.syncedItemsCount)")
+        lines.append("Synced tags: \(diagnostics.syncedTagsCount)")
+        lines.append("Synced item-tag links: \(diagnostics.syncedItemTagsCount)")
+        lines.append("Pending changes: \(diagnostics.pendingChangesCount)")
+        lines.append("Metadata rows: \(diagnostics.metadataCount)")
+
+        if !diagnostics.sampleItems.isEmpty {
+            lines.append("")
+            lines.append("Latest synced items:")
+            for item in diagnostics.sampleItems {
+                lines.append("• \(item.title)")
+                if let sourceURL = item.sourceURL, !sourceURL.isEmpty {
+                    lines.append("  \(sourceURL)")
+                }
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static func stateDescription(_ state: CloudSyncStatus.State) -> String {
+        switch state {
+        case .starting:
+            return "Starting"
+        case .available:
+            return "On"
+        case .unavailable:
+            return "Off"
+        case .error:
+            return "Issue"
+        case .needsLocalReset:
+            return "Needs local reset"
+        }
+    }
+
+    private static func stateDetail(_ state: CloudSyncStatus.State) -> String? {
+        switch state {
+        case .starting, .available:
+            return nil
+        case let .unavailable(reason), let .error(reason), let .needsLocalReset(reason):
+            return reason
+        }
+    }
+
+    private static func timestamp(_ date: Date?) -> String {
+        guard let date else { return "never" }
+        return date.formatted(date: .abbreviated, time: .standard)
+    }
+}

--- a/StowerPackage/Sources/StowerFeatureV2/Support/TextAuthoringSheet.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/TextAuthoringSheet.swift
@@ -203,10 +203,7 @@ public struct TextAuthoringSheet: View {
 
     @ViewBuilder private var footer: some View {
         if let errorMessage {
-            Text(errorMessage)
-                .font(.caption)
-                .foregroundStyle(palette.error)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            CopyableText(text: errorMessage, textColor: palette.error)
         } else if previewKind == .markdown {
             Text("Write in markdown, then switch to Preview to inspect the rendered formatting without losing the source.")
                 .font(.caption)

--- a/StowerPackage/Tests/StowerFeatureV2Tests/AppFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/AppFeatureTests.swift
@@ -348,6 +348,39 @@ struct AppFeatureTests {
         #expect(createdItems.value == 0)
         #expect(failures.value == ["Queued URL capture failed."])
     }
+
+    @Test
+    func startupFailureIsVisibleAndDismissible() async {
+        // `startupErrorMessage` used to be set and read by nothing, so a failed
+        // bootstrap presented a navigable app with a silently empty library.
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.startupFailed("App Group container unavailable.")) {
+            $0.startupFinished = true
+            $0.startupErrorMessage = "App Group container unavailable."
+        }
+        await store.send(.dismissStartupErrorTapped) {
+            $0.startupErrorMessage = nil
+        }
+    }
+
+    @Test
+    func aSuccessfulStartupClearsAnEarlierFailure() async {
+        var state = AppFeature.State()
+        state.startupErrorMessage = "Previous failure."
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.startupFinished) {
+            $0.startupFinished = true
+            $0.startupErrorMessage = nil
+        }
+    }
 }
 
 private enum QueuedURLCaptureError: Error, LocalizedError {

--- a/StowerPackage/Tests/StowerFeatureV2Tests/CopyableDiagnosticsTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/CopyableDiagnosticsTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+@testable import StowerData
+@testable import StowerFeature
+import Testing
+
+#if os(macOS)
+import AppKit
+#endif
+
+/// Every error and diagnostic in the app used to be a plain `Text` — not
+/// selectable, sometimes truncated, and impossible to get out of the app except
+/// by retyping it from a screenshot. These tests pin the part of that fix that
+/// is mechanically checkable: what actually reaches the clipboard.
+@Suite
+struct CopyableDiagnosticsTests {
+    // MARK: - Clipboard
+
+    #if os(macOS)
+    @Test
+    func clipboardRoundTrips() {
+        // Only assertable on macOS; UIPasteboard is not reliably readable from
+        // a unit-test process.
+        let value = "CKError Code=2 \"Failed to send changes\""
+        ClipboardSupport.copy(value)
+        #expect(NSPasteboard.general.string(forType: .string) == value)
+    }
+    #endif
+
+    // MARK: - Copy payload is never the truncated string
+
+    @Test
+    func copyableTextCopiesTheFullStringWhenDisplayIsTruncated() {
+        let full = String(repeating: "a very long diagnostic line. ", count: 40)
+        let view = CopyableText(text: full, lineLimit: 2)
+        #expect(view.payload == full)
+    }
+
+    @Test
+    func copyableTextPrefersAnExplicitCopyPayload() {
+        let view = CopyableText(text: "short label", copyText: "the whole story")
+        #expect(view.payload == "the whole story")
+    }
+
+    // MARK: - Failed-import report
+
+    private func failure(_ payload: String, _ reason: String?) -> FailedImport {
+        FailedImport(
+            job: IngestionJob(
+                kind: .url,
+                payload: payload,
+                id: UUID(),
+                createdAt: Date(timeIntervalSince1970: 0),
+                status: .failed,
+                claimedAt: nil,
+                attemptCount: 3,
+                lastError: reason
+            )
+        )
+    }
+
+    @Test
+    func failedImportKeepsTheUntruncatedPayload() {
+        // `label` is elided for the banner with a literal ellipsis, so it
+        // cannot be used to reconstruct what was being imported.
+        let long = "https://example.com/" + String(repeating: "segment/", count: 20) + "end"
+        let entry = failure(long, "The request timed out.")
+        #expect(entry.label.contains("…"))
+        #expect(entry.rawPayload == long)
+    }
+
+    @Test
+    func reportIncludesEveryFailureNotJustTheFirst() {
+        // The banner shows one failure and says "and N more"; copying has to
+        // produce all of them or it is no more useful than the screen.
+        let imports = [
+            failure("https://example.com/one", "Timed out."),
+            failure("https://example.com/two", "Blocked by a bot check."),
+            failure("https://example.com/three", nil),
+        ]
+        let report = FailedImport.diagnosticReport(from: imports)
+
+        #expect(report.contains("3 Stower imports failed"))
+        #expect(report.contains("https://example.com/one"))
+        #expect(report.contains("https://example.com/two"))
+        #expect(report.contains("https://example.com/three"))
+        #expect(report.contains("Blocked by a bot check."))
+        #expect(report.contains("No reason recorded."))
+        #expect(!report.contains("…"))
+    }
+
+    @Test
+    func emptyReportForNoFailures() {
+        #expect(FailedImport.diagnosticReport(from: []).isEmpty)
+    }
+
+    // MARK: - Sync diagnostics report
+
+    @Test
+    func syncReportCarriesFullURLsAndEveryCount() {
+        let longURL = "https://example.com/" + String(repeating: "path/", count: 30) + "article"
+        let diagnostics = SyncDiagnostics(
+            syncedItemsCount: 12,
+            pendingChangesCount: 3,
+            metadataCount: 7,
+            syncedTagsCount: 4,
+            syncedItemTagsCount: 5,
+            sampleItems: [SyncItemSummary(id: UUID(), title: "An article", sourceURL: longURL)]
+        )
+        let status = CloudSyncStatus(state: .error("Cannot create new type in production schema"))
+        let report = SyncDiagnosticsReport.text(diagnostics: diagnostics, status: status)
+
+        #expect(report.contains(longURL))
+        #expect(report.contains("Synced rows: 12"))
+        #expect(report.contains("Synced tags: 4"))
+        #expect(report.contains("Synced item-tag links: 5"))
+        #expect(report.contains("Pending changes: 3"))
+        #expect(report.contains("Metadata rows: 7"))
+        #expect(report.contains("Cannot create new type in production schema"))
+    }
+
+    @Test
+    func syncReportHandlesAHealthyStateWithoutDetail() {
+        let report = SyncDiagnosticsReport.text(
+            diagnostics: SyncDiagnostics(syncedItemsCount: 0, pendingChangesCount: 0, metadataCount: 0),
+            status: CloudSyncStatus(state: .available)
+        )
+        #expect(report.contains("State: On"))
+        #expect(!report.contains("Detail:"))
+        #expect(report.contains("Last success: never"))
+    }
+}
+
+/// The previous clipboard helper was private to one screen, which is why no
+/// error message in the app could be copied. This keeps it consolidated.
+@Suite
+struct ClipboardConsolidationTests {
+    @Test
+    func pasteboardIsUsedOnlyInClipboardSupport() throws {
+        let sources = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/StowerFeatureV2")
+
+        let files = try FileManager.default
+            .subpathsOfDirectory(atPath: sources.path)
+            .filter { $0.hasSuffix(".swift") }
+
+        for relativePath in files where relativePath != "Support/ClipboardSupport.swift" {
+            let contents = try String(
+                contentsOf: sources.appendingPathComponent(relativePath),
+                encoding: .utf8
+            )
+            #expect(
+                !contents.contains("UIPasteboard") && !contents.contains("NSPasteboard"),
+                "Pasteboard use belongs in ClipboardSupport, found in \(relativePath)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
A CloudKit failure renders a long `CKError` dump in Settings → Sync. It was a plain `Text`: not selectable, not copyable, so the only way to get it out of the app was to retype it from a screenshot.

Exploration found that was true of **every** error and diagnostic in the app, several of which are also truncated for layout. There was exactly one piece of clipboard code in the whole package — a `private func copyToClipboard` inside `LibraryScreen`, reachable only from "Copy Original URL".

## What's added

Two pieces in `Support/`:

- **`ClipboardSupport`** — the single place the app writes to the pasteboard.
- **`CopyableText`** (selectable text + Copy button) and **`CopyButton`** (the button alone). Banners already own a row of buttons, so they take the button; everything else takes the pair. Copy always yields the **full** string even where the visible one is elided.

Applied to: the sync status detail and error in Settings, the import-failure banner, the reader's error fallback / download prompt / partial-capture banner, the listen and AI panels, the macOS library rows, the iOS Add-URL sheet, and the shared text-authoring sheet.

## Three things beyond a plain swap

- **Sync Diagnostics gets one Copy** producing a full report, rather than a control on every row. The rows stay elided; the report carries untruncated URLs.
- **`FailedImport` gained `rawPayload`.** Its `label` is elided with a literal `…` that discards the rest, so copying could not have reconstructed what failed. The banner still shows one truncated failure; copying now yields *every* failure in full.
- **The iOS Add-URL error moved out of the `Form` section footer into a row.** A footer renders interactive controls at footnote size outside the grouped inset, so a copy button there would be near-untappable and read as decoration.

## A bug found on the way

`AppFeature.State.startupErrorMessage` was set on `.startupFailed` and **read by no view**, while `.startupFailed` also sets `startupFinished = true` — so a failed bootstrap presented a fully navigable app with a silently empty library and no indication anything was wrong. It's now surfaced as a notice with Copy / Dismiss / Retry.

This is not hypothetical. The moment it shipped, the simulator showed:

> ⚠️ Stower didn't finish starting up. — *Could not determine iCloud account status*

That failure has been happening on every simulator run for this entire work session and was completely invisible.

## Deliberate scope calls

- **AI answer bubbles get a context menu, not a per-bubble button** — a visible Copy on every bubble is noise in a scrolling transcript, and selection already works there.
- **The `needsLocalReset` alert is untouched.** Every `ButtonState` in a SwiftUI alert dismisses it, so a Copy button would look like it cancelled a destructive flow. The same string already appears in Settings → Sync, which this makes copyable.
- **No `View` extension or `ViewModifier`.** The package has zero of either; a modifier that silently inserts a sibling button also changes the caller's layout invisibly.

## Verification

341 tests pass (11 new), SwiftLint strict clean, iOS + macOS builds succeed. New tests cover the clipboard round-trip (macOS), that the copy payload is the untruncated string, that the failure report includes every import with full payloads, that the sync report carries full URLs and all counts, and the startup-error reducer transitions. There's also a source-scanning test — in the style of the existing `CopyPolicyTests` — asserting `UIPasteboard`/`NSPasteboard` appear only in `ClipboardSupport`, so a private clipboard helper can't reappear in a screen file.

**Not verified on screen:** the Mac display was asleep and the iOS Simulator control tool is broken on this Xcode (missing `SimulatorKit.framework`), so I could capture the device framebuffer but not drive the UI. The startup notice above is confirmed rendering live; the Settings copy button, the Form-footer restructure, and macOS layout are compile- and test-verified only. Worth a look before merging, particularly:

1. Settings → Sync with the error present: select the text, press Copy, confirm the **whole** CKError string pastes.
2. That `.textSelection` on the macOS library error rows hasn't affected tap/context-menu behaviour on the adjacent article rows.
3. The new rows against `SettingsScreen`'s `.frame(minWidth: 520)` on macOS.

## Related, not fixed here

The error itself is not an app bug: `savedArticleCaptureSyncTables` and `savedArticleCaptureChunkSyncTables` are registered for sync but have not been deployed to the CloudKit **Production** environment. That's a CloudKit Console action. Until it's done, article capture packages never sync between devices.