### PR TITLE
Stop iOS killing the app for holding a database lock while suspended

### DIFF
--- a/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
+++ b/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
@@ -118,6 +118,20 @@ public enum StowerDatabase {
     public static func makeDatabase() throws -> any DatabaseWriter {
         var configuration = Configuration()
         configuration.foreignKeysEnabled = true
+
+        // The database lives in an App Group container shared with the share
+        // extension. iOS kills a process with `0xDEAD10CC` ("dead lock") if it
+        // still holds a lock on a file in a shared container when it is
+        // suspended — which is exactly what happened in production: a periodic
+        // CloudKit sync kicked off a write transaction in the background and
+        // the app was suspended while it was still open.
+        //
+        // With this flag, the connection observes `Database.suspendNotification`
+        // and stops acquiring new locks, so a pending write fails with
+        // SQLITE_INTERRUPT / SQLITE_ABORT instead of getting the process
+        // killed. `DatabaseSuspensionObserver` posts the notifications, and
+        // `DatabaseError.isSuspended` identifies the resulting errors.
+        configuration.observesSuspensionNotifications = true
         configuration.prepareDatabase { db in
             do {
                 try db.attachMetadatabase(containerIdentifier: cloudKitContainerID)

--- a/StowerPackage/Sources/StowerData/Data/DatabaseSuspension.swift
+++ b/StowerPackage/Sources/StowerData/Data/DatabaseSuspension.swift
@@ -1,0 +1,72 @@
+import Foundation
+import GRDB
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Drives GRDB's database suspension around the app lifecycle.
+///
+/// The database lives in an App Group container shared with the share
+/// extension. iOS terminates a process with `0xDEAD10CC` if it is still
+/// holding a lock on a file in a shared container when it gets suspended.
+/// Setting `Configuration.observesSuspensionNotifications` is only half the
+/// technique — something has to actually post the notifications.
+///
+/// Suspending on background means an in-flight write fails with
+/// `SQLITE_INTERRUPT` or `SQLITE_ABORT` instead of taking the process down.
+/// Callers treat those as "try again once we're back", not as real failures —
+/// see `DatabaseError.isSuspended`.
+///
+/// macOS has no equivalent suspension, so this is a no-op there.
+public enum DatabaseSuspensionObserver {
+    /// Whether this platform suspends processes in a way that triggers
+    /// `0xDEAD10CC`.
+    ///
+    /// iOS and iPadOS do. macOS does not — and suspending there would be
+    /// actively harmful: a Mac app in the background is still expected to run
+    /// its periodic CloudKit sync, and a suspended database would interrupt
+    /// every one of those writes for no benefit.
+    public static var isSupported: Bool {
+        #if os(iOS)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    /// Tells the database to stop acquiring locks. Post before the process is
+    /// suspended — i.e. as the app enters the background.
+    public static func suspend() {
+        guard isSupported else { return }
+        NotificationCenter.default.post(name: Database.suspendNotification, object: nil)
+    }
+
+    /// Lets the database acquire locks again. Post when the app returns to the
+    /// foreground, or before any background-mode work that touches the database.
+    public static func resume() {
+        guard isSupported else { return }
+        NotificationCenter.default.post(name: Database.resumeNotification, object: nil)
+    }
+}
+
+extension DatabaseError {
+    /// Whether this error is the database refusing to work because it has been
+    /// suspended, rather than anything being wrong with the data.
+    ///
+    /// GRDB surfaces suspension as `SQLITE_INTERRUPT` or `SQLITE_ABORT`. Work
+    /// that hits one of these should be left alone to run again after the app
+    /// resumes — retrying immediately would just fail the same way, and
+    /// recording it as a failure would blame the user's data for the app
+    /// being backgrounded.
+    public var isSuspended: Bool {
+        resultCode == .SQLITE_INTERRUPT || resultCode == .SQLITE_ABORT
+    }
+}
+
+extension Error {
+    /// Whether this error was caused by database suspension, at any depth.
+    public var isDatabaseSuspension: Bool {
+        (self as? DatabaseError)?.isSuspended ?? false
+    }
+}

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Jobs.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Jobs.swift
@@ -496,17 +496,42 @@ extension StowerRepository {
             var now
             @Dependency(\.uuid)
             var uuid
-            return try await database.write { db -> Int in
+            // Scan in a read, write only what is missing.
+            //
+            // This used to be one write transaction wrapping two full-table
+            // scans, which meant a write lock on the shared App Group database
+            // was held for as long as the scans took. Periodic CloudKit sync
+            // calls this in the background, so on a large library that lock was
+            // routinely open when iOS suspended the app — the 0xDEAD10CC
+            // termination seen in production. Holding a *read* during the scan
+            // and taking the write only when there is something to insert
+            // shrinks that window to near nothing, and skips it entirely for
+            // the common case where nothing needs hydrating.
+            let pending: [(item: SavedItemSyncTable, url: String)] = try await database.read { db in
                 let synced: [SavedItemSyncTable] = try SavedItemSyncTable
                     .where { !$0.isArchived }
                     .fetchAll(db)
                 let locals: [SavedItemContentLocalTable] = try SavedItemContentLocalTable.fetchAll(db)
                 let localIDs: Set<UUID> = Set(locals.map(\.itemID))
 
+                return synced.compactMap { item in
+                    guard !localIDs.contains(item.id) else { return nil }
+                    guard let url = item.sourceURL, !url.isEmpty else { return nil }
+                    return (item, url)
+                }
+            }
+
+            guard !pending.isEmpty else { return 0 }
+
+            return try await database.write { db -> Int in
                 var enqueued = 0
-                for item in synced {
-                    guard !localIDs.contains(item.id) else { continue }
-                    guard let url = item.sourceURL, !url.isEmpty else { continue }
+                for (item, url) in pending {
+                    // Re-check inside the write: another process (the share
+                    // extension) may have inserted content since the read.
+                    let existing = try SavedItemContentLocalTable
+                        .find(item.id)
+                        .fetchOne(db)
+                    guard existing == nil else { continue }
 
                     try SavedItemContentLocalTable
                         .insert {

--- a/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
@@ -241,6 +241,12 @@ public struct AppFeature {
                             await send(.startupFinished)
                             await send(.library(.reload))
                             await send(.settings(.load))
+                        } catch where error.isDatabaseSuspension {
+                            // Backgrounded mid-startup. Not a failure worth
+                            // reporting — startup re-runs on the next
+                            // activation, and showing "database is suspended"
+                            // would be alarming and useless.
+                            await send(.startupFinished)
                         } catch {
                             await send(.startupFailed(error.localizedDescription))
                         }
@@ -596,6 +602,13 @@ private func processIngestionJobs(
         } catch is CancellationError {
             try? await repository.failIngestionJob(job.id, "Import cancelled.", now())
             throw CancellationError()
+        } catch where error.isDatabaseSuspension {
+            // The app is being backgrounded and the database has stopped
+            // taking locks. Nothing is wrong with this import — stop draining
+            // and let the job be reclaimed on the next run. Recording it as a
+            // failure would blame the user's article for the app being
+            // suspended, and surface "database is suspended" as the reason.
+            return
         } catch {
             // `try?`, not `try`: if recording the failure itself fails, the
             // remaining queued imports must still be drained. Rethrowing here

--- a/StowerPackage/Sources/StowerFeatureV2/ContentView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/ContentView.swift
@@ -15,16 +15,28 @@ public struct ContentView: View {
         AppView(store: store)
             .task { store.send(.onAppear) }
             .onChange(of: scenePhase) { _, newPhase in
-                // When the user returns to Stower after sharing a URL from
-                // Safari (or any other app), the share extension has already
-                // enqueued an ingestion job to the shared App Group database,
-                // but the main app has no other way to discover it. Re-drain
-                // the queue and reload the library whenever the scene becomes
-                // active. `AppFeature` guards against running before startup
-                // has finished, so this is a safe no-op on the very first
-                // activation after launch.
-                if newPhase == .active {
+                switch newPhase {
+                case .background:
+                    // The database is in an App Group container, and iOS kills
+                    // a process with 0xDEAD10CC if it still holds a lock on a
+                    // shared file when suspended. Periodic CloudKit sync writes
+                    // in the background, so this is not hypothetical — it is
+                    // what took the shipped build down. Suspending here turns a
+                    // termination into an interrupted write we can retry.
+                    DatabaseSuspensionObserver.suspend()
+                case .active:
+                    DatabaseSuspensionObserver.resume()
+                    // When the user returns to Stower after sharing a URL from
+                    // Safari (or any other app), the share extension has
+                    // already enqueued an ingestion job to the shared App Group
+                    // database, but the main app has no other way to discover
+                    // it. Re-drain the queue and reload the library whenever
+                    // the scene becomes active.
                     store.send(.sceneDidBecomeActive)
+                case .inactive:
+                    break
+                @unknown default:
+                    break
                 }
             }
     }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/CopyableDiagnosticsTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/CopyableDiagnosticsTests.swift
@@ -11,6 +11,7 @@ import AppKit
 /// selectable, sometimes truncated, and impossible to get out of the app except
 /// by retyping it from a screenshot. These tests pin the part of that fix that
 /// is mechanically checkable: what actually reaches the clipboard.
+@MainActor
 @Suite
 struct CopyableDiagnosticsTests {
     // MARK: - Clipboard

--- a/StowerPackage/Tests/StowerFeatureV2Tests/DatabaseSuspensionTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/DatabaseSuspensionTests.swift
@@ -1,0 +1,160 @@
+import ComposableArchitecture
+import Dependencies
+import Foundation
+import GRDB
+@testable import StowerData
+@testable import StowerFeature
+import Testing
+
+/// The shipped build was terminated by iOS with `0xDEAD10CC` — it still held a
+/// write lock on the App Group database when it was suspended. The crash landed
+/// inside `enqueueHydrationJobsForMissingContent`, called from the periodic
+/// CloudKit sync, which runs in the background.
+///
+/// These cover the parts of the fix that are checkable without backgrounding a
+/// real app.
+@Suite
+struct DatabaseSuspensionTests {
+    // MARK: - Configuration
+
+    @Test
+    func databaseObservesSuspensionNotifications() throws {
+        // Without this the suspend notification does nothing and the process
+        // keeps taking locks right up to the moment iOS kills it.
+        let database = try StowerDatabase.makeDatabase()
+        #expect(database.configuration.observesSuspensionNotifications)
+    }
+
+    @Test
+    func suspensionAppliesOnlyWhereTheOSSuspendsProcesses() {
+        // macOS has no 0xDEAD10CC, and suspending there would interrupt the
+        // periodic background sync a Mac app is expected to keep running.
+        #if os(iOS)
+        #expect(DatabaseSuspensionObserver.isSupported)
+        #else
+        #expect(!DatabaseSuspensionObserver.isSupported)
+        #endif
+    }
+
+    // MARK: - Recognising suspension errors
+
+    @Test
+    func interruptAndAbortAreRecognisedAsSuspension() {
+        #expect(DatabaseError(resultCode: .SQLITE_INTERRUPT).isSuspended)
+        #expect(DatabaseError(resultCode: .SQLITE_ABORT).isSuspended)
+        #expect((DatabaseError(resultCode: .SQLITE_INTERRUPT) as Error).isDatabaseSuspension)
+    }
+
+    @Test
+    func ordinaryDatabaseErrorsAreNotSuspension() {
+        #expect(!DatabaseError(resultCode: .SQLITE_CONSTRAINT).isSuspended)
+        #expect(!DatabaseError(resultCode: .SQLITE_CORRUPT).isSuspended)
+        #expect(!(URLError(.timedOut) as Error).isDatabaseSuspension)
+    }
+
+    // MARK: - Hydration scan no longer holds a write lock to read
+
+    @Test
+    func hydrationScanDoesNoWriteWhenNothingIsMissing() async throws {
+        // The crash was a write transaction wrapping two full-table scans. With
+        // nothing to hydrate there is now no write transaction at all, so the
+        // common background case never takes a write lock.
+        let database = try StowerDatabase.makeDatabase()
+        let repository = StowerRepository.live(database: database, cloudSyncClient: .noop)
+
+        try await withDependencies {
+            $0.date.now = Date(timeIntervalSince1970: 1000)
+            $0.uuid = .incrementing
+        } operation: {
+            let item = try await repository.createItemFromIngestion(
+                .sharedText("An article with local content already present.")
+            )
+            #expect(item.id != UUID(uuidString: "00000000-0000-0000-0000-000000000000"))
+        }
+
+        let enqueued = try await repository.enqueueHydrationJobsForMissingContent()
+        #expect(enqueued == 0)
+    }
+
+    @Test
+    func hydrationScanStillEnqueuesForItemsMissingContent() async throws {
+        let database = try StowerDatabase.makeDatabase()
+        let repository = StowerRepository.live(database: database, cloudSyncClient: .noop)
+        let itemID = UUID()
+
+        // A synced row with a source URL and no local content — what arrives on
+        // a second device via CloudKit.
+        try await database.write { db in
+            try SavedItemSyncTable
+                .insert {
+                    SavedItemSyncTable.Draft(
+                        id: itemID,
+                        title: "Synced from another device",
+                        sourceURL: "https://example.com/article",
+                        createdAt: Date(timeIntervalSince1970: 1000),
+                        updatedAt: Date(timeIntervalSince1970: 1000)
+                    )
+                }
+                .execute(db)
+        }
+
+        let enqueued = try await withDependencies {
+            $0.date.now = Date(timeIntervalSince1970: 2000)
+            $0.uuid = .incrementing
+        } operation: {
+            try await repository.enqueueHydrationJobsForMissingContent()
+        }
+        #expect(enqueued == 1)
+
+        // And it is idempotent — the re-check inside the write stops a second
+        // run from double-inserting.
+        let again = try await withDependencies {
+            $0.date.now = Date(timeIntervalSince1970: 3000)
+            $0.uuid = .incrementing
+        } operation: {
+            try await repository.enqueueHydrationJobsForMissingContent()
+        }
+        #expect(again == 0)
+    }
+}
+
+/// A suspended database must not be reported to the user as a broken import.
+@MainActor
+@Suite
+struct SuspensionDoesNotBecomeUserFacingFailureTests {
+    @Test
+    func suspendedImportIsNotRecordedAsAFailure() async throws {
+        let database = try StowerDatabase.makeDatabase()
+        let repository = StowerRepository.live(database: database, cloudSyncClient: .noop)
+        let now = Date(timeIntervalSince1970: 5000)
+
+        try await withDependencies {
+            $0.date.now = now
+            $0.uuid = .incrementing
+        } operation: {
+            try await repository.enqueueIngestionJob(.url, "https://example.com/post")
+        }
+
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.stowerRepository = repository
+            $0.date.now = now
+            $0.ingestionCoordinator = .init { try await $0() }
+            // The article save fails the way a backgrounded app fails.
+            $0.articleSaveClient.save = { _ in
+                throw DatabaseError(resultCode: .SQLITE_INTERRUPT, message: "Database is suspended")
+            }
+            $0.cloudSyncClient = .noop
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.sceneDidBecomeActive)
+        await store.receive(\.failedImportsLoaded)
+
+        // The job must not be marked failed — nothing is wrong with it.
+        let failures = try await repository.fetchFailedIngestionJobs()
+        #expect(failures.isEmpty)
+        #expect(store.state.failedImports.isEmpty)
+    }
+}


### PR DESCRIPTION
Fixes the TestFlight crash in 0.4.2 (21) on iPhone 17,1 / iOS 27.0.

## What actually happened

```
Exception Type:     EXC_CRASH (SIGKILL)
Termination Reason: RUNNINGBOARD 0xdead10cc
```

`0xDEAD10CC` ("dead lock") is not a code crash — it is iOS **killing** a process that still holds a lock on a file in a *shared* container when it gets suspended. The offending thread:

```
StowerRepository._enqueueHydrationJobsForMissingContent
  → DatabaseWriter.write → Database.inTransaction → sqlite3_step
    → SelectStatement.fetchAll   (StowerRepository+Jobs.swift)
```

Everything lines up:

- The database lives in the **App Group** container shared with the share extension — precisely the file this rule is about.
- That function is called from the **CloudKit sync-completion path**, which runs on a **120-second background timer**. Uptime at the crash was 37 minutes, so this was not launch — it was a periodic sync firing while backgrounded.
- The function held a **write transaction across two full-table scans**, so the lock window scaled with library size.

Not a race, not memory: a foreseeable termination that gets more likely the more articles you have.

## The fix

GRDB documents this exact case (*DatabaseSharing → How to limit the 0xDEAD10CC exception*). All three parts are needed.

**1. `observesSuspensionNotifications` on the shared configuration.** Both the app and the share extension go through `StowerDatabase.makeDatabase()`, so one change covers every writing process. Once suspended, the connection stops acquiring locks and a pending write fails with `SQLITE_INTERRUPT`/`SQLITE_ABORT` instead of the process being killed.

**2. Actually post the notifications.** The flag alone does nothing — GRDB only listens. `DatabaseSuspensionObserver` posts `suspendNotification` when the scene enters `.background` and `resumeNotification` on `.active`.

It is a **no-op on macOS**, deliberately. There is no equivalent termination there, and suspending would interrupt the periodic sync a Mac app is expected to keep running in the background. I wrote the doc comment claiming this before implementing it, then caught the omission — hence the explicit `isSupported` and a test pinning it per platform.

**3. Shrink the transaction the crash was caught in.** The scan now runs in a `read`, and the `write` is taken only when something needs hydrating — which is never, in the steady state. Rows are re-checked inside the write because the share extension can insert between the two.

## Suspension is not a user-facing failure

Without this, being backgrounded mid-import would mark the article **failed** and — thanks to the failure detail added in #40 — surface *"database is suspended"* to the user as the reason. A suspension during startup would likewise report the app as having failed to start. Both are now treated as "stop, try again on the next run".

## Verification

348 tests pass (7 new), SwiftLint strict clean, iOS + macOS builds succeed.

The new tests cover what is checkable without backgrounding a real device: that the constructed database really has the flag set (proving it survives SQLiteData's configuration plumbing), that `SQLITE_INTERRUPT`/`SQLITE_ABORT` are recognised as suspension while ordinary errors are not, that the hydration scan does no write when nothing is missing and is idempotent when something is, that suspension is platform-gated, and — through a `TestStore` — that a suspended import is **not** recorded as a failure.

**Not verifiable here:** the actual termination only reproduces by backgrounding a real device mid-sync. The honest confirmation is that a build with this change survives the same usage that produced the report. Worth running on your phone for a day before shipping.

## Two notes

- `observesSuspensionNotifications` is marked 🔥 EXPERIMENTAL by GRDB. It is nonetheless the documented remedy, and the failure mode without it is a hard kill.
- I did **not** commit `testflight_feedback/` — `feedback.json` contains your email address.