### PR TITLE
Reclaim redundant storage and add a Settings storage section

### DIFF
--- a/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
+++ b/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
@@ -267,6 +267,9 @@ public enum StowerDatabase {
         migrator.registerMigration("add-versioned-web-article-captures") { db in
             try migration_v16(db)
         }
+        migrator.registerMigration("add-orphan-candidate-quarantine") { db in
+            try migration_v17(db)
+        }
         try migrator.migrate(database)
     }
 
@@ -770,6 +773,21 @@ public enum StowerDatabase {
         try db.execute(sql: #"CREATE INDEX IF NOT EXISTS "idx_savedArticleCaptureChunkSyncTables_itemID" ON "savedArticleCaptureChunkSyncTables"("itemID")"#)
     }
 
+    /// Schema-only: quarantine bookkeeping for the orphaned-sync-row sweep in
+    /// `StorageMaintenanceClient`. All destructive cleanup runs at maintenance
+    /// time, never inside a migration, so it can be gated on sync health and
+    /// re-run safely.
+    private static func migration_v17(_ db: Database) throws {
+        try db.execute(sql: """
+            CREATE TABLE IF NOT EXISTS "orphanCandidateLocalTables" (
+              "key" TEXT PRIMARY KEY NOT NULL,
+              "tableName" TEXT NOT NULL,
+              "orphanID" TEXT NOT NULL,
+              "firstSeenAt" TEXT NOT NULL
+            ) STRICT
+            """)
+    }
+
     private static func migration_v10(_ db: Database) throws {
         do {
             try db.execute(sql: #"ALTER TABLE "savedItemContentLocalTables" ADD COLUMN "rawSourceText" TEXT NOT NULL DEFAULT ''"#)
@@ -836,6 +854,7 @@ extension DependencyValues {
         syncDiagnosticsClient = SyncDiagnosticsClient(
             load: StowerDatabase.makeDiagnosticsLoad(database: database)
         )
+        storageMaintenanceClient = .live(database: database)
         stowerRepository = .live(database: database, cloudSyncClient: cloudSyncClient)
     }
 }

--- a/StowerPackage/Sources/StowerData/Data/StorageMaintenanceClient.swift
+++ b/StowerPackage/Sources/StowerData/Data/StorageMaintenanceClient.swift
@@ -1,0 +1,286 @@
+import Dependencies
+import Foundation
+import OSLog
+import SQLiteData
+
+private let kMaintenanceLogger = Logger(subsystem: "com.ryanleewilliams.stower", category: "StorageMaintenance")
+
+/// Size and fragmentation statistics for the main database file.
+public struct DatabaseStorageStats: Equatable, Sendable {
+    public var pageCount: Int
+    public var pageSize: Int
+    public var freelistCount: Int
+    public var walBytes: Int
+
+    /// Bytes occupied by the main database file.
+    public var fileBytes: Int { pageCount * pageSize }
+    /// Bytes held by free pages that only a VACUUM can return to the system.
+    public var reclaimableBytes: Int { freelistCount * pageSize }
+
+    public init(pageCount: Int = 0, pageSize: Int = 0, freelistCount: Int = 0, walBytes: Int = 0) {
+        self.pageCount = pageCount
+        self.pageSize = pageSize
+        self.freelistCount = freelistCount
+        self.walBytes = walBytes
+    }
+}
+
+/// Database-side storage maintenance: orphaned sync-row cleanup, dead blob
+/// removal, size statistics, and space reclamation. File-system sweeps live in
+/// `StorageUsageClient` (StowerFeature); this client owns everything that
+/// touches `stower.sqlite`.
+public struct StorageMaintenanceClient: Sendable {
+    /// Current size/fragmentation stats for the database file.
+    public var databaseStats: @Sendable () async throws -> DatabaseStorageStats
+    /// Deletes rows from the legacy `savedImageAssetLocalTables` blob store,
+    /// which nothing has written or read for several schema versions.
+    /// Returns the number of rows removed.
+    public var clearDeadImageAssetBlobs: @Sendable () async throws -> Int
+    /// Two-pass quarantine sweep of content sync rows whose item is gone.
+    /// Returns the number of rows deleted this pass. Callers must only invoke
+    /// this while CloudKit sync is healthy — see the quarantine rationale on
+    /// `OrphanCandidateLocalTable`.
+    public var sweepOrphanedSyncRows: @Sendable () async throws -> Int
+    /// Absolute payload paths of ingestion jobs that may still be retried.
+    /// The staging-directory sweeper must never delete these.
+    public var activeJobPayloadPaths: @Sendable () async throws -> Set<String>
+    /// Truncating WAL checkpoint.
+    public var checkpoint: @Sendable () async throws -> Void
+    /// Full VACUUM. Throws `StorageMaintenanceError.insufficientDiskSpace`
+    /// when the volume lacks room for the rebuilt copy. Callers are
+    /// responsible for only invoking this while the app is in the foreground —
+    /// VACUUM holds an exclusive lock on the shared App Group file, which is
+    /// fatal (0xDEAD10CC) if the process is suspended mid-run.
+    public var vacuum: @Sendable () async throws -> Void
+
+    public init(
+        databaseStats: @escaping @Sendable () async throws -> DatabaseStorageStats,
+        clearDeadImageAssetBlobs: @escaping @Sendable () async throws -> Int,
+        sweepOrphanedSyncRows: @escaping @Sendable () async throws -> Int,
+        activeJobPayloadPaths: @escaping @Sendable () async throws -> Set<String>,
+        checkpoint: @escaping @Sendable () async throws -> Void,
+        vacuum: @escaping @Sendable () async throws -> Void
+    ) {
+        self.databaseStats = databaseStats
+        self.clearDeadImageAssetBlobs = clearDeadImageAssetBlobs
+        self.sweepOrphanedSyncRows = sweepOrphanedSyncRows
+        self.activeJobPayloadPaths = activeJobPayloadPaths
+        self.checkpoint = checkpoint
+        self.vacuum = vacuum
+    }
+
+    public static let noop = Self(
+        databaseStats: { DatabaseStorageStats() },
+        clearDeadImageAssetBlobs: { 0 },
+        sweepOrphanedSyncRows: { 0 },
+        activeJobPayloadPaths: { [] },
+        checkpoint: {},
+        vacuum: {}
+    )
+}
+
+public enum StorageMaintenanceError: Error, Equatable, Sendable {
+    /// VACUUM needs roughly a full copy of the database; the volume didn't
+    /// have it. Carries (requiredBytes, availableBytes).
+    case insufficientDiskSpace(required: Int, available: Int)
+}
+
+extension StorageMaintenanceClient {
+    /// Rows quarantined less recently than this are eligible for deletion.
+    public static let orphanQuarantineInterval: TimeInterval = 7 * 24 * 3600
+
+    public static func live(database: any DatabaseWriter) -> Self {
+        Self(
+            databaseStats: {
+                var stats = try await database.read { db in
+                    DatabaseStorageStats(
+                        pageCount: try Int.fetchOne(db, sql: "PRAGMA page_count") ?? 0,
+                        pageSize: try Int.fetchOne(db, sql: "PRAGMA page_size") ?? 0,
+                        freelistCount: try Int.fetchOne(db, sql: "PRAGMA freelist_count") ?? 0
+                    )
+                }
+                let walPath = database.path + "-wal"
+                if let size = try? FileManager.default
+                    .attributesOfItem(atPath: walPath)[.size] as? Int {
+                    stats.walBytes = size
+                }
+                return stats
+            },
+            clearDeadImageAssetBlobs: {
+                try await database.write { db in
+                    let count = try SavedImageAssetLocalTable.fetchCount(db)
+                    guard count > 0 else { return 0 }
+                    try SavedImageAssetLocalTable.delete().execute(db)
+                    return count
+                }
+            },
+            sweepOrphanedSyncRows: {
+                @Dependency(\.date.now)
+                var now
+                let deleted = try await database.write { db in
+                    try _sweepOrphanedSyncRows(db, now: now)
+                }
+                if deleted > 0 {
+                    kMaintenanceLogger.info("Orphan sweep deleted \(deleted) sync rows")
+                }
+                return deleted
+            },
+            activeJobPayloadPaths: {
+                try await database.read { db in
+                    let payloads = try IngestionJobLocalTable
+                        .where { $0.kind.in(["pdf", "website"]) }
+                        .where { $0.status.in(["queued", "claimed", "failed"]) }
+                        .select(\.payload)
+                        .fetchAll(db)
+                    return Set(payloads)
+                }
+            },
+            checkpoint: {
+                try await database.writeWithoutTransaction { db in
+                    try db.checkpoint(.truncate)
+                }
+            },
+            vacuum: {
+                let stats = try await database.read { db in
+                    DatabaseStorageStats(
+                        pageCount: try Int.fetchOne(db, sql: "PRAGMA page_count") ?? 0,
+                        pageSize: try Int.fetchOne(db, sql: "PRAGMA page_size") ?? 0
+                    )
+                }
+                let required = Int(Double(stats.fileBytes) * 1.2)
+                let available = availableDiskCapacity(forPath: database.path)
+                if let available, available < required {
+                    throw StorageMaintenanceError.insufficientDiskSpace(
+                        required: required,
+                        available: available
+                    )
+                }
+                // VACUUM cannot run inside a transaction, and the barrier
+                // keeps concurrent readers from observing the rebuild.
+                try await database.barrierWriteWithoutTransaction { db in
+                    try db.execute(sql: "VACUUM")
+                }
+            }
+        )
+    }
+
+    private static func availableDiskCapacity(forPath path: String) -> Int? {
+        let url = URL(fileURLWithPath: path).deletingLastPathComponent()
+        let values = try? url.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        return values?.volumeAvailableCapacityForImportantUsage.map(Int.init)
+    }
+
+    /// One quarantine pass. Split out so tests can drive it with a fixed
+    /// clock through `withDependencies`.
+    static func _sweepOrphanedSyncRows(_ db: Database, now: Date) throws -> Int {
+        let liveItemIDs = Set(try SavedItemSyncTable.select(\.id).fetchAll(db))
+        let cutoff = now.addingTimeInterval(-orphanQuarantineInterval)
+        var deletedRows = 0
+
+        func sweep(
+            tableName: String,
+            currentOrphanIDs: Set<UUID>,
+            deleteRows: (_ ripeIDs: [UUID]) throws -> Int
+        ) throws {
+            // Release candidates that are no longer orphaned (their item row
+            // arrived after they were quarantined).
+            let candidates = try OrphanCandidateLocalTable
+                .where { $0.tableName.eq(tableName) }
+                .fetchAll(db)
+            let healedKeys = candidates
+                .filter { !currentOrphanIDs.contains($0.orphanID) }
+                .map(\.key)
+            if !healedKeys.isEmpty {
+                try OrphanCandidateLocalTable
+                    .where { $0.key.in(healedKeys) }
+                    .delete()
+                    .execute(db)
+            }
+
+            // Quarantine newly discovered orphans.
+            let known = Set(candidates.map(\.orphanID))
+            let fresh = currentOrphanIDs.subtracting(known)
+            for orphanID in fresh {
+                try OrphanCandidateLocalTable.insert {
+                    OrphanCandidateLocalTable(
+                        key: OrphanCandidateLocalTable.makeKey(tableName: tableName, orphanID: orphanID),
+                        tableName: tableName,
+                        orphanID: orphanID,
+                        firstSeenAt: now
+                    )
+                }
+                .execute(db)
+            }
+
+            // Delete rows that have been continuously orphaned for the full
+            // quarantine window.
+            let ripeIDs = candidates
+                .filter { currentOrphanIDs.contains($0.orphanID) && $0.firstSeenAt <= cutoff }
+                .map(\.orphanID)
+            guard !ripeIDs.isEmpty else { return }
+            deletedRows += try deleteRows(ripeIDs)
+            let ripeKeys = ripeIDs.map {
+                OrphanCandidateLocalTable.makeKey(tableName: tableName, orphanID: $0)
+            }
+            try OrphanCandidateLocalTable
+                .where { $0.key.in(ripeKeys) }
+                .delete()
+                .execute(db)
+        }
+
+        try sweep(
+            tableName: SavedWebsiteArchiveSyncTable.tableName,
+            currentOrphanIDs: Set(try SavedWebsiteArchiveSyncTable.select(\.id).fetchAll(db))
+                .subtracting(liveItemIDs)
+        ) { ripe in
+            let count = try SavedWebsiteArchiveSyncTable.where { $0.id.in(ripe) }.fetchCount(db)
+            try SavedWebsiteArchiveSyncTable.where { $0.id.in(ripe) }.delete().execute(db)
+            return count
+        }
+        try sweep(
+            tableName: SavedPDFContentSyncTable.tableName,
+            currentOrphanIDs: Set(try SavedPDFContentSyncTable.select(\.id).fetchAll(db))
+                .subtracting(liveItemIDs)
+        ) { ripe in
+            let count = try SavedPDFContentSyncTable.where { $0.id.in(ripe) }.fetchCount(db)
+            try SavedPDFContentSyncTable.where { $0.id.in(ripe) }.delete().execute(db)
+            return count
+        }
+        try sweep(
+            tableName: SavedTextContentSyncTable.tableName,
+            currentOrphanIDs: Set(try SavedTextContentSyncTable.select(\.id).fetchAll(db))
+                .subtracting(liveItemIDs)
+        ) { ripe in
+            let count = try SavedTextContentSyncTable.where { $0.id.in(ripe) }.fetchCount(db)
+            try SavedTextContentSyncTable.where { $0.id.in(ripe) }.delete().execute(db)
+            return count
+        }
+        try sweep(
+            tableName: SavedArticleCaptureSyncTable.tableName,
+            currentOrphanIDs: Set(try SavedArticleCaptureSyncTable.select(\.itemID).fetchAll(db))
+                .subtracting(liveItemIDs)
+        ) { ripe in
+            let manifests = try SavedArticleCaptureSyncTable.where { $0.itemID.in(ripe) }.fetchCount(db)
+            let chunks = try SavedArticleCaptureChunkSyncTable.where { $0.itemID.in(ripe) }.fetchCount(db)
+            try SavedArticleCaptureChunkSyncTable.where { $0.itemID.in(ripe) }.delete().execute(db)
+            try SavedArticleCaptureSyncTable.where { $0.itemID.in(ripe) }.delete().execute(db)
+            return manifests + chunks
+        }
+
+        return deletedRows
+    }
+}
+
+// MARK: - Dependency Key
+
+private enum StorageMaintenanceClientKey: DependencyKey {
+    static let liveValue: StorageMaintenanceClient = .noop
+    static let testValue: StorageMaintenanceClient = .noop
+}
+
+extension DependencyValues {
+    public var storageMaintenanceClient: StorageMaintenanceClient {
+        get { self[StorageMaintenanceClientKey.self] }
+        set { self[StorageMaintenanceClientKey.self] = newValue }
+    }
+}

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Filters.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Filters.swift
@@ -191,6 +191,13 @@ extension StowerRepository {
                 try ItemTagSyncTable.where { $0.itemID.eq(id) }.delete().execute(db)
                 try SavedArticleCaptureChunkSyncTable.where { $0.itemID.eq(id) }.delete().execute(db)
                 try SavedArticleCaptureSyncTable.where { $0.itemID.eq(id) }.delete().execute(db)
+                // Content sync tables key their `id` on the item's ID and have no
+                // foreign keys, so they must be deleted explicitly or their rows
+                // (including multi-hundred-MB website zips) outlive the item in
+                // both the local database and CloudKit.
+                try SavedWebsiteArchiveSyncTable.find(id).delete().execute(db)
+                try SavedPDFContentSyncTable.find(id).delete().execute(db)
+                try SavedTextContentSyncTable.find(id).delete().execute(db)
                 try SavedItemSyncTable.find(id).delete().execute(db)
             }
             scheduleSync()
@@ -218,6 +225,11 @@ extension StowerRepository {
                     try ItemTagSyncTable.where { $0.itemID.in(ids) }.delete().execute(db)
                     try SavedArticleCaptureChunkSyncTable.where { $0.itemID.in(ids) }.delete().execute(db)
                     try SavedArticleCaptureSyncTable.where { $0.itemID.in(ids) }.delete().execute(db)
+                    // See _permanentlyDelete: content sync tables have no foreign
+                    // keys and must be cleared explicitly to avoid orphaned blobs.
+                    try SavedWebsiteArchiveSyncTable.where { $0.id.in(ids) }.delete().execute(db)
+                    try SavedPDFContentSyncTable.where { $0.id.in(ids) }.delete().execute(db)
+                    try SavedTextContentSyncTable.where { $0.id.in(ids) }.delete().execute(db)
                     try SavedItemSyncTable.where { $0.id.in(ids) }.delete().execute(db)
                 }
                 return ids

--- a/StowerPackage/Sources/StowerData/Data/Tables.swift
+++ b/StowerPackage/Sources/StowerData/Data/Tables.swift
@@ -275,3 +275,25 @@ nonisolated public struct IngestionJobLocalTable: Hashable, Identifiable, Sendab
     public var attemptCount: Int = 0
     public var lastError: String?
 }
+
+/// Local-only quarantine for content sync rows whose item row is missing.
+/// During initial CloudKit sync, content rows can arrive before their
+/// `SavedItemSyncTable` row, so an immediate delete would destroy the master
+/// copy of a perfectly live item. Rows sit here until they have been orphaned
+/// continuously for the quarantine window, and are released the moment the
+/// matching item row appears.
+@Table
+nonisolated public struct OrphanCandidateLocalTable: Hashable, Identifiable, Sendable {
+    /// `"{tableName}:{orphanID}"` — one candidate per (table, row) pair.
+    @Column(primaryKey: true)
+    public let key: String
+    public var tableName: String = ""
+    public var orphanID: UUID
+    public var firstSeenAt: Date = .now
+
+    public var id: String { key }
+
+    public static func makeKey(tableName: String, orphanID: UUID) -> String {
+        "\(tableName):\(orphanID.uuidString)"
+    }
+}

--- a/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
@@ -149,6 +149,8 @@ public struct AppFeature {
     var date
     @Dependency(\.ingestionCoordinator)
     var ingestionCoordinator
+    @Dependency(\.storageUsageClient)
+    var storageUsageClient
     @Dependency(\.context)
     var context
 
@@ -176,6 +178,7 @@ public struct AppFeature {
                 let textIngestionClient = self.textIngestionClient
                 let date = self.date
                 let ingestionCoordinator = self.ingestionCoordinator
+                let storageUsageClient = self.storageUsageClient
                 let clock = self.clock
                 let periodicSync: EffectOf<Self> =
                     context == .live
@@ -241,6 +244,21 @@ public struct AppFeature {
                             await send(.startupFinished)
                             await send(.library(.reload))
                             await send(.settings(.load))
+                            // Storage maintenance runs last so it never delays
+                            // startup, and only every few days. Sweeps are
+                            // age-gated and the orphan sweep quarantines for a
+                            // week before deleting, so running shortly after a
+                            // fresh install is safe.
+                            let defaults = UserDefaults.standard
+                            let lastMaintenance = defaults.object(
+                                forKey: "lastStorageMaintenanceDate"
+                            ) as? Date
+                            let isDue = lastMaintenance
+                                .map { date.now.timeIntervalSince($0) >= 3 * 24 * 3600 } ?? true
+                            if isDue {
+                                _ = try? await storageUsageClient.runMaintenance(.periodic)
+                                defaults.set(date.now, forKey: "lastStorageMaintenanceDate")
+                            }
                         } catch where error.isDatabaseSuspension {
                             // Backgrounded mid-startup. Not a failure worth
                             // reporting — startup re-runs on the next

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsFeature.swift
@@ -62,6 +62,7 @@ public struct SettingsFeature {
         public var cloudSyncStatus: CloudSyncStatus = .starting
         public var diagnostics: SyncDiagnostics?
         public var reextraction: LibraryReextractionState = .idle
+        public var storage = StorageFeature.State()
 
         public init() {}
     }
@@ -85,6 +86,8 @@ public struct SettingsFeature {
         case reextractItemFinished(title: String?, succeeded: Bool)
         case reextractCompleted(wasCancelled: Bool)
         case reextractDismissed
+
+        case storage(StorageFeature.Action)
     }
 
     @Dependency(\.stowerRepository)
@@ -97,8 +100,14 @@ public struct SettingsFeature {
     var ingestionCoordinator
 
     public var body: some ReducerOf<Self> {
+        Scope(state: \.storage, action: \.storage) {
+            StorageFeature()
+        }
         Reduce { state, action in
             switch action {
+            case .storage:
+                return .none
+
             case .load:
                 let repository = self.repository
                 return .run { send in

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Settings/SettingsScreen.swift
@@ -109,6 +109,10 @@ public struct SettingsScreen: View {
                 )
             }
 
+            StorageSectionView(
+                store: store.scope(state: \.storage, action: \.storage)
+            )
+
             if let error = store.errorMessage {
                 CopyableText(text: error, font: .body, textColor: palette.error)
             }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Settings/StorageFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Settings/StorageFeature.swift
@@ -1,0 +1,112 @@
+import ComposableArchitecture
+import Foundation
+
+/// The Settings → Storage section: usage breakdown plus the user-triggered
+/// "Reclaim Space" maintenance pass. Snapshots are computed lazily when the
+/// section appears — a full scan walks every archive directory, so it must
+/// never run at app launch.
+@Reducer
+public struct StorageFeature {
+    public init() {}
+
+    public enum MaintenanceState: Equatable, Sendable {
+        case idle
+        case running
+        case finished(MaintenanceReport)
+        case failed(String)
+
+        public var isRunning: Bool { self == .running }
+    }
+
+    @ObservableState
+    public struct State: Equatable {
+        public var snapshot: StorageSnapshot?
+        public var isComputing = false
+        public var maintenance: MaintenanceState = .idle
+        public var errorMessage: String?
+
+        public init() {}
+    }
+
+    public enum Action: Equatable {
+        case task
+        case refresh
+        case snapshotLoaded(StorageSnapshot)
+        case snapshotFailed(String)
+        case reclaimTapped
+        case maintenanceFinished(MaintenanceReport)
+        case maintenanceFailed(String)
+    }
+
+    @Dependency(\.storageUsageClient)
+    var storageUsageClient
+
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .task:
+                guard !state.isComputing else { return .none }
+                state.isComputing = true
+                return loadSnapshot(force: false)
+
+            case .refresh:
+                guard !state.isComputing else { return .none }
+                state.isComputing = true
+                return loadSnapshot(force: true)
+
+            case .snapshotLoaded(let snapshot):
+                state.isComputing = false
+                state.snapshot = snapshot
+                state.errorMessage = nil
+                return .none
+
+            case .snapshotFailed(let message):
+                state.isComputing = false
+                state.errorMessage = message
+                return .none
+
+            case .reclaimTapped:
+                guard !state.maintenance.isRunning else { return .none }
+                state.maintenance = .running
+                state.errorMessage = nil
+                let client = self.storageUsageClient
+                return .run { send in
+                    do {
+                        let report = try await client.runMaintenance(.userReclaim)
+                        await send(.maintenanceFinished(report))
+                    } catch {
+                        await send(.maintenanceFailed(error.localizedDescription))
+                    }
+                }
+                .cancellable(id: CancelID.maintenance, cancelInFlight: true)
+
+            case .maintenanceFinished(let report):
+                state.maintenance = .finished(report)
+                state.isComputing = true
+                return loadSnapshot(force: true)
+
+            case .maintenanceFailed(let message):
+                state.maintenance = .failed(message)
+                return .none
+            }
+        }
+    }
+
+    private func loadSnapshot(force: Bool) -> EffectOf<Self> {
+        let client = self.storageUsageClient
+        return .run { send in
+            do {
+                let snapshot = try await client.computeSnapshot(force)
+                await send(.snapshotLoaded(snapshot))
+            } catch {
+                await send(.snapshotFailed(error.localizedDescription))
+            }
+        }
+        .cancellable(id: CancelID.snapshot, cancelInFlight: true)
+    }
+
+    enum CancelID {
+        case snapshot
+        case maintenance
+    }
+}

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Settings/StorageSectionView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Settings/StorageSectionView.swift
@@ -1,0 +1,141 @@
+import ComposableArchitecture
+import SwiftUI
+
+/// The Settings → Storage section. Rendered inside `SettingsScreen`'s `Form`,
+/// so it emits `Section`s rather than owning a container.
+struct StorageSectionView: View {
+    let store: StoreOf<StorageFeature>
+    @Environment(\.flexokiPalette)
+    private var palette
+
+    var body: some View {
+        Section {
+            if let snapshot = store.snapshot {
+                LabeledContent("Total") {
+                    Text(Self.format(snapshot.totalBytes))
+                        .foregroundStyle(.secondary)
+                }
+                breakdownRows(snapshot)
+                if !snapshot.largestItems.isEmpty {
+                    DisclosureGroup("Largest Items") {
+                        ForEach(snapshot.largestItems) { item in
+                            LabeledContent {
+                                Text(Self.format(item.bytes))
+                                    .foregroundStyle(.secondary)
+                            } label: {
+                                Text(item.title)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                            }
+                        }
+                    }
+                }
+            } else if store.isComputing {
+                ProgressView {
+                    Text("Measuring…")
+                        .font(.callout)
+                }
+            }
+
+            reclaimRows
+
+            if let error = store.errorMessage {
+                CopyableText(text: error, font: .caption, textColor: palette.error)
+            }
+        } header: {
+            Text("Storage")
+        } footer: {
+            Text(
+                """
+                Reclaiming space removes leftover temporary files, cleans up \
+                data from deleted items, and compacts the database. Your saved \
+                items are not affected.
+                """
+            )
+        }
+        .task {
+            store.send(.task)
+        }
+    }
+
+    @ViewBuilder
+    private func breakdownRows(_ snapshot: StorageSnapshot) -> some View {
+        LabeledContent("Database") {
+            Text(Self.format(snapshot.databaseFileBytes + snapshot.databaseWALBytes))
+                .foregroundStyle(.secondary)
+        }
+        LabeledContent("Saved Items") {
+            Text(Self.format(snapshot.archiveBytes))
+                .foregroundStyle(.secondary)
+        }
+        if snapshot.imagesBytes > 0 {
+            LabeledContent("Images") {
+                Text(Self.format(snapshot.imagesBytes))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        if snapshot.cachesBytes > 0 {
+            LabeledContent("Caches") {
+                Text(Self.format(snapshot.cachesBytes))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        if snapshot.pendingBytes > 0 {
+            LabeledContent("Pending Imports") {
+                Text(Self.format(snapshot.pendingBytes))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        if snapshot.legacyDatabaseBytes > 0 {
+            LabeledContent("Old Database Copy") {
+                Text(Self.format(snapshot.legacyDatabaseBytes))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        if snapshot.databaseReclaimableBytes > 0 {
+            LabeledContent("Reclaimable") {
+                Text(Self.format(snapshot.databaseReclaimableBytes))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder private var reclaimRows: some View {
+        switch store.maintenance {
+        case .idle:
+            Button("Reclaim Space") {
+                store.send(.reclaimTapped)
+            }
+
+        case .running:
+            ProgressView {
+                Text("Reclaiming space…")
+                    .font(.callout)
+            }
+
+        case .finished(let report):
+            VStack(alignment: .leading, spacing: 4) {
+                Text(
+                    report.freedBytes > 0
+                        ? "Freed \(Self.format(report.freedBytes))."
+                        : "Nothing to reclaim."
+                )
+                .font(.callout)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            Button("Reclaim Again") {
+                store.send(.reclaimTapped)
+            }
+
+        case .failed(let message):
+            CopyableText(text: message, font: .caption, textColor: palette.error)
+            Button("Try Again") {
+                store.send(.reclaimTapped)
+            }
+        }
+    }
+
+    private static func format(_ bytes: Int) -> String {
+        ByteCountFormatStyle(style: .file).format(Int64(bytes))
+    }
+}

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ArticleCapturePackage.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ArticleCapturePackage.swift
@@ -30,6 +30,7 @@ enum ArticleCapturePackage {
     static let documentFilename = "document.json"
     static let plainTextFilename = "plain.txt"
     static let installedPackageFilename = "capture.zip"
+    static let captureDirectoryName = "web-capture-v1"
 
     static func stage(
         captureID: UUID,
@@ -139,10 +140,9 @@ enum ArticleCapturePackage {
         guard metadata.captureID == expectedCaptureID, metadata.version == captureVersion else {
             throw ArticleCapturePackageError.wrongCapture
         }
-        try packageData.write(
-            to: extractedDirectory.appendingPathComponent(installedPackageFilename),
-            options: .atomic
-        )
+        // The package zip is deliberately NOT copied into the installed
+        // directory: its bytes already live in the synced capture chunk rows,
+        // so an on-disk copy would store every article a third time.
 
         try fileManager.createDirectory(at: itemDirectory, withIntermediateDirectories: true)
         if fileManager.fileExists(atPath: destination.path) {
@@ -201,7 +201,7 @@ enum ArticleCapturePackage {
 
     static func captureDirectory(for itemID: UUID) -> URL {
         AssetArchiver.archiveDirectory(for: itemID)
-            .appendingPathComponent("web-capture-v1", isDirectory: true)
+            .appendingPathComponent(captureDirectoryName, isDirectory: true)
     }
 
     static func archiveURL(for itemID: UUID, original: Bool) -> URL? {

--- a/StowerPackage/Sources/StowerFeatureV2/Support/StorageUsageClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/StorageUsageClient.swift
@@ -1,0 +1,487 @@
+import Dependencies
+import Foundation
+import OSLog
+import StowerData
+
+private let kStorageLogger = Logger(subsystem: "com.ryanleewilliams.stower", category: "StorageUsage")
+
+// MARK: - Value types
+
+public struct ItemStorageSize: Equatable, Sendable, Identifiable {
+    public var id: UUID
+    public var title: String
+    public var bytes: Int
+
+    public init(id: UUID, title: String, bytes: Int) {
+        self.id = id
+        self.title = title
+        self.bytes = bytes
+    }
+}
+
+/// A point-in-time accounting of everything Stower keeps on disk.
+public struct StorageSnapshot: Equatable, Sendable {
+    public var databaseFileBytes: Int = 0
+    public var databaseWALBytes: Int = 0
+    /// Free pages inside the database file that only a VACUUM returns.
+    public var databaseReclaimableBytes: Int = 0
+    /// `Documents/StowerArchive` — installed article/website/PDF archives.
+    public var archiveBytes: Int = 0
+    /// `Documents/StowerImages` — persistent downloaded images.
+    public var imagesBytes: Int = 0
+    /// Self-evicting URLCache under `Library/Caches`.
+    public var cachesBytes: Int = 0
+    /// Staged share-extension imports in the App Group container.
+    public var pendingBytes: Int = 0
+    /// Pre-App-Group database copy left in Application Support.
+    public var legacyDatabaseBytes: Int = 0
+    /// Largest per-item archive directories, descending.
+    public var largestItems = [ItemStorageSize]()
+    public var computedAt: Date = .distantPast
+
+    public var totalBytes: Int {
+        databaseFileBytes + databaseWALBytes + archiveBytes + imagesBytes
+            + cachesBytes + pendingBytes + legacyDatabaseBytes
+    }
+
+    public init() {}
+}
+
+public struct MaintenanceReport: Equatable, Sendable {
+    public var freedBytes: Int = 0
+    public var steps = [String]()
+
+    public init(freedBytes: Int = 0, steps: [String] = []) {
+        self.freedBytes = freedBytes
+        self.steps = steps
+    }
+}
+
+public enum MaintenanceTrigger: Equatable, Sendable {
+    /// Launch-time housekeeping: conservative, only vacuums when it pays off.
+    case periodic
+    /// User tapped "Reclaim Space": sweeps everything and always vacuums.
+    case userReclaim
+}
+
+// MARK: - Roots
+
+/// Every filesystem location the client touches, injectable for tests.
+public struct StorageRoots: Sendable {
+    public let archiveRoot: URL
+    public let imagesRoot: URL
+    public let cachesRoot: URL
+    public let pendingRoots: [URL]
+    public let temporaryRoots: [URL]
+    public let legacyDatabaseURL: URL?
+    public let databaseURL: URL?
+
+    public static func live() -> Self {
+        let fileManager = FileManager.default
+        let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let caches = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let temporary = fileManager.temporaryDirectory
+        let appGroup = fileManager
+            .containerURL(forSecurityApplicationGroupIdentifier: StowerDatabase.appGroupID)
+        let applicationSupport = try? fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        )
+        return Self(
+            archiveRoot: documents.appendingPathComponent("StowerArchive", isDirectory: true),
+            imagesRoot: documents.appendingPathComponent("StowerImages", isDirectory: true),
+            cachesRoot: caches.appendingPathComponent("StowerImageCache", isDirectory: true),
+            pendingRoots: [
+                appGroup?.appendingPathComponent("PendingPDFs", isDirectory: true),
+                appGroup?.appendingPathComponent("PendingWebsites", isDirectory: true),
+            ].compactMap(\.self),
+            temporaryRoots: [temporary],
+            legacyDatabaseURL: applicationSupport?.appendingPathComponent("SQLiteData.db"),
+            databaseURL: appGroup?
+                .appendingPathComponent("Database", isDirectory: true)
+                .appendingPathComponent("stower.sqlite")
+        )
+    }
+
+    public init(
+        archiveRoot: URL,
+        imagesRoot: URL,
+        cachesRoot: URL,
+        pendingRoots: [URL],
+        temporaryRoots: [URL],
+        legacyDatabaseURL: URL?,
+        databaseURL: URL?
+    ) {
+        self.archiveRoot = archiveRoot
+        self.imagesRoot = imagesRoot
+        self.cachesRoot = cachesRoot
+        self.pendingRoots = pendingRoots
+        self.temporaryRoots = temporaryRoots
+        self.legacyDatabaseURL = legacyDatabaseURL
+        self.databaseURL = databaseURL
+    }
+}
+
+// MARK: - Client
+
+/// Filesystem-side storage accounting and reclamation. Database-side work is
+/// delegated to `StorageMaintenanceClient`; this client owns directory scans,
+/// stranded-file sweeps, and the maintenance orchestration the app and the
+/// Settings storage section call into.
+public struct StorageUsageClient: Sendable {
+    /// Cached (60 s) storage accounting. Pass `force` to rescan.
+    public var computeSnapshot: @Sendable (_ force: Bool) async throws -> StorageSnapshot
+    /// Runs the full maintenance pass for the given trigger.
+    public var runMaintenance: @Sendable (MaintenanceTrigger) async throws -> MaintenanceReport
+
+    public init(
+        computeSnapshot: @escaping @Sendable (_ force: Bool) async throws -> StorageSnapshot,
+        runMaintenance: @escaping @Sendable (MaintenanceTrigger) async throws -> MaintenanceReport
+    ) {
+        self.computeSnapshot = computeSnapshot
+        self.runMaintenance = runMaintenance
+    }
+
+    public static let noop = Self(
+        computeSnapshot: { _ in StorageSnapshot() },
+        runMaintenance: { _ in MaintenanceReport() }
+    )
+
+    public static func live(roots: StorageRoots) -> Self {
+        let scanner = StorageScanActor(roots: roots)
+        return Self(
+            computeSnapshot: { force in
+                try await scanner.snapshot(force: force)
+            },
+            runMaintenance: { trigger in
+                try await scanner.runMaintenance(trigger: trigger)
+            }
+        )
+    }
+}
+
+// MARK: - Scan actor
+
+/// Serializes scans and maintenance so a "Reclaim Space" tap can't race the
+/// launch-time pass, and caches the last snapshot (directory walks over a
+/// multi-GB archive are thousands of stat calls).
+actor StorageScanActor {
+    private let roots: StorageRoots
+    private var cached: StorageSnapshot?
+    private let cacheLifetime: TimeInterval = 60
+
+    /// Staged Pending* imports younger than this are never swept, even when
+    /// no job row references them (a job may be about to be enqueued).
+    static let strandedStagingMaxAge: TimeInterval = 7 * 24 * 3600
+    /// tmp/ scratch directories younger than this are left alone.
+    static let temporaryScratchMaxAge: TimeInterval = 24 * 3600
+    /// The legacy sandbox database is auto-deleted once the App Group copy
+    /// has been in service this long.
+    static let legacyDatabaseRetention: TimeInterval = 30 * 24 * 3600
+    /// Periodic vacuums only run when they would reclaim at least this much…
+    static let periodicVacuumMinimumBytes = 50 * 1024 * 1024
+    /// …and at least this fraction of the database file.
+    static let periodicVacuumMinimumFraction = 0.2
+
+    init(roots: StorageRoots) {
+        self.roots = roots
+    }
+
+    // MARK: Snapshot
+
+    func snapshot(force: Bool) async throws -> StorageSnapshot {
+        @Dependency(\.date.now)
+        var now
+        if !force, let cached, now.timeIntervalSince(cached.computedAt) < cacheLifetime {
+            return cached
+        }
+        var snapshot = StorageSnapshot()
+        snapshot.computedAt = now
+
+        @Dependency(\.storageMaintenanceClient)
+        var maintenance
+        if let stats = try? await maintenance.databaseStats() {
+            snapshot.databaseFileBytes = stats.fileBytes
+            snapshot.databaseWALBytes = stats.walBytes
+            snapshot.databaseReclaimableBytes = stats.reclaimableBytes
+        }
+
+        snapshot.imagesBytes = Self.directorySize(roots.imagesRoot)
+        snapshot.cachesBytes = Self.directorySize(roots.cachesRoot)
+        snapshot.pendingBytes = roots.pendingRoots.reduce(0) { $0 + Self.directorySize($1) }
+        snapshot.legacyDatabaseBytes = Self.legacyDatabaseSize(roots.legacyDatabaseURL)
+
+        let (archiveTotal, perItem) = Self.archiveSizes(root: roots.archiveRoot)
+        snapshot.archiveBytes = archiveTotal
+        snapshot.largestItems = try await Self.titledLargestItems(perItem: perItem)
+
+        cached = snapshot
+        return snapshot
+    }
+
+    // MARK: Maintenance
+
+    func runMaintenance(trigger: MaintenanceTrigger) async throws -> MaintenanceReport {
+        @Dependency(\.date.now)
+        var now
+        @Dependency(\.storageMaintenanceClient)
+        var maintenance
+        var report = MaintenanceReport()
+
+        let activePaths = (try? await maintenance.activeJobPayloadPaths()) ?? []
+        report.freedBytes += sweepStrandedStaging(now: now, activePaths: activePaths)
+        report.steps.append("Swept stranded imports")
+
+        report.freedBytes += sweepTemporaryScratch(now: now)
+        report.steps.append("Swept temporary files")
+
+        report.freedBytes += sweepInstalledCaptureZips()
+        report.steps.append("Removed redundant capture archives")
+
+        if let removed = try? await maintenance.clearDeadImageAssetBlobs(), removed > 0 {
+            report.steps.append("Cleared \(removed) legacy image rows")
+        }
+
+        // Orphaned sync rows propagate their deletion to CloudKit, so the
+        // caller gates this entire maintenance pass on sync health.
+        if let swept = try? await maintenance.sweepOrphanedSyncRows(), swept > 0 {
+            report.steps.append("Removed \(swept) orphaned sync rows")
+        }
+
+        report.freedBytes += sweepLegacyDatabase(now: now, force: trigger == .userReclaim)
+
+        let statsBefore = try? await maintenance.databaseStats()
+        let shouldVacuum: Bool
+        switch trigger {
+        case .userReclaim:
+            shouldVacuum = true
+        case .periodic:
+            if let stats = statsBefore {
+                shouldVacuum = stats.reclaimableBytes >= Self.periodicVacuumMinimumBytes
+                    && Double(stats.reclaimableBytes)
+                        >= Double(stats.fileBytes) * Self.periodicVacuumMinimumFraction
+            } else {
+                shouldVacuum = false
+            }
+        }
+        if shouldVacuum {
+            do {
+                try await maintenance.checkpoint()
+                try await maintenance.vacuum()
+                if let before = statsBefore, let after = try? await maintenance.databaseStats() {
+                    report.freedBytes += max(0, (before.fileBytes + before.walBytes) - (after.fileBytes + after.walBytes))
+                }
+                report.steps.append("Compacted database")
+            } catch let error where error.isDatabaseSuspension {
+                // The app was suspended mid-maintenance; the vacuum retries on
+                // a future pass. Never fail the whole report over it.
+                kStorageLogger.info("VACUUM skipped: database suspended")
+            } catch let StorageMaintenanceError.insufficientDiskSpace(required, available) {
+                kStorageLogger.warning("VACUUM skipped: needs \(required) bytes, only \(available) free")
+            }
+        }
+
+        cached = nil
+        return report
+    }
+
+    // MARK: Sweeps
+
+    /// Removes staged share-extension imports that are old enough to be
+    /// abandoned AND not referenced by any job that could still be retried.
+    private func sweepStrandedStaging(now: Date, activePaths: Set<String>) -> Int {
+        // Directory enumeration resolves symlinks (`/var` → `/private/var`),
+        // so payload paths must be normalized the same way before comparison.
+        let normalizedActivePaths = Set(activePaths.map(Self.normalizedPath))
+        var freed = 0
+        for root in roots.pendingRoots {
+            for entry in Self.contents(of: root) {
+                guard let age = Self.age(of: entry, now: now), age > Self.strandedStagingMaxAge else {
+                    continue
+                }
+                let entryPath = Self.normalizedPath(entry.path)
+                let isActive = normalizedActivePaths.contains { payload in
+                    payload == entryPath || payload.hasPrefix(entryPath + "/")
+                }
+                if isActive { continue }
+                freed += Self.remove(entry)
+            }
+        }
+        return freed
+    }
+
+    private static func normalizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+    }
+
+    private func sweepTemporaryScratch(now: Date) -> Int {
+        var freed = 0
+        for root in roots.temporaryRoots {
+            for entry in Self.contents(of: root) {
+                let name = entry.lastPathComponent
+                guard name == "StowerReader" || name.hasPrefix("StowerCapture-") else { continue }
+                guard let age = Self.age(of: entry, now: now), age > Self.temporaryScratchMaxAge else {
+                    continue
+                }
+                freed += Self.remove(entry)
+            }
+        }
+        return freed
+    }
+
+    /// Deletes the `capture.zip` older installs left inside each installed
+    /// capture directory (its bytes live in the synced chunk rows).
+    private func sweepInstalledCaptureZips() -> Int {
+        var freed = 0
+        for itemDir in Self.contents(of: roots.archiveRoot) {
+            // In-flight installs and rollback backups use dot-prefixed
+            // directories; leave anything mid-operation alone.
+            guard !itemDir.lastPathComponent.hasPrefix(".") else { continue }
+            let zip = itemDir
+                .appendingPathComponent(ArticleCapturePackage.captureDirectoryName, isDirectory: true)
+                .appendingPathComponent(ArticleCapturePackage.installedPackageFilename)
+            if FileManager.default.fileExists(atPath: zip.path) {
+                freed += Self.remove(zip)
+            }
+        }
+        return freed
+    }
+
+    private func sweepLegacyDatabase(now: Date, force: Bool) -> Int {
+        guard let legacyURL = roots.legacyDatabaseURL,
+              FileManager.default.fileExists(atPath: legacyURL.path)
+        else { return 0 }
+
+        if !force {
+            // Auto-delete only once the App Group database has been the live
+            // copy long enough that the "recovery copy" has no value left.
+            guard let databaseURL = roots.databaseURL,
+                  let created = try? FileManager.default
+                      .attributesOfItem(atPath: databaseURL.path)[.creationDate] as? Date,
+                  now.timeIntervalSince(created) >= Self.legacyDatabaseRetention
+            else { return 0 }
+        }
+
+        var freed = Self.remove(legacyURL)
+        freed += Self.remove(URL(fileURLWithPath: legacyURL.path + ".wal"))
+        freed += Self.remove(URL(fileURLWithPath: legacyURL.path + ".shm"))
+        if freed > 0 {
+            kStorageLogger.info("Deleted legacy sandbox database (\(freed) bytes)")
+        }
+        return freed
+    }
+
+    // MARK: Filesystem helpers
+
+    private static func contents(of directory: URL) -> [URL] {
+        (try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey, .contentModificationDateKey],
+            options: []
+        )) ?? []
+    }
+
+    private static func age(of url: URL, now: Date) -> TimeInterval? {
+        let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .creationDateKey])
+        guard let stamp = values?.contentModificationDate ?? values?.creationDate else { return nil }
+        return now.timeIntervalSince(stamp)
+    }
+
+    /// Removes a file or directory, returning the bytes it occupied.
+    private static func remove(_ url: URL) -> Int {
+        guard FileManager.default.fileExists(atPath: url.path) else { return 0 }
+        let size = itemSize(url)
+        do {
+            try FileManager.default.removeItem(at: url)
+            return size
+        } catch {
+            kStorageLogger.warning("Failed to remove \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return 0
+        }
+    }
+
+    private static func itemSize(_ url: URL) -> Int {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return 0
+        }
+        return isDirectory.boolValue ? directorySize(url) : fileSize(url)
+    }
+
+    private static func fileSize(_ url: URL) -> Int {
+        let values = try? url.resourceValues(forKeys: [.totalFileAllocatedSizeKey, .fileSizeKey])
+        return values?.totalFileAllocatedSize ?? values?.fileSize ?? 0
+    }
+
+    static func directorySize(_ directory: URL) -> Int {
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.totalFileAllocatedSizeKey, .fileSizeKey],
+            // No .skipsHiddenFiles: dot-prefixed install/backup leftovers
+            // occupy real space and must be counted.
+            options: []
+        ) else { return 0 }
+        var total = 0
+        for case let url as URL in enumerator {
+            total += fileSize(url)
+        }
+        return total
+    }
+
+    private static func legacyDatabaseSize(_ legacyURL: URL?) -> Int {
+        guard let legacyURL else { return 0 }
+        return fileSize(legacyURL)
+            + fileSize(URL(fileURLWithPath: legacyURL.path + ".wal"))
+            + fileSize(URL(fileURLWithPath: legacyURL.path + ".shm"))
+    }
+
+    private static func archiveSizes(root: URL) -> (total: Int, perItem: [UUID: Int]) {
+        var total = 0
+        var perItem = [UUID: Int]()
+        for entry in contents(of: root) {
+            let size = itemSize(entry)
+            total += size
+            if let itemID = UUID(uuidString: entry.lastPathComponent) {
+                perItem[itemID] = size
+            }
+        }
+        return (total, perItem)
+    }
+
+    private static func titledLargestItems(perItem: [UUID: Int]) async throws -> [ItemStorageSize] {
+        guard !perItem.isEmpty else { return [] }
+        @Dependency(\.stowerRepository)
+        var repository
+        var titles = [UUID: String]()
+        if let library = try? await repository.fetchLibrary(.all) {
+            for item in library { titles[item.id] = item.title }
+        }
+        if let trash = try? await repository.fetchLibrary(.recentlyDeleted) {
+            for item in trash { titles[item.id] = item.title }
+        }
+        return perItem
+            .sorted { $0.value > $1.value }
+            .prefix(10)
+            .map { id, bytes in
+                ItemStorageSize(id: id, title: titles[id] ?? "Removed item", bytes: bytes)
+            }
+    }
+}
+
+// MARK: - Dependency Key
+
+private enum StorageUsageClientKey: DependencyKey {
+    static var liveValue: StorageUsageClient {
+        .live(roots: .live())
+    }
+    static let testValue: StorageUsageClient = .noop
+}
+
+extension DependencyValues {
+    public var storageUsageClient: StorageUsageClient {
+        get { self[StorageUsageClientKey.self] }
+        set { self[StorageUsageClientKey.self] = newValue }
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/ArticleCapturePackageTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/ArticleCapturePackageTests.swift
@@ -30,6 +30,13 @@ struct ArticleCapturePackageTests {
         #expect(try Data(contentsOf: readerURL) == Data("reader archive".utf8))
         #expect(try Data(contentsOf: originalURL) == Data("original archive".utf8))
         #expect(ArticleCapturePackage.metadata(for: itemID)?.completeness == .partial)
+
+        // The package zip must not be duplicated into the installed directory;
+        // its bytes are already retained as synced capture chunks.
+        let installedZip = readerURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(ArticleCapturePackage.installedPackageFilename)
+        #expect(!FileManager.default.fileExists(atPath: installedZip.path))
     }
 
     @Test

--- a/StowerPackage/Tests/StowerFeatureV2Tests/StorageFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/StorageFeatureTests.swift
@@ -1,0 +1,111 @@
+import ComposableArchitecture
+import Foundation
+@testable import StowerFeature
+import Testing
+
+@MainActor
+@Suite
+struct StorageFeatureTests {
+    private static func makeSnapshot(archiveBytes: Int = 1024) -> StorageSnapshot {
+        var snapshot = StorageSnapshot()
+        snapshot.archiveBytes = archiveBytes
+        snapshot.computedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        return snapshot
+    }
+
+    @Test
+    func task_loadsSnapshot() async {
+        let snapshot = Self.makeSnapshot()
+        let store = TestStore(initialState: StorageFeature.State()) {
+            StorageFeature()
+        } withDependencies: {
+            $0.storageUsageClient = StorageUsageClient(
+                computeSnapshot: { _ in snapshot },
+                runMaintenance: { _ in MaintenanceReport() }
+            )
+        }
+
+        await store.send(.task) {
+            $0.isComputing = true
+        }
+        await store.receive(.snapshotLoaded(snapshot)) {
+            $0.isComputing = false
+            $0.snapshot = snapshot
+        }
+    }
+
+    @Test
+    func reclaim_runsMaintenanceThenRefreshesSnapshot() async {
+        let report = MaintenanceReport(freedBytes: 2048, steps: ["Swept stranded imports"])
+        let snapshot = Self.makeSnapshot(archiveBytes: 64)
+        let store = TestStore(initialState: StorageFeature.State()) {
+            StorageFeature()
+        } withDependencies: {
+            $0.storageUsageClient = StorageUsageClient(
+                computeSnapshot: { force in
+                    #expect(force)
+                    return snapshot
+                },
+                runMaintenance: { trigger in
+                    #expect(trigger == .userReclaim)
+                    return report
+                }
+            )
+        }
+
+        await store.send(.reclaimTapped) {
+            $0.maintenance = .running
+        }
+        await store.receive(.maintenanceFinished(report)) {
+            $0.maintenance = .finished(report)
+            $0.isComputing = true
+        }
+        await store.receive(.snapshotLoaded(snapshot)) {
+            $0.isComputing = false
+            $0.snapshot = snapshot
+        }
+    }
+
+    @Test
+    func reclaim_failureSurfacesMessage() async {
+        struct Failure: Error, LocalizedError {
+            var errorDescription: String? { "disk full" }
+        }
+        let store = TestStore(initialState: StorageFeature.State()) {
+            StorageFeature()
+        } withDependencies: {
+            $0.storageUsageClient = StorageUsageClient(
+                computeSnapshot: { _ in StorageSnapshot() },
+                runMaintenance: { _ in throw Failure() }
+            )
+        }
+
+        await store.send(.reclaimTapped) {
+            $0.maintenance = .running
+        }
+        await store.receive(.maintenanceFailed("disk full")) {
+            $0.maintenance = .failed("disk full")
+        }
+    }
+
+    @Test
+    func reclaim_isNotReentrantWhileRunning() async {
+        let store = TestStore(initialState: StorageFeature.State()) {
+            StorageFeature()
+        } withDependencies: {
+            $0.storageUsageClient = StorageUsageClient(
+                computeSnapshot: { _ in StorageSnapshot() },
+                runMaintenance: { _ in
+                    try await Task.never()
+                }
+            )
+        }
+
+        await store.send(.reclaimTapped) {
+            $0.maintenance = .running
+        }
+        // A second tap while running must be ignored entirely.
+        await store.send(.reclaimTapped)
+        await store.skipInFlightEffects()
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/StorageLeakFixTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/StorageLeakFixTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import SQLiteData
+@testable import StowerData
+@testable import StowerFeature
+import Testing
+
+/// Permanent deletion must clear every content sync table keyed on the item's
+/// ID. These tables have no foreign keys, so a missed delete leaves large
+/// blobs (website zips especially) orphaned in the local database and in
+/// CloudKit forever.
+@Suite
+struct StorageLeakFixTests {
+    private func makeFixture() throws -> (database: any DatabaseWriter, repository: StowerRepository) {
+        let database = try StowerDatabase.makeDatabase()
+        return (database, StowerRepository.live(database: database, cloudSyncClient: .noop))
+    }
+
+    private func seedContentRows(for id: UUID, in database: any DatabaseWriter) async throws {
+        try await database.write { db in
+            try SavedWebsiteArchiveSyncTable.insert {
+                SavedWebsiteArchiveSyncTable(
+                    id: id,
+                    zipData: Data("zip-bytes".utf8),
+                    sha256: "abc",
+                    originalFilename: "site.zip",
+                    byteCount: 9
+                )
+            }
+            .execute(db)
+            try SavedPDFContentSyncTable.insert {
+                SavedPDFContentSyncTable(id: id, documentJSON: "{}", plainText: "pdf text")
+            }
+            .execute(db)
+            // Text items already write their own text sync row at creation, so
+            // upsert rather than insert to keep the fixture independent of that.
+            try SavedTextContentSyncTable.upsert {
+                SavedTextContentSyncTable.Draft(id: id, plainText: "text", rawSourceText: "raw")
+            }
+            .execute(db)
+        }
+    }
+
+    private func contentRowCounts(for id: UUID, in database: any DatabaseWriter) async throws -> (website: Int, pdf: Int, text: Int) {
+        try await database.read { db in
+            (
+                website: try SavedWebsiteArchiveSyncTable.where { $0.id.eq(id) }.fetchCount(db),
+                pdf: try SavedPDFContentSyncTable.where { $0.id.eq(id) }.fetchCount(db),
+                text: try SavedTextContentSyncTable.where { $0.id.eq(id) }.fetchCount(db)
+            )
+        }
+    }
+
+    @Test
+    func permanentlyDelete_clearsContentSyncTables() async throws {
+        let (database, repository) = try makeFixture()
+        let item = try await repository.createItemFromIngestion(.sharedText("Doomed"))
+        try await seedContentRows(for: item.id, in: database)
+
+        try await repository.deleteItem(item.id)
+        try await repository.permanentlyDelete(item.id)
+
+        let counts = try await contentRowCounts(for: item.id, in: database)
+        #expect(counts.website == 0)
+        #expect(counts.pdf == 0)
+        #expect(counts.text == 0)
+    }
+
+    @Test
+    func purgeOldTrash_clearsContentSyncTables() async throws {
+        let (database, repository) = try makeFixture()
+        let expired = try await repository.createItemFromIngestion(.sharedText("Old"))
+        let fresh = try await repository.createItemFromIngestion(.sharedText("New"))
+        try await seedContentRows(for: expired.id, in: database)
+        try await seedContentRows(for: fresh.id, in: database)
+
+        try await repository.deleteItem(expired.id)
+        try await repository.deleteItem(fresh.id)
+        // Back-date only the expired item past the 30-day retention window.
+        try await database.write { db in
+            try SavedItemSyncTable
+                .find(expired.id)
+                .update { $0.deletedAt = #bind(Date.now.addingTimeInterval(-31 * 24 * 3600) as Date?) }
+                .execute(db)
+        }
+
+        let purged = try await repository.purgeOldTrash()
+        #expect(purged == [expired.id])
+
+        let expiredCounts = try await contentRowCounts(for: expired.id, in: database)
+        #expect(expiredCounts.website == 0)
+        #expect(expiredCounts.pdf == 0)
+        #expect(expiredCounts.text == 0)
+
+        // The still-retained trash item keeps its content rows.
+        let freshCounts = try await contentRowCounts(for: fresh.id, in: database)
+        #expect(freshCounts.website == 1)
+        #expect(freshCounts.pdf == 1)
+        #expect(freshCounts.text == 1)
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/StorageMaintenanceTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/StorageMaintenanceTests.swift
@@ -1,0 +1,273 @@
+import Dependencies
+import Foundation
+import SQLiteData
+@testable import StowerData
+@testable import StowerFeature
+import Testing
+
+@Suite
+struct StorageMaintenanceTests {
+    @Test
+    func clearDeadImageAssetBlobs_removesLegacyRows() async throws {
+        let database = try StowerDatabase.makeDatabase()
+        let repository = StowerRepository.live(database: database, cloudSyncClient: .noop)
+        let client = StorageMaintenanceClient.live(database: database)
+
+        // The legacy table has an FK to the item table, so anchor the blob
+        // to a real item the way old app versions did.
+        let item = try await repository.createItemFromIngestion(.sharedText("Legacy"))
+        try await database.write { db in
+            try SavedImageAssetLocalTable.insert {
+                SavedImageAssetLocalTable(
+                    id: UUID(),
+                    itemID: item.id,
+                    imageData: Data(repeating: 0xAB, count: 1024)
+                )
+            }
+            .execute(db)
+        }
+
+        #expect(try await client.clearDeadImageAssetBlobs() == 1)
+        let remaining = try await database.read { db in
+            try SavedImageAssetLocalTable.fetchCount(db)
+        }
+        #expect(remaining == 0)
+        // Re-running is a no-op.
+        #expect(try await client.clearDeadImageAssetBlobs() == 0)
+    }
+
+    @Test
+    func databaseStats_reportsPagesAndFreelist() async throws {
+        let database = try StowerDatabase.makeDatabase()
+        let client = StorageMaintenanceClient.live(database: database)
+
+        let stats = try await client.databaseStats()
+        #expect(stats.pageCount > 0)
+        #expect(stats.pageSize > 0)
+        #expect(stats.fileBytes == stats.pageCount * stats.pageSize)
+        #expect(stats.reclaimableBytes == stats.freelistCount * stats.pageSize)
+    }
+
+    @Test
+    func vacuum_reclaimsFreelistPagesAndPreservesRows() async throws {
+        let database = try StowerDatabase.makeDatabase()
+        let repository = StowerRepository.live(database: database, cloudSyncClient: .noop)
+        let client = StorageMaintenanceClient.live(database: database)
+        let item = try await repository.createItemFromIngestion(.sharedText("Bulky"))
+        let keeper = UUID()
+
+        try await database.write { db in
+            try SavedImageAssetLocalTable.insert {
+                SavedImageAssetLocalTable(
+                    id: keeper,
+                    itemID: item.id,
+                    imageData: Data(repeating: 0x01, count: 64)
+                )
+            }
+            .execute(db)
+            try SavedImageAssetLocalTable.insert {
+                SavedImageAssetLocalTable(
+                    id: UUID(),
+                    itemID: item.id,
+                    imageData: Data(repeating: 0xFF, count: 5 * 1024 * 1024)
+                )
+            }
+            .execute(db)
+        }
+        try await database.write { db in
+            try SavedImageAssetLocalTable
+                .where { $0.id.neq(keeper) }
+                .delete()
+                .execute(db)
+        }
+
+        let before = try await client.databaseStats()
+        #expect(before.freelistCount > 0)
+
+        try await client.checkpoint()
+        try await client.vacuum()
+
+        let after = try await client.databaseStats()
+        #expect(after.freelistCount == 0)
+        #expect(after.fileBytes < before.fileBytes)
+        let survivors = try await database.read { db in
+            try SavedImageAssetLocalTable.select(\.id).fetchAll(db)
+        }
+        #expect(survivors == [keeper])
+    }
+
+    @Test
+    func activeJobPayloadPaths_includesOnlyRetryableFileJobs() async throws {
+        let database = try StowerDatabase.makeDatabase()
+        let client = StorageMaintenanceClient.live(database: database)
+
+        try await database.write { db in
+            try IngestionJobLocalTable.insert {
+                IngestionJobLocalTable(id: UUID(), kind: "pdf", payload: "/pending/a.pdf", status: "queued")
+                IngestionJobLocalTable(id: UUID(), kind: "website", payload: "/pending/site", status: "claimed")
+                IngestionJobLocalTable(id: UUID(), kind: "pdf", payload: "/pending/b.pdf", status: "failed")
+                IngestionJobLocalTable(id: UUID(), kind: "pdf", payload: "/pending/done.pdf", status: "completed")
+                IngestionJobLocalTable(id: UUID(), kind: "url", payload: "https://example.com", status: "queued")
+            }
+            .execute(db)
+        }
+
+        let paths = try await client.activeJobPayloadPaths()
+        #expect(paths == ["/pending/a.pdf", "/pending/site", "/pending/b.pdf"])
+    }
+}
+
+@Suite
+struct OrphanSweepTests {
+    private func makeFixture() throws -> (database: any DatabaseWriter, repository: StowerRepository) {
+        let database = try StowerDatabase.makeDatabase()
+        return (database, StowerRepository.live(database: database, cloudSyncClient: .noop))
+    }
+
+    private func sweep(_ database: any DatabaseWriter, now: Date) async throws -> Int {
+        try await withDependencies {
+            $0.date = .constant(now)
+        } operation: {
+            try await StorageMaintenanceClient.live(database: database).sweepOrphanedSyncRows()
+        }
+    }
+
+    @Test
+    func orphanIsQuarantinedThenDeletedAfterWindow() async throws {
+        let (database, _) = try makeFixture()
+        let orphanID = UUID()
+        try await database.write { db in
+            try SavedWebsiteArchiveSyncTable.insert {
+                SavedWebsiteArchiveSyncTable(id: orphanID, zipData: Data("zip".utf8))
+            }
+            .execute(db)
+        }
+
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        // First pass quarantines but must not delete.
+        #expect(try await sweep(database, now: start) == 0)
+        var rows = try await database.read { db in
+            try SavedWebsiteArchiveSyncTable.fetchCount(db)
+        }
+        #expect(rows == 1)
+
+        // Second pass inside the window still must not delete.
+        #expect(try await sweep(database, now: start.addingTimeInterval(24 * 3600)) == 0)
+
+        // Past the quarantine window the row is removed.
+        let afterWindow = start.addingTimeInterval(StorageMaintenanceClient.orphanQuarantineInterval + 60)
+        #expect(try await sweep(database, now: afterWindow) == 1)
+        rows = try await database.read { db in
+            try SavedWebsiteArchiveSyncTable.fetchCount(db)
+        }
+        #expect(rows == 0)
+        let candidates = try await database.read { db in
+            try OrphanCandidateLocalTable.fetchCount(db)
+        }
+        #expect(candidates == 0)
+    }
+
+    @Test
+    func liveItemsRowsAreNeverTouched() async throws {
+        let (database, repository) = try makeFixture()
+        let item = try await repository.createItemFromIngestion(.sharedText("Alive"))
+        try await database.write { db in
+            try SavedWebsiteArchiveSyncTable.insert {
+                SavedWebsiteArchiveSyncTable(id: item.id, zipData: Data("zip".utf8))
+            }
+            .execute(db)
+        }
+
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        #expect(try await sweep(database, now: start) == 0)
+        let farFuture = start.addingTimeInterval(100 * 24 * 3600)
+        #expect(try await sweep(database, now: farFuture) == 0)
+
+        let rows = try await database.read { db in
+            try SavedWebsiteArchiveSyncTable.fetchCount(db)
+        }
+        #expect(rows == 1)
+    }
+
+    @Test
+    func candidateIsReleasedWhenItemRowArrivesLate() async throws {
+        let (database, repository) = try makeFixture()
+        let orphanID = UUID()
+        try await database.write { db in
+            try SavedPDFContentSyncTable.insert {
+                SavedPDFContentSyncTable(id: orphanID, documentJSON: "{}", plainText: "pdf")
+            }
+            .execute(db)
+        }
+
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        #expect(try await sweep(database, now: start) == 0)
+
+        // Simulate the item row arriving from CloudKit after quarantine began.
+        try await database.write { db in
+            try SavedItemSyncTable.insert {
+                SavedItemSyncTable(id: orphanID, title: "Late arrival")
+            }
+            .execute(db)
+        }
+        _ = try await repository.fetchLibrary(.all)
+
+        let afterWindow = start.addingTimeInterval(StorageMaintenanceClient.orphanQuarantineInterval + 60)
+        #expect(try await sweep(database, now: afterWindow) == 0)
+
+        let rows = try await database.read { db in
+            try SavedPDFContentSyncTable.fetchCount(db)
+        }
+        #expect(rows == 1)
+        let candidates = try await database.read { db in
+            try OrphanCandidateLocalTable
+                .where { $0.orphanID.eq(orphanID) }
+                .fetchCount(db)
+        }
+        #expect(candidates == 0)
+    }
+
+    @Test
+    func orphanedCaptureManifestAndChunksAreSweptTogether() async throws {
+        let (database, _) = try makeFixture()
+        let orphanItemID = UUID()
+        let captureID = UUID()
+        try await database.write { db in
+            try SavedArticleCaptureSyncTable.insert {
+                SavedArticleCaptureSyncTable(id: UUID(), itemID: orphanItemID, captureID: captureID)
+            }
+            .execute(db)
+            try SavedArticleCaptureChunkSyncTable.insert {
+                SavedArticleCaptureChunkSyncTable(
+                    id: UUID(),
+                    itemID: orphanItemID,
+                    captureID: captureID,
+                    sequence: 0,
+                    data: Data("chunk".utf8)
+                )
+                SavedArticleCaptureChunkSyncTable(
+                    id: UUID(),
+                    itemID: orphanItemID,
+                    captureID: captureID,
+                    sequence: 1,
+                    data: Data("chunk2".utf8)
+                )
+            }
+            .execute(db)
+        }
+
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        #expect(try await sweep(database, now: start) == 0)
+        let afterWindow = start.addingTimeInterval(StorageMaintenanceClient.orphanQuarantineInterval + 60)
+        #expect(try await sweep(database, now: afterWindow) == 3)
+
+        let (manifests, chunks) = try await database.read { db in
+            (
+                try SavedArticleCaptureSyncTable.fetchCount(db),
+                try SavedArticleCaptureChunkSyncTable.fetchCount(db)
+            )
+        }
+        #expect(manifests == 0)
+        #expect(chunks == 0)
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/StorageUsageClientTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/StorageUsageClientTests.swift
@@ -1,0 +1,189 @@
+import Dependencies
+import Foundation
+@testable import StowerData
+@testable import StowerFeature
+import Testing
+
+@Suite
+struct StorageUsageClientTests {
+    private struct Fixture {
+        var roots: StorageRoots
+        var client: StorageUsageClient
+        var scratch: URL
+
+        func path(_ components: String...) -> URL {
+            components.reduce(scratch) { $0.appendingPathComponent($1) }
+        }
+    }
+
+    private func makeFixture() throws -> Fixture {
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("storage-usage-tests-\(UUID().uuidString)", isDirectory: true)
+        let roots = StorageRoots(
+            archiveRoot: scratch.appendingPathComponent("StowerArchive", isDirectory: true),
+            imagesRoot: scratch.appendingPathComponent("StowerImages", isDirectory: true),
+            cachesRoot: scratch.appendingPathComponent("StowerImageCache", isDirectory: true),
+            pendingRoots: [
+                scratch.appendingPathComponent("PendingPDFs", isDirectory: true),
+                scratch.appendingPathComponent("PendingWebsites", isDirectory: true),
+            ],
+            temporaryRoots: [scratch.appendingPathComponent("tmp", isDirectory: true)],
+            legacyDatabaseURL: scratch.appendingPathComponent("SQLiteData.db"),
+            databaseURL: scratch.appendingPathComponent("stower.sqlite")
+        )
+        for dir in [roots.archiveRoot, roots.imagesRoot, roots.cachesRoot] + roots.pendingRoots + roots.temporaryRoots {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        return Fixture(roots: roots, client: .live(roots: roots), scratch: scratch)
+    }
+
+    private func write(_ bytes: Int, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(repeating: 0x5A, count: bytes).write(to: url)
+    }
+
+    private func setModificationDate(_ date: Date, at url: URL) throws {
+        try FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: url.path)
+    }
+
+    @Test
+    func snapshot_accountsPerCategoryAndLargestItems() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.scratch) }
+        let bigItem = UUID()
+        let smallItem = UUID()
+        try write(4096, to: fixture.roots.archiveRoot.appendingPathComponent("\(bigItem.uuidString)/index.html"))
+        try write(1024, to: fixture.roots.archiveRoot.appendingPathComponent("\(smallItem.uuidString)/index.html"))
+        try write(512, to: fixture.roots.imagesRoot.appendingPathComponent("hero.jpg"))
+        try write(256, to: fixture.roots.pendingRoots[0].appendingPathComponent("stranded.pdf"))
+        try write(128, to: fixture.roots.legacyDatabaseURL!)
+
+        let snapshot = try await withDependencies {
+            $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+            $0.storageMaintenanceClient = .noop
+        } operation: {
+            try await fixture.client.computeSnapshot(true)
+        }
+
+        #expect(snapshot.archiveBytes >= 5120)
+        #expect(snapshot.imagesBytes >= 512)
+        #expect(snapshot.pendingBytes >= 256)
+        #expect(snapshot.legacyDatabaseBytes >= 128)
+        #expect(snapshot.largestItems.first?.id == bigItem)
+        #expect(snapshot.largestItems.count == 2)
+        #expect(snapshot.totalBytes > 0)
+    }
+
+    @Test
+    func strandedStagingSweep_respectsAgeAndActiveJobPaths() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.scratch) }
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let old = now.addingTimeInterval(-8 * 24 * 3600)
+
+        // Old and unreferenced: swept.
+        let stranded = fixture.roots.pendingRoots[0].appendingPathComponent("stranded.pdf")
+        try write(100, to: stranded)
+        try setModificationDate(old, at: stranded)
+        // Old but referenced by a retryable job: kept.
+        let active = fixture.roots.pendingRoots[0].appendingPathComponent("active.pdf")
+        try write(100, to: active)
+        try setModificationDate(old, at: active)
+        // Old website dir whose payload points inside it: kept.
+        let activeSiteDir = fixture.roots.pendingRoots[1].appendingPathComponent("site-dir", isDirectory: true)
+        try write(100, to: activeSiteDir.appendingPathComponent("guide.zip"))
+        try setModificationDate(old, at: activeSiteDir)
+        // Fresh and unreferenced: kept (may be about to be enqueued).
+        let fresh = fixture.roots.pendingRoots[0].appendingPathComponent("fresh.pdf")
+        try write(100, to: fresh)
+
+        let report = try await withDependencies {
+            $0.date = .constant(now)
+            $0.storageMaintenanceClient = StorageMaintenanceClient(
+                databaseStats: { DatabaseStorageStats() },
+                clearDeadImageAssetBlobs: { 0 },
+                sweepOrphanedSyncRows: { 0 },
+                activeJobPayloadPaths: {
+                    [
+                        active.path,
+                        activeSiteDir.appendingPathComponent("guide.zip").path,
+                    ]
+                },
+                checkpoint: {},
+                vacuum: {}
+            )
+        } operation: {
+            try await fixture.client.runMaintenance(.periodic)
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: stranded.path))
+        #expect(FileManager.default.fileExists(atPath: active.path))
+        #expect(FileManager.default.fileExists(atPath: activeSiteDir.path))
+        #expect(FileManager.default.fileExists(atPath: fresh.path))
+        #expect(report.freedBytes >= 100)
+    }
+
+    @Test
+    func captureZipSweep_removesOnlyInstalledZips() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.scratch) }
+        let itemID = UUID()
+        let captureDir = fixture.roots.archiveRoot
+            .appendingPathComponent(itemID.uuidString, isDirectory: true)
+            .appendingPathComponent(ArticleCapturePackage.captureDirectoryName, isDirectory: true)
+        let legacyZip = captureDir.appendingPathComponent(ArticleCapturePackage.installedPackageFilename)
+        let keeper = captureDir.appendingPathComponent(ArticleCapturePackage.readerArchiveFilename)
+        try write(2048, to: legacyZip)
+        try write(64, to: keeper)
+        // Mid-install staging dirs must not be touched.
+        let staging = fixture.roots.archiveRoot
+            .appendingPathComponent(".capture-install-\(UUID().uuidString)", isDirectory: true)
+        let stagingZip = staging
+            .appendingPathComponent(ArticleCapturePackage.captureDirectoryName, isDirectory: true)
+            .appendingPathComponent(ArticleCapturePackage.installedPackageFilename)
+        try write(2048, to: stagingZip)
+
+        _ = try await withDependencies {
+            $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+            $0.storageMaintenanceClient = .noop
+        } operation: {
+            try await fixture.client.runMaintenance(.periodic)
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: legacyZip.path))
+        #expect(FileManager.default.fileExists(atPath: keeper.path))
+        #expect(FileManager.default.fileExists(atPath: stagingZip.path))
+    }
+
+    @Test
+    func legacyDatabase_deletedOnUserReclaim_keptByYoungPeriodicPass() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.scratch) }
+        let legacy = fixture.roots.legacyDatabaseURL!
+        try write(1024, to: legacy)
+        try write(64, to: URL(fileURLWithPath: legacy.path + ".wal"))
+        // App Group database created "now" — the 30-day auto-delete gate is
+        // not met, so a periodic pass must keep the recovery copy.
+        try write(64, to: fixture.roots.databaseURL!)
+
+        let dependencies: (inout DependencyValues) -> Void = {
+            $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+            $0.storageMaintenanceClient = .noop
+        }
+
+        _ = try await withDependencies(dependencies) {
+            try await fixture.client.runMaintenance(.periodic)
+        }
+        #expect(FileManager.default.fileExists(atPath: legacy.path))
+
+        let report = try await withDependencies(dependencies) {
+            try await fixture.client.runMaintenance(.userReclaim)
+        }
+        #expect(!FileManager.default.fileExists(atPath: legacy.path))
+        #expect(!FileManager.default.fileExists(atPath: legacy.path + ".wal"))
+        #expect(report.freedBytes >= 1024)
+    }
+}


### PR DESCRIPTION
A device report showed the app occupying 3.29 GB, most of it redundant
copies and leaks rather than unique content. Every web article was
stored three times (synced capture chunks in SQLite, the same zip
written back into the installed archive directory, and the extracted
webarchives), permanently deleting an item leaked its website-zip, PDF,
and text content sync rows forever (those tables have no foreign keys),
the database was never vacuumed, and interrupted imports stranded
full-size files in the App Group staging directories.

Stop writing capture.zip into the installed archive directory — nothing
ever read it; hydration reconstructs from the synced chunk rows. Delete
the three content sync tables' rows in permanent delete and trash purge.

Clean up rows that older builds already orphaned with a quarantine sweep
(migration v17 adds the bookkeeping table): a content row whose item is
missing is only deleted after staying orphaned for seven consecutive
days, because during initial CloudKit sync content rows can arrive
before their item row and an immediate delete would destroy the master
copy of a live item.

StorageMaintenanceClient owns the database side: orphan sweep, dead
legacy image-blob removal, page statistics, truncating checkpoint, and
VACUUM. The vacuum refuses to run without 1.2x the file size free on
disk and callers only invoke it in the foreground — it holds an
exclusive lock on the shared App Group file, exactly the 0xDEAD10CC
condition the suspension work just fixed — and suspension errors are
treated as retry-next-launch.

StorageUsageClient owns the filesystem side: a cached snapshot of every
storage category, sweeps for stranded staging files (age-gated and
excluding paths still referenced by retryable ingestion jobs), legacy
capture zips, and the pre-App-Group database copy (after 30 days, or
immediately on user request). A maintenance pass runs at startup every
three days, and a new Settings > Storage section shows the breakdown
with the largest items and a Reclaim Space button.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>