### PR TITLE
Store heavy content in iCloud and download it on demand

### DIFF
--- a/StowerPackage/Sources/StowerData/Data/Bootstrap+CloudSync.swift
+++ b/StowerPackage/Sources/StowerData/Data/Bootstrap+CloudSync.swift
@@ -42,6 +42,7 @@ extension StowerDatabase {
                 SavedWebsiteArchiveSyncTable.self,
                 SavedArticleCaptureSyncTable.self,
                 SavedArticleCaptureChunkSyncTable.self,
+                SavedAssetManifestSyncTable.self,
                 containerIdentifier: StowerDatabase.cloudKitContainerID,
                 delegate: delegate
             )

--- a/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
+++ b/StowerPackage/Sources/StowerData/Data/Bootstrap.swift
@@ -270,6 +270,9 @@ public enum StowerDatabase {
         migrator.registerMigration("add-orphan-candidate-quarantine") { db in
             try migration_v17(db)
         }
+        migrator.registerMigration("add-cloud-asset-store") { db in
+            try migration_v18(db)
+        }
         try migrator.migrate(database)
     }
 
@@ -788,6 +791,41 @@ public enum StowerDatabase {
             """)
     }
 
+    /// Cloud asset store: synced manifests for heavy payloads that live as
+    /// app-managed CKRecords in their own zone, plus local-only per-item
+    /// storage state (pin/LRU/upload) and the single-row offload policy.
+    /// UUID primary keys and no unique indexes on the synced table, per the
+    /// SyncEngine safety rules.
+    private static func migration_v18(_ db: Database) throws {
+        try db.execute(sql: """
+            CREATE TABLE IF NOT EXISTS "savedAssetManifestSyncTables" (
+              "id" TEXT PRIMARY KEY NOT NULL, "itemID" TEXT NOT NULL,
+              "kind" TEXT NOT NULL DEFAULT '', "recordName" TEXT NOT NULL DEFAULT '',
+              "sha256" TEXT NOT NULL DEFAULT '', "byteCount" INTEGER NOT NULL DEFAULT 0,
+              "originalFilename" TEXT NOT NULL DEFAULT '', "createdAt" TEXT NOT NULL,
+              "updatedAt" TEXT NOT NULL
+            ) STRICT
+            """)
+        try db.execute(sql: #"CREATE INDEX IF NOT EXISTS "idx_savedAssetManifestSyncTables_itemID" ON "savedAssetManifestSyncTables"("itemID")"#)
+        try db.execute(sql: """
+            CREATE TABLE IF NOT EXISTS "itemStorageLocalTables" (
+              "itemID" TEXT PRIMARY KEY NOT NULL,
+              "isPinned" INTEGER NOT NULL DEFAULT 0,
+              "lastOpenedAt" TEXT,
+              "uploadState" TEXT NOT NULL DEFAULT 'pending',
+              "offloadedAt" TEXT,
+              "updatedAt" TEXT NOT NULL
+            ) STRICT
+            """)
+        try db.execute(sql: """
+            CREATE TABLE IF NOT EXISTS "storagePolicyLocalTables" (
+              "id" TEXT PRIMARY KEY NOT NULL,
+              "budgetBytes" INTEGER,
+              "updatedAt" TEXT NOT NULL
+            ) STRICT
+            """)
+    }
+
     private static func migration_v10(_ db: Database) throws {
         do {
             try db.execute(sql: #"ALTER TABLE "savedItemContentLocalTables" ADD COLUMN "rawSourceText" TEXT NOT NULL DEFAULT ''"#)
@@ -855,6 +893,12 @@ extension DependencyValues {
             load: StowerDatabase.makeDiagnosticsLoad(database: database)
         )
         storageMaintenanceClient = .live(database: database)
+        itemStorageClient = .live(database: database)
+        @Dependency(\.context)
+        var context
+        if context == .live {
+            cloudAssetClient = .live(containerIdentifier: StowerDatabase.cloudKitContainerID)
+        }
         stowerRepository = .live(database: database, cloudSyncClient: cloudSyncClient)
     }
 }

--- a/StowerPackage/Sources/StowerData/Data/CloudAssetClient.swift
+++ b/StowerPackage/Sources/StowerData/Data/CloudAssetClient.swift
@@ -1,0 +1,256 @@
+import Dependencies
+import Foundation
+import OSLog
+#if canImport(CloudKit)
+import CloudKit
+#endif
+
+private let kAssetLogger = Logger(subsystem: "com.ryanleewilliams.stower", category: "CloudAssets")
+
+public enum CloudAssetError: Error, Equatable, Sendable {
+    /// The user's iCloud storage is full — the payload cannot be uploaded.
+    case quotaExceeded
+    /// No signed-in iCloud account.
+    case notAuthenticated
+    /// The record does not exist in the asset zone.
+    case assetMissing
+    /// The record exists but carried no usable payload.
+    case corruptAsset
+    /// Anything transient the caller should retry later.
+    case transient(String)
+}
+
+/// Direct CloudKit access to the app-managed asset zone. Heavy payloads (PDF
+/// originals, website import zips) live here as immutable, content-addressed
+/// `StowerAsset` records — outside the SQLiteData SyncEngine, which is what
+/// lets a device drop its local copy while the bytes stay in iCloud.
+///
+/// The zone (`StowerAssetZone`) is separate from the SyncEngine's zone so the
+/// two systems never contend over record ownership.
+public struct CloudAssetClient: Sendable {
+    /// Uploads the file as `recordName`. Succeeds (without re-uploading) when
+    /// an identical record already exists — records are content-addressed, so
+    /// a same-name record IS the same content.
+    public var upload: @Sendable (_ manifest: AssetManifest, _ fileURL: URL) async throws -> Void
+    /// Downloads the record's payload to `destination` (replacing it).
+    public var download: @Sendable (_ recordName: String, _ destination: URL) async throws -> Void
+    public var exists: @Sendable (_ recordName: String) async throws -> Bool
+    /// Best-effort delete; missing records are success.
+    public var delete: @Sendable (_ recordName: String) async throws -> Void
+
+    public init(
+        upload: @escaping @Sendable (AssetManifest, URL) async throws -> Void,
+        download: @escaping @Sendable (String, URL) async throws -> Void,
+        exists: @escaping @Sendable (String) async throws -> Bool,
+        delete: @escaping @Sendable (String) async throws -> Void
+    ) {
+        self.upload = upload
+        self.download = download
+        self.exists = exists
+        self.delete = delete
+    }
+
+    public static let noop = Self(
+        upload: { _, _ in },
+        download: { _, _ in throw CloudAssetError.assetMissing },
+        exists: { _ in false },
+        delete: { _ in }
+    )
+}
+
+#if canImport(CloudKit)
+extension CloudAssetClient {
+    public static func live(containerIdentifier: String) -> Self {
+        let store = CloudAssetStore(containerIdentifier: containerIdentifier)
+        return Self(
+            upload: { manifest, fileURL in
+                try await store.upload(manifest: manifest, fileURL: fileURL)
+            },
+            download: { recordName, destination in
+                try await store.download(recordName: recordName, to: destination)
+            },
+            exists: { recordName in
+                try await store.exists(recordName: recordName)
+            },
+            delete: { recordName in
+                try await store.delete(recordName: recordName)
+            }
+        )
+    }
+}
+
+/// Serializes zone creation and owns the CKDatabase handle.
+actor CloudAssetStore {
+    static let zoneName = "StowerAssetZone"
+    static let recordType = "StowerAsset"
+
+    private let container: CKContainer
+    private var zoneReady = false
+
+    private var database: CKDatabase { container.privateCloudDatabase }
+    private var zoneID: CKRecordZone.ID {
+        CKRecordZone.ID(zoneName: Self.zoneName, ownerName: CKCurrentUserDefaultName)
+    }
+
+    init(containerIdentifier: String) {
+        self.container = CKContainer(identifier: containerIdentifier)
+    }
+
+    func upload(manifest: AssetManifest, fileURL: URL) async throws {
+        try await ensureZone()
+        let recordID = CKRecord.ID(recordName: manifest.recordName, zoneID: zoneID)
+        let record = CKRecord(recordType: Self.recordType, recordID: recordID)
+        record["payload"] = CKAsset(fileURL: fileURL)
+        record["itemID"] = manifest.itemID.uuidString as CKRecordValue
+        record["kind"] = manifest.kind.rawValue as CKRecordValue
+        record["sha256"] = manifest.sha256 as CKRecordValue
+        record["byteCount"] = manifest.byteCount as CKRecordValue
+        record["originalFilename"] = manifest.originalFilename as CKRecordValue
+
+        do {
+            try await withRetry {
+                let result = try await self.database.modifyRecords(
+                    saving: [record],
+                    deleting: [],
+                    savePolicy: .ifServerRecordUnchanged
+                )
+                _ = try result.saveResults.mapValues { try $0.get() }
+            }
+        } catch let error as CKError where error.code == .serverRecordChanged {
+            // Content-addressed record name: an existing record with this name
+            // is byte-identical content another device already uploaded.
+            kAssetLogger.info("Asset \(manifest.recordName, privacy: .public) already uploaded elsewhere")
+        } catch {
+            throw mapped(error)
+        }
+    }
+
+    func download(recordName: String, to destination: URL) async throws {
+        let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
+        let record: CKRecord
+        do {
+            record = try await withRetry {
+                try await self.database.record(for: recordID)
+            }
+        } catch {
+            throw mapped(error)
+        }
+        guard let asset = record["payload"] as? CKAsset, let assetURL = asset.fileURL else {
+            throw CloudAssetError.corruptAsset
+        }
+        try FileManager.default.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.copyItem(at: assetURL, to: destination)
+    }
+
+    func exists(recordName: String) async throws -> Bool {
+        let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
+        do {
+            _ = try await withRetry {
+                try await self.database.record(for: recordID)
+            }
+            return true
+        } catch {
+            if case CloudAssetError.assetMissing = mapped(error) {
+                return false
+            }
+            throw mapped(error)
+        }
+    }
+
+    func delete(recordName: String) async throws {
+        let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
+        do {
+            try await withRetry {
+                _ = try await self.database.deleteRecord(withID: recordID)
+            }
+        } catch {
+            if case CloudAssetError.assetMissing = mapped(error) {
+                return
+            }
+            throw mapped(error)
+        }
+    }
+
+    private func ensureZone() async throws {
+        guard !zoneReady else { return }
+        do {
+            _ = try await database.modifyRecordZones(
+                saving: [CKRecordZone(zoneID: zoneID)],
+                deleting: []
+            )
+            zoneReady = true
+        } catch {
+            throw mapped(error)
+        }
+    }
+
+    /// One bounded retry pass for transient CloudKit failures; the job queue
+    /// provides the durable retries.
+    private func withRetry<T: Sendable>(_ work: @Sendable () async throws -> T) async throws -> T {
+        var attempt = 0
+        while true {
+            do {
+                return try await work()
+            } catch let error as CKError where attempt < 2 && isRetryable(error) {
+                attempt += 1
+                let delay = error.retryAfterSeconds ?? Double(attempt * 2)
+                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            }
+        }
+    }
+
+    private func isRetryable(_ error: CKError) -> Bool {
+        switch error.code {
+        case .serviceUnavailable, .requestRateLimited, .zoneBusy, .networkFailure, .networkUnavailable:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func mapped(_ error: Error) -> Error {
+        guard let ckError = error as? CKError else { return error }
+        switch ckError.code {
+        case .quotaExceeded:
+            return CloudAssetError.quotaExceeded
+        case .notAuthenticated, .accountTemporarilyUnavailable:
+            return CloudAssetError.notAuthenticated
+        case .unknownItem, .zoneNotFound:
+            return CloudAssetError.assetMissing
+        case .networkFailure, .networkUnavailable, .serviceUnavailable, .requestRateLimited, .zoneBusy:
+            return CloudAssetError.transient(ckError.localizedDescription)
+        case .partialFailure:
+            if let inner = ckError.partialErrorsByItemID?.values.first {
+                return mapped(inner)
+            }
+            return error
+        default:
+            return error
+        }
+    }
+}
+#else
+extension CloudAssetClient {
+    public static func live(containerIdentifier _: String) -> Self { .noop }
+}
+#endif
+
+// MARK: - Dependency Key
+
+private enum CloudAssetClientKey: DependencyKey {
+    static let liveValue: CloudAssetClient = .noop
+    static let testValue: CloudAssetClient = .noop
+}
+
+extension DependencyValues {
+    public var cloudAssetClient: CloudAssetClient {
+        get { self[CloudAssetClientKey.self] }
+        set { self[CloudAssetClientKey.self] = newValue }
+    }
+}

--- a/StowerPackage/Sources/StowerData/Data/ItemStorageClient.swift
+++ b/StowerPackage/Sources/StowerData/Data/ItemStorageClient.swift
@@ -1,0 +1,419 @@
+import Dependencies
+import Foundation
+import SQLiteData
+
+/// Everything the offload feature needs to know about an item's storage
+/// state, joined from the item, content, storage, and manifest tables.
+public struct ItemStorageInfo: Equatable, Sendable, Identifiable {
+    public var itemID: UUID
+    public var renderFormat: String
+    public var isRead: Bool
+    public var isPinned: Bool
+    public var lastOpenedAt: Date?
+    public var uploadState: String
+    public var offloadedAt: Date?
+    public var hasCaptureManifest: Bool
+    public var assetManifests = [AssetManifest]()
+
+    public var id: UUID { itemID }
+
+    public init(
+        itemID: UUID,
+        renderFormat: String = "structuredV1",
+        isRead: Bool = false,
+        isPinned: Bool = false,
+        lastOpenedAt: Date? = nil,
+        uploadState: String = "pending",
+        offloadedAt: Date? = nil,
+        hasCaptureManifest: Bool = false,
+        assetManifests: [AssetManifest] = []
+    ) {
+        self.itemID = itemID
+        self.renderFormat = renderFormat
+        self.isRead = isRead
+        self.isPinned = isPinned
+        self.lastOpenedAt = lastOpenedAt
+        self.uploadState = uploadState
+        self.offloadedAt = offloadedAt
+        self.hasCaptureManifest = hasCaptureManifest
+        self.assetManifests = assetManifests
+    }
+}
+
+/// Database operations for per-item storage state, asset manifests, and the
+/// offload policy. The CloudKit side lives in `CloudAssetClient`; this client
+/// never leaves SQLite.
+public struct ItemStorageClient: Sendable {
+    public var upsertManifest: @Sendable (AssetManifest) async throws -> Void
+    public var manifest: @Sendable (_ itemID: UUID, _ kind: CloudAssetKind) async throws -> AssetManifest?
+    public var manifests: @Sendable (_ itemIDs: [UUID]) async throws -> [AssetManifest]
+    public var touchOpened: @Sendable (_ itemID: UUID) async throws -> Void
+    public var setPinned: @Sendable (_ itemID: UUID, _ isPinned: Bool) async throws -> Void
+    public var setUploadState: @Sendable (_ itemID: UUID, _ state: String) async throws -> Void
+    public var setOffloaded: @Sendable (_ itemID: UUID, _ isOffloaded: Bool) async throws -> Void
+    public var storageInfo: @Sendable (_ itemID: UUID) async throws -> ItemStorageInfo?
+    /// Batched `storageInfo` for library lists.
+    public var storageInfosForItems: @Sendable (_ itemIDs: [UUID]) async throws -> [ItemStorageInfo]
+    /// All live, read items with their storage state — the eviction service
+    /// filters and orders these.
+    public var evictionCandidates: @Sendable () async throws -> [ItemStorageInfo]
+    public var budgetBytes: @Sendable () async throws -> Int?
+    public var setBudgetBytes: @Sendable (Int?) async throws -> Void
+    /// Atomically records the manifest and deletes the legacy `zipData` sync
+    /// row it replaces. Callers MUST have confirmed the CloudKit upload first
+    /// — the deletion propagates to every device.
+    public var replaceWebsiteArchiveWithManifest: @Sendable (AssetManifest) async throws -> Void
+    /// Live PDF items with no `pdf` asset manifest — upload backfill targets.
+    public var pdfItemIDsWithoutManifest: @Sendable () async throws -> [UUID]
+    /// Items still carrying a legacy `zipData` sync row — migration targets.
+    public var websiteZipItemIDsWithoutManifest: @Sendable () async throws -> [UUID]
+
+    public static let noop = Self(
+        upsertManifest: { _ in },
+        manifest: { _, _ in nil },
+        manifests: { _ in [] },
+        touchOpened: { _ in },
+        setPinned: { _, _ in },
+        setUploadState: { _, _ in },
+        setOffloaded: { _, _ in },
+        storageInfo: { _ in nil },
+        storageInfosForItems: { _ in [] },
+        evictionCandidates: { [] },
+        budgetBytes: { nil },
+        setBudgetBytes: { _ in },
+        replaceWebsiteArchiveWithManifest: { _ in },
+        pdfItemIDsWithoutManifest: { [] },
+        websiteZipItemIDsWithoutManifest: { [] }
+    )
+
+    public init(
+        upsertManifest: @escaping @Sendable (AssetManifest) async throws -> Void,
+        manifest: @escaping @Sendable (UUID, CloudAssetKind) async throws -> AssetManifest?,
+        manifests: @escaping @Sendable ([UUID]) async throws -> [AssetManifest],
+        touchOpened: @escaping @Sendable (UUID) async throws -> Void,
+        setPinned: @escaping @Sendable (UUID, Bool) async throws -> Void,
+        setUploadState: @escaping @Sendable (UUID, String) async throws -> Void,
+        setOffloaded: @escaping @Sendable (UUID, Bool) async throws -> Void,
+        storageInfo: @escaping @Sendable (UUID) async throws -> ItemStorageInfo?,
+        storageInfosForItems: @escaping @Sendable ([UUID]) async throws -> [ItemStorageInfo],
+        evictionCandidates: @escaping @Sendable () async throws -> [ItemStorageInfo],
+        budgetBytes: @escaping @Sendable () async throws -> Int?,
+        setBudgetBytes: @escaping @Sendable (Int?) async throws -> Void,
+        replaceWebsiteArchiveWithManifest: @escaping @Sendable (AssetManifest) async throws -> Void,
+        pdfItemIDsWithoutManifest: @escaping @Sendable () async throws -> [UUID],
+        websiteZipItemIDsWithoutManifest: @escaping @Sendable () async throws -> [UUID]
+    ) {
+        self.upsertManifest = upsertManifest
+        self.manifest = manifest
+        self.manifests = manifests
+        self.touchOpened = touchOpened
+        self.setPinned = setPinned
+        self.setUploadState = setUploadState
+        self.setOffloaded = setOffloaded
+        self.storageInfo = storageInfo
+        self.storageInfosForItems = storageInfosForItems
+        self.evictionCandidates = evictionCandidates
+        self.budgetBytes = budgetBytes
+        self.setBudgetBytes = setBudgetBytes
+        self.replaceWebsiteArchiveWithManifest = replaceWebsiteArchiveWithManifest
+        self.pdfItemIDsWithoutManifest = pdfItemIDsWithoutManifest
+        self.websiteZipItemIDsWithoutManifest = websiteZipItemIDsWithoutManifest
+    }
+}
+
+extension ItemStorageClient {
+    public static func live(database: any DatabaseWriter) -> Self {
+        Self(
+            upsertManifest: { manifest in
+                @Dependency(\.date.now)
+                var now
+                try await database.write { db in
+                    // One manifest per (item, kind): replace any prior row so
+                    // a re-upload with new content supersedes the old record.
+                    try SavedAssetManifestSyncTable
+                        .where { $0.itemID.eq(manifest.itemID) }
+                        .where { $0.kind.eq(manifest.kind.rawValue) }
+                        .delete()
+                        .execute(db)
+                    try SavedAssetManifestSyncTable.insert {
+                        SavedAssetManifestSyncTable(
+                            id: manifest.id,
+                            itemID: manifest.itemID,
+                            kind: manifest.kind.rawValue,
+                            recordName: manifest.recordName,
+                            sha256: manifest.sha256,
+                            byteCount: manifest.byteCount,
+                            originalFilename: manifest.originalFilename,
+                            createdAt: now,
+                            updatedAt: now
+                        )
+                    }
+                    .execute(db)
+                }
+            },
+            manifest: { itemID, kind in
+                try await database.read { db in
+                    try SavedAssetManifestSyncTable
+                        .where { $0.itemID.eq(itemID) }
+                        .where { $0.kind.eq(kind.rawValue) }
+                        .fetchOne(db)
+                        .flatMap(assetManifest(from:))
+                }
+            },
+            manifests: { itemIDs in
+                try await database.read { db in
+                    try SavedAssetManifestSyncTable
+                        .where { $0.itemID.in(itemIDs) }
+                        .fetchAll(db)
+                        .compactMap(assetManifest(from:))
+                }
+            },
+            touchOpened: { itemID in
+                @Dependency(\.date.now)
+                var now
+                try await database.write { db in
+                    try upsertStorageRow(db, itemID: itemID, now: now) {
+                        $0.lastOpenedAt = #bind(now as Date?)
+                    }
+                }
+            },
+            setPinned: { itemID, isPinned in
+                @Dependency(\.date.now)
+                var now
+                try await database.write { db in
+                    try upsertStorageRow(db, itemID: itemID, now: now) {
+                        $0.isPinned = isPinned
+                    }
+                }
+            },
+            setUploadState: { itemID, state in
+                @Dependency(\.date.now)
+                var now
+                try await database.write { db in
+                    try upsertStorageRow(db, itemID: itemID, now: now) {
+                        $0.uploadState = state
+                    }
+                }
+            },
+            setOffloaded: { itemID, isOffloaded in
+                @Dependency(\.date.now)
+                var now
+                try await database.write { db in
+                    try upsertStorageRow(db, itemID: itemID, now: now) {
+                        $0.offloadedAt = #bind(isOffloaded ? now : nil as Date?)
+                    }
+                }
+            },
+            storageInfo: { itemID in
+                try await database.read { db in
+                    try storageInfos(db, itemIDs: [itemID]).first
+                }
+            },
+            storageInfosForItems: { itemIDs in
+                try await database.read { db in
+                    try storageInfos(db, itemIDs: itemIDs)
+                }
+            },
+            evictionCandidates: {
+                try await database.read { db in
+                    let readItemIDs = try SavedItemSyncTable
+                        .where(\.isRead)
+                        .where { $0.deletedAt.is(nil) }
+                        .select(\.id)
+                        .fetchAll(db)
+                    return try storageInfos(db, itemIDs: readItemIDs)
+                }
+            },
+            budgetBytes: {
+                try await database.read { db in
+                    try StoragePolicyLocalTable
+                        .find(StoragePolicyLocalTable.singletonID)
+                        .fetchOne(db)?
+                        .budgetBytes
+                }
+            },
+            setBudgetBytes: { budget in
+                @Dependency(\.date.now)
+                var now
+                try await database.write { db in
+                    try StoragePolicyLocalTable.upsert {
+                        StoragePolicyLocalTable.Draft(
+                            id: StoragePolicyLocalTable.singletonID,
+                            budgetBytes: budget,
+                            updatedAt: now
+                        )
+                    }
+                    .execute(db)
+                }
+            },
+            replaceWebsiteArchiveWithManifest: { manifest in
+                @Dependency(\.date.now)
+                var now
+                try await database.write { db in
+                    try SavedAssetManifestSyncTable
+                        .where { $0.itemID.eq(manifest.itemID) }
+                        .where { $0.kind.eq(manifest.kind.rawValue) }
+                        .delete()
+                        .execute(db)
+                    try SavedAssetManifestSyncTable.insert {
+                        SavedAssetManifestSyncTable(
+                            id: manifest.id,
+                            itemID: manifest.itemID,
+                            kind: manifest.kind.rawValue,
+                            recordName: manifest.recordName,
+                            sha256: manifest.sha256,
+                            byteCount: manifest.byteCount,
+                            originalFilename: manifest.originalFilename,
+                            createdAt: now,
+                            updatedAt: now
+                        )
+                    }
+                    .execute(db)
+                    try SavedWebsiteArchiveSyncTable
+                        .find(manifest.itemID)
+                        .delete()
+                        .execute(db)
+                    try upsertStorageRow(db, itemID: manifest.itemID, now: now) {
+                        $0.uploadState = "uploaded"
+                    }
+                }
+            },
+            pdfItemIDsWithoutManifest: {
+                try await database.read { db in
+                    let pdfItemIDs = try SavedItemContentLocalTable
+                        .where { $0.renderFormat.eq("pdf") }
+                        .select(\.itemID)
+                        .fetchAll(db)
+                    guard !pdfItemIDs.isEmpty else { return [] }
+                    let liveIDs = Set(
+                        try SavedItemSyncTable
+                            .where { $0.id.in(pdfItemIDs) }
+                            .where { $0.deletedAt.is(nil) }
+                            .select(\.id)
+                            .fetchAll(db)
+                    )
+                    let manifested = Set(
+                        try SavedAssetManifestSyncTable
+                            .where { $0.kind.eq(CloudAssetKind.pdf.rawValue) }
+                            .select(\.itemID)
+                            .fetchAll(db)
+                    )
+                    return pdfItemIDs.filter { liveIDs.contains($0) && !manifested.contains($0) }
+                }
+            },
+            websiteZipItemIDsWithoutManifest: {
+                try await database.read { db in
+                    let zipItemIDs = try SavedWebsiteArchiveSyncTable
+                        .where { $0.byteCount > 0 }
+                        .select(\.id)
+                        .fetchAll(db)
+                    guard !zipItemIDs.isEmpty else { return [] }
+                    let liveIDs = Set(
+                        try SavedItemSyncTable
+                            .where { $0.id.in(zipItemIDs) }
+                            .where { $0.deletedAt.is(nil) }
+                            .select(\.id)
+                            .fetchAll(db)
+                    )
+                    let manifested = Set(
+                        try SavedAssetManifestSyncTable
+                            .where { $0.kind.eq(CloudAssetKind.websiteZip.rawValue) }
+                            .select(\.itemID)
+                            .fetchAll(db)
+                    )
+                    return zipItemIDs.filter { liveIDs.contains($0) && !manifested.contains($0) }
+                }
+            }
+        )
+    }
+
+    private static func upsertStorageRow(
+        _ db: Database,
+        itemID: UUID,
+        now: Date,
+        update: (inout Updates<ItemStorageLocalTable>) -> Void
+    ) throws {
+        let exists = try ItemStorageLocalTable.find(itemID).fetchCount(db) > 0
+        if !exists {
+            try ItemStorageLocalTable.insert {
+                ItemStorageLocalTable(itemID: itemID, updatedAt: now)
+            }
+            .execute(db)
+        }
+        try ItemStorageLocalTable
+            .find(itemID)
+            .update {
+                update(&$0)
+                $0.updatedAt = now
+            }
+            .execute(db)
+    }
+
+    private static func storageInfos(_ db: Database, itemIDs: [UUID]) throws -> [ItemStorageInfo] {
+        guard !itemIDs.isEmpty else { return [] }
+        let items = try SavedItemSyncTable
+            .where { $0.id.in(itemIDs) }
+            .fetchAll(db)
+        let contents = try SavedItemContentLocalTable
+            .where { $0.itemID.in(itemIDs) }
+            .fetchAll(db)
+        let storageRows = try ItemStorageLocalTable
+            .where { $0.itemID.in(itemIDs) }
+            .fetchAll(db)
+        let manifestRows = try SavedAssetManifestSyncTable
+            .where { $0.itemID.in(itemIDs) }
+            .fetchAll(db)
+        let captureItemIDs = Set(
+            try SavedArticleCaptureSyncTable
+                .where { $0.itemID.in(itemIDs) }
+                .select(\.itemID)
+                .fetchAll(db)
+        )
+
+        let contentByID = Dictionary(uniqueKeysWithValues: contents.map { ($0.itemID, $0) })
+        let storageByID = Dictionary(uniqueKeysWithValues: storageRows.map { ($0.itemID, $0) })
+        let manifestsByID = Dictionary(grouping: manifestRows.compactMap(assetManifest(from:)), by: \.itemID)
+
+        return items.map { item in
+            let storage = storageByID[item.id]
+            return ItemStorageInfo(
+                itemID: item.id,
+                renderFormat: contentByID[item.id]?.renderFormat ?? "structuredV1",
+                isRead: item.isRead,
+                isPinned: storage?.isPinned ?? false,
+                lastOpenedAt: storage?.lastOpenedAt,
+                uploadState: storage?.uploadState ?? "pending",
+                offloadedAt: storage?.offloadedAt,
+                hasCaptureManifest: captureItemIDs.contains(item.id),
+                assetManifests: manifestsByID[item.id] ?? []
+            )
+        }
+    }
+
+    private static func assetManifest(from row: SavedAssetManifestSyncTable) -> AssetManifest? {
+        guard let kind = CloudAssetKind(rawValue: row.kind) else { return nil }
+        return AssetManifest(
+            id: row.id,
+            itemID: row.itemID,
+            kind: kind,
+            recordName: row.recordName,
+            sha256: row.sha256,
+            byteCount: row.byteCount,
+            originalFilename: row.originalFilename
+        )
+    }
+}
+
+// MARK: - Dependency Key
+
+private enum ItemStorageClientKey: DependencyKey {
+    static let liveValue: ItemStorageClient = .noop
+    static let testValue: ItemStorageClient = .noop
+}
+
+extension DependencyValues {
+    public var itemStorageClient: ItemStorageClient {
+        get { self[ItemStorageClientKey.self] }
+        set { self[ItemStorageClientKey.self] = newValue }
+    }
+}

--- a/StowerPackage/Sources/StowerData/Data/StorageMaintenanceClient.swift
+++ b/StowerPackage/Sources/StowerData/Data/StorageMaintenanceClient.swift
@@ -256,6 +256,16 @@ extension StorageMaintenanceClient {
             return count
         }
         try sweep(
+            tableName: SavedAssetManifestSyncTable.tableName,
+            currentOrphanIDs: Set(try SavedAssetManifestSyncTable.select(\.itemID).fetchAll(db))
+                .subtracting(liveItemIDs)
+        ) { ripe in
+            let count = try SavedAssetManifestSyncTable.where { $0.itemID.in(ripe) }.fetchCount(db)
+            try SavedAssetManifestSyncTable.where { $0.itemID.in(ripe) }.delete().execute(db)
+            try ItemStorageLocalTable.where { $0.itemID.in(ripe) }.delete().execute(db)
+            return count
+        }
+        try sweep(
             tableName: SavedArticleCaptureSyncTable.tableName,
             currentOrphanIDs: Set(try SavedArticleCaptureSyncTable.select(\.itemID).fetchAll(db))
                 .subtracting(liveItemIDs)

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Filters.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Filters.swift
@@ -198,6 +198,8 @@ extension StowerRepository {
                 try SavedWebsiteArchiveSyncTable.find(id).delete().execute(db)
                 try SavedPDFContentSyncTable.find(id).delete().execute(db)
                 try SavedTextContentSyncTable.find(id).delete().execute(db)
+                try SavedAssetManifestSyncTable.where { $0.itemID.eq(id) }.delete().execute(db)
+                try ItemStorageLocalTable.find(id).delete().execute(db)
                 try SavedItemSyncTable.find(id).delete().execute(db)
             }
             scheduleSync()
@@ -230,6 +232,8 @@ extension StowerRepository {
                     try SavedWebsiteArchiveSyncTable.where { $0.id.in(ids) }.delete().execute(db)
                     try SavedPDFContentSyncTable.where { $0.id.in(ids) }.delete().execute(db)
                     try SavedTextContentSyncTable.where { $0.id.in(ids) }.delete().execute(db)
+                    try SavedAssetManifestSyncTable.where { $0.itemID.in(ids) }.delete().execute(db)
+                    try ItemStorageLocalTable.where { $0.itemID.in(ids) }.delete().execute(db)
                     try SavedItemSyncTable.where { $0.id.in(ids) }.delete().execute(db)
                 }
                 return ids

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Jobs.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Jobs.swift
@@ -589,7 +589,8 @@ private extension IngestionJob.Kind {
     /// those still enqueue unconditionally.
     var isDeduplicated: Bool {
         switch self {
-        case .hydrate, .hydrateText, .hydrateWebsite, .url:
+        case .hydrate, .hydrateText, .hydrateWebsite, .url,
+             .uploadAsset, .downloadAsset, .migrateWebsiteAsset:
             true
         case .pdf, .website, .text, .markdown:
             false

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Website.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Website.swift
@@ -80,6 +80,13 @@ extension StowerRepository {
                     // Only enqueue when the item exists and the local archive is missing.
                     guard try SavedItemSyncTable.find(row.id).fetchOne(db) != nil else { continue }
                     if archiveExists(row.id) { continue }
+                    // An offloaded item's archive is missing *on purpose* —
+                    // auto-rehydrating it would undo the offload every sync.
+                    let offloaded = try ItemStorageLocalTable
+                        .find(row.id)
+                        .fetchOne(db)?
+                        .offloadedAt != nil
+                    if offloaded { continue }
 
                     let payload = try String(
                         bytes: JSONEncoder().encode(WebsiteHydrationPayload(itemID: row.id)),

--- a/StowerPackage/Sources/StowerData/Data/Tables.swift
+++ b/StowerPackage/Sources/StowerData/Data/Tables.swift
@@ -276,6 +276,55 @@ nonisolated public struct IngestionJobLocalTable: Hashable, Identifiable, Sendab
     public var lastError: String?
 }
 
+/// CloudKit-synced manifest for a heavy payload stored in the app-managed
+/// asset zone (`StowerAssetZone`) rather than in a sync-table BLOB column.
+/// Only this small row replicates through the SyncEngine; the bytes live in
+/// a `StowerAsset` CKRecord the app uploads and downloads directly, which is
+/// what lets a device delete its local copy without deleting the iCloud copy.
+@Table
+nonisolated public struct SavedAssetManifestSyncTable: Hashable, Identifiable, Sendable {
+    public let id: UUID
+    public var itemID: UUID
+    /// `CloudAssetKind` raw value: `pdf` or `websiteZip`.
+    public var kind: String = ""
+    /// CKRecord name in the asset zone, derived from itemID + sha256.
+    public var recordName: String = ""
+    public var sha256: String = ""
+    public var byteCount: Int = 0
+    public var originalFilename: String = ""
+    public var createdAt: Date = .now
+    public var updatedAt: Date = .now
+}
+
+/// Local-only, per-device storage state for an item: pinning, last-open
+/// recency for LRU eviction, and upload/offload bookkeeping. Deliberately
+/// not synced — "keep this downloaded" is a per-device decision.
+@Table
+nonisolated public struct ItemStorageLocalTable: Hashable, Identifiable, Sendable {
+    @Column(primaryKey: true)
+    public let itemID: UUID
+    public var isPinned: Bool = false
+    public var lastOpenedAt: Date?
+    /// `pending` until the asset upload is confirmed in CloudKit, then
+    /// `uploaded`; `failed` marks the item ineligible for eviction.
+    public var uploadState: String = "pending"
+    public var offloadedAt: Date?
+    public var updatedAt: Date = .now
+
+    public var id: UUID { itemID }
+}
+
+/// Local-only, single-row automatic-offload policy.
+@Table
+nonisolated public struct StoragePolicyLocalTable: Hashable, Identifiable, Sendable {
+    public let id: UUID
+    /// nil disables automatic eviction.
+    public var budgetBytes: Int?
+    public var updatedAt: Date = .now
+
+    public static let singletonID = UUID(uuidString: "F05339A1-0000-0000-0000-000000000001")!
+}
+
 /// Local-only quarantine for content sync rows whose item row is missing.
 /// During initial CloudKit sync, content rows can arrive before their
 /// `SavedItemSyncTable` row, so an immediate delete would destroy the master

--- a/StowerPackage/Sources/StowerData/Domain/Models.swift
+++ b/StowerPackage/Sources/StowerData/Domain/Models.swift
@@ -394,6 +394,9 @@ public struct IngestionJob: Equatable, Identifiable, Sendable {
         case pdf = "pdf"
         case website = "website"
         case hydrateWebsite = "hydrateWebsite"
+        case uploadAsset = "uploadAsset"
+        case downloadAsset = "downloadAsset"
+        case migrateWebsiteAsset = "migrateWebsiteAsset"
     }
 
     public let id: UUID
@@ -455,5 +458,71 @@ public struct WebsiteHydrationPayload: Codable, Equatable, Sendable {
 
     public init(itemID: UUID) {
         self.itemID = itemID
+    }
+}
+
+/// Payload kinds stored in the app-managed CloudKit asset zone.
+public enum CloudAssetKind: String, Codable, CaseIterable, Sendable {
+    /// The original `document.pdf` bytes of a PDF item.
+    case pdf = "pdf"
+    /// The original imported `.zip` of a user-imported website.
+    case websiteZip = "websiteZip"
+}
+
+/// Payload for `uploadAsset` / `downloadAsset` / `migrateWebsiteAsset` jobs.
+public struct AssetJobPayload: Codable, Equatable, Sendable {
+    public var itemID: UUID
+    public var kind: CloudAssetKind
+    /// Carried through upload jobs so the manifest can preserve the name the
+    /// user's file had at import time.
+    public var originalFilename: String?
+
+    public init(itemID: UUID, kind: CloudAssetKind, originalFilename: String? = nil) {
+        self.itemID = itemID
+        self.kind = kind
+        self.originalFilename = originalFilename
+    }
+
+    public func encoded() throws -> String {
+        String(bytes: try JSONEncoder().encode(self), encoding: .utf8) ?? ""
+    }
+
+    public static func decoded(from payload: String) throws -> Self {
+        try JSONDecoder().decode(Self.self, from: Data(payload.utf8))
+    }
+}
+
+/// Domain view of a `SavedAssetManifestSyncTable` row.
+public struct AssetManifest: Equatable, Sendable, Identifiable {
+    public var id: UUID
+    public var itemID: UUID
+    public var kind: CloudAssetKind
+    public var recordName: String
+    public var sha256: String
+    public var byteCount: Int
+    public var originalFilename: String
+
+    public init(
+        id: UUID,
+        itemID: UUID,
+        kind: CloudAssetKind,
+        recordName: String,
+        sha256: String,
+        byteCount: Int,
+        originalFilename: String
+    ) {
+        self.id = id
+        self.itemID = itemID
+        self.kind = kind
+        self.recordName = recordName
+        self.sha256 = sha256
+        self.byteCount = byteCount
+        self.originalFilename = originalFilename
+    }
+
+    /// Deterministic record name: two devices holding identical content
+    /// produce the same record, making concurrent uploads conflict-free.
+    public static func makeRecordName(kind: CloudAssetKind, itemID: UUID, sha256: String) -> String {
+        "asset-\(kind.rawValue)-\(itemID.uuidString)-\(String(sha256.prefix(16)))"
     }
 }

--- a/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
@@ -151,6 +151,10 @@ public struct AppFeature {
     var ingestionCoordinator
     @Dependency(\.storageUsageClient)
     var storageUsageClient
+    @Dependency(\.itemStorageClient)
+    var itemStorageClient
+    @Dependency(\.cloudAssetClient)
+    var cloudAssetClient
     @Dependency(\.context)
     var context
 
@@ -179,6 +183,7 @@ public struct AppFeature {
                 let date = self.date
                 let ingestionCoordinator = self.ingestionCoordinator
                 let storageUsageClient = self.storageUsageClient
+                let openReaderItemID = state.reader?.itemID
                 let clock = self.clock
                 let periodicSync: EffectOf<Self> =
                     context == .live
@@ -214,9 +219,20 @@ public struct AppFeature {
                     // Sidebar subscription: loads counts + tags and listens for changes.
                     .send(.sidebar(.onAppear)),
                     // Purge expired trash items (fire-and-forget).
-                    .run { _ in
+                    .run { [itemStorageClient, cloudAssetClient] _ in
+                        // Snapshot trash manifests first: the purge deletes the
+                        // manifest rows, and the CloudKit asset records can
+                        // only be cleaned up by record name.
+                        let trashedIDs = (try? await repository.fetchLibrary(.recentlyDeleted))?.map(\.id) ?? []
+                        let manifestsByItem = Dictionary(
+                            grouping: (try? await itemStorageClient.manifests(trashedIDs)) ?? [],
+                            by: \.itemID
+                        )
                         for itemID in (try? await repository.purgeOldTrash()) ?? [] {
                             AssetArchiver.deleteArchive(for: itemID)
+                            for manifest in manifestsByItem[itemID] ?? [] {
+                                try? await cloudAssetClient.delete(manifest.recordName)
+                            }
                         }
                     },
                     .run { send in
@@ -259,6 +275,25 @@ public struct AppFeature {
                                 _ = try? await storageUsageClient.runMaintenance(.periodic)
                                 defaults.set(date.now, forKey: "lastStorageMaintenanceDate")
                             }
+                            // Cloud-asset backfill: upload PDFs that predate
+                            // the asset store and (past the gate date) migrate
+                            // legacy website zips; then run the budget-based
+                            // eviction pass. All idempotent and cheap when
+                            // there is nothing to do.
+                            if (try? await CloudAssetService.enqueueBackfillJobs(repository: repository)) ?? 0 > 0 {
+                                try? await ingestionCoordinator.run {
+                                    try await processIngestionJobs(
+                                        repository: repository,
+                                        ingestionClient: ingestionClient,
+                                        pdfIngestionClient: pdfIngestionClient,
+                                        textIngestionClient: textIngestionClient
+                                    ) { date.now }
+                                }
+                            }
+                            _ = try? await StorageOffloadService.runEviction(
+                                repository: repository,
+                                excluding: Set([openReaderItemID].compactMap(\.self))
+                            )
                         } catch where error.isDatabaseSuspension {
                             // Backgrounded mid-startup. Not a failure worth
                             // reporting — startup re-runs on the next
@@ -518,7 +553,11 @@ public struct AppFeature {
                     item: item,
                     appearance: state.cachedAppearance
                 )
-                return .none
+                // Recency stamp drives least-recently-opened eviction order.
+                let itemStorageClient = self.itemStorageClient
+                return .run { _ in
+                    try? await itemStorageClient.touchOpened(item.id)
+                }
 
             case .reader(.presented(.backgroundChanged(let bg))):
                 state.cachedAppearance.background = bg
@@ -664,6 +703,13 @@ private func processIngestionJob(
                 let result = try await pdfIngestionClient.ingest(pdfURL)
                 let item = try await repository.createItemFromIngestion(result)
                 try? PDFArchiver.archivePDF(from: pdfURL, itemID: item.id)
+                if let payload = try? AssetJobPayload(
+                    itemID: item.id,
+                    kind: .pdf,
+                    originalFilename: pdfURL.lastPathComponent
+                ).encoded() {
+                    try? await repository.enqueueIngestionJob(.uploadAsset, payload)
+                }
                 try? FileManager.default.removeItem(at: scratchDir)
             } catch {
                 let fallback = pdfURL.deletingPathExtension().lastPathComponent
@@ -743,6 +789,18 @@ private func processIngestionJob(
                 )
                 try? FileManager.default.removeItem(at: scratchDir)
             }
+        case .uploadAsset:
+            let payload = try AssetJobPayload.decoded(from: job.payload)
+            try await CloudAssetService.upload(payload: payload)
+        case .downloadAsset:
+            let payload = try AssetJobPayload.decoded(from: job.payload)
+            try await CloudAssetService.restore(itemID: payload.itemID, repository: repository)
+        case .migrateWebsiteAsset:
+            let payload = try AssetJobPayload.decoded(from: job.payload)
+            try await CloudAssetService.migrateWebsiteZip(
+                itemID: payload.itemID,
+                repository: repository
+            )
         case .hydrateWebsite:
             // Receive-side: the website archive arrived via CloudKit sync but
             // the site isn't unpacked locally yet. Pull the zip bytes out of

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryFeature.swift
@@ -25,6 +25,9 @@ public struct LibraryFeature {
         public var inlineTagCreation: InlineTagCreation?
         /// Draft for the in-app text/markdown composer.
         public var textImportDraft: TextImportDraft?
+        /// Per-item offload/pin state, refreshed alongside the item list.
+        /// Drives the download-management context menu and the cloud badge.
+        public var storageInfoByID = [UUID: ItemStorageInfo]()
 
         /// Library search matches against title, URL, site name, author,
         /// excerpt, AND full body text (`item.content`). The body-text
@@ -129,6 +132,12 @@ public struct LibraryFeature {
         case saveURLFailed(String)
         case importPDFSelected(URL)
         case importWebsiteSelected(URL)
+
+        // Download management (offload)
+        case storageInfoLoaded([UUID: ItemStorageInfo])
+        case setPinned(UUID, Bool)
+        case removeDownload(UUID)
+        case downloadNow(UUID)
         case addTextTapped
         case textImportDismissed
         case textImportTitleChanged(String)
@@ -170,6 +179,10 @@ public struct LibraryFeature {
     var pdfIngestionClient
     @Dependency(\.textIngestionClient)
     var textIngestionClient
+    @Dependency(\.itemStorageClient)
+    var itemStorageClient
+    @Dependency(\.cloudAssetClient)
+    var cloudAssetClient
 
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -330,7 +343,51 @@ public struct LibraryFeature {
             case .response(let items):
                 state.isLoading = false
                 state.items = items
+                let itemStorageClient = self.itemStorageClient
+                return .run { [ids = items.map(\.id)] send in
+                    var infos = [UUID: ItemStorageInfo]()
+                    for info in (try? await itemStorageClient.storageInfosForItems(ids)) ?? [] {
+                        infos[info.itemID] = info
+                    }
+                    await send(.storageInfoLoaded(infos))
+                }
+
+            case .storageInfoLoaded(let infos):
+                state.storageInfoByID = infos
                 return .none
+
+            case let .setPinned(id, isPinned):
+                state.storageInfoByID[id]?.isPinned = isPinned
+                let itemStorageClient = self.itemStorageClient
+                return .run { _ in
+                    try? await itemStorageClient.setPinned(id, isPinned)
+                }
+
+            case .removeDownload(let id):
+                state.storageInfoByID[id]?.offloadedAt = .distantPast
+                let repository = self.repository
+                return .run { send in
+                    do {
+                        try await StorageOffloadService.offload(itemID: id, repository: repository)
+                    } catch {
+                        await send(.failed(error.localizedDescription))
+                    }
+                    await send(.reload)
+                }
+
+            case .downloadNow(let id):
+                if let index = state.items.firstIndex(where: { $0.id == id }) {
+                    state.items[index].processingState = .extracting
+                }
+                let repository = self.repository
+                return .run { send in
+                    do {
+                        try await CloudAssetService.restore(itemID: id, repository: repository)
+                    } catch {
+                        await send(.failed(error.localizedDescription))
+                    }
+                    await send(.reload)
+                }
 
             case .failed(let error):
                 state.isLoading = false
@@ -559,6 +616,13 @@ public struct LibraryFeature {
                         let result = try await pdfIngestionClient.ingest(pickedURL)
                         let item = try await repository.createItemFromIngestion(result)
                         try? PDFArchiver.archivePDF(from: pickedURL, itemID: item.id)
+                        if let payload = try? AssetJobPayload(
+                            itemID: item.id,
+                            kind: .pdf,
+                            originalFilename: pickedURL.lastPathComponent
+                        ).encoded() {
+                            try? await repository.enqueueIngestionJob(.uploadAsset, payload)
+                        }
                         await send(.saveURLFinished(item))
                         await send(.openItem(item))
                     } catch {
@@ -617,11 +681,21 @@ public struct LibraryFeature {
             case .permanentlyDelete(let id):
                 state.items.removeAll { $0.id == id }
                 let repository = self.repository
+                let itemStorageClient = self.itemStorageClient
+                let cloudAssetClient = self.cloudAssetClient
                 return .run { send in
                     do {
+                        // Capture asset record names before the delete removes
+                        // the manifest rows, then clean up the CloudKit copies
+                        // best-effort — a failure here only leaves an orphaned
+                        // record in the user's own private zone.
+                        let manifests = (try? await itemStorageClient.manifests([id])) ?? []
                         try await repository.permanentlyDelete(id)
                         AssetArchiver.deleteArchive(for: id)
                         PDFArchiver.deletePDF(for: id)
+                        for manifest in manifests {
+                            try? await cloudAssetClient.delete(manifest.recordName)
+                        }
                         await send(.deleteFinished)
                     } catch {
                         await send(.deleteFailed(error.localizedDescription))

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryItemRow.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryItemRow.swift
@@ -5,6 +5,7 @@ struct LibraryItemRow: View {
     let query: String
     let tags: [Tag]
     let displayStyle: LibraryDisplayStyle
+    var isOffloaded = false
 
     @Environment(\.flexokiPalette)
     private var palette
@@ -30,6 +31,13 @@ struct LibraryItemRow: View {
                         Image(systemName: "star.fill")
                             .foregroundStyle(palette.warning)
                             .accessibilityLabel("Starred")
+                    }
+
+                    if isOffloaded {
+                        Image(systemName: "icloud.and.arrow.down")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .accessibilityLabel("Stored in iCloud")
                     }
 
                     processingIndicator

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Library/LibraryScreen.swift
@@ -66,7 +66,8 @@ public struct LibraryScreen: View {
                         item: item,
                         query: store.query,
                         tags: resolvedTags(for: item),
-                        displayStyle: store.displayStyle
+                        displayStyle: store.displayStyle,
+                        isOffloaded: store.storageInfoByID[item.id]?.offloadedAt != nil
                     )
                 }
                 .buttonStyle(.plain)
@@ -147,6 +148,7 @@ public struct LibraryScreen: View {
                             store.send(.toggleRead(item.id))
                         }
                         tagsSubmenu(for: item)
+                        downloadManagementMenuItems(for: item)
                         Button("Refresh Reader View") {
                             store.send(.reprocessItem(item.id))
                         }
@@ -790,6 +792,41 @@ public struct LibraryScreen: View {
             }
         } label: {
             Label("Tags", systemImage: "tag")
+        }
+    }
+
+    // MARK: - Download Management
+
+    /// Context-menu entries for items whose heavy content can live in
+    /// iCloud: PDFs, website imports, and interactive captures. Regular
+    /// articles get no entries — their content always stays local.
+    @ViewBuilder
+    private func downloadManagementMenuItems(for item: SavedItem) -> some View {
+        if let info = store.storageInfoByID[item.id] {
+            if info.offloadedAt != nil {
+                Button {
+                    store.send(.downloadNow(item.id))
+                } label: {
+                    Label("Download Now", systemImage: "icloud.and.arrow.down")
+                }
+            } else if StorageOffloadService.canOffload(info) {
+                Button {
+                    store.send(.removeDownload(item.id))
+                } label: {
+                    Label("Remove Download", systemImage: "xmark.icloud")
+                }
+            }
+            if info.offloadedAt != nil || StorageOffloadService.canOffload(info) || info.isPinned {
+                Button {
+                    store.send(.setPinned(item.id, !info.isPinned))
+                } label: {
+                    if info.isPinned {
+                        Label("Keep Downloaded", systemImage: "checkmark")
+                    } else {
+                        Text("Keep Downloaded")
+                    }
+                }
+            }
         }
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderFeature.swift
@@ -19,6 +19,9 @@ public struct ReaderFeature {
         var ai = ReaderAIFeature.State()
         public var isLoading = false
         public var errorMessage: String?
+        /// Non-idle while an offloaded item's content is being restored from
+        /// iCloud (or reinstalled from local capture chunks).
+        public var offloadRestore: OffloadRestoreState = .idle
         @Presents public var inlineEmbedURL: InlineEmbedFeature.State?
         public var textEditor: TextEditorState?
 
@@ -116,10 +119,18 @@ public struct ReaderFeature {
         }
     }
 
+    public enum OffloadRestoreState: Equatable, Sendable {
+        case idle
+        case restoring
+        case failed(String)
+    }
+
     public enum Action: Equatable {
         case load
         case loaded(SavedItem?, ReaderDocument?, String?)
         case failed(String)
+        case restoreOffloadedContent
+        case offloadRestoreFinished(String?)
 
         case speech(ReaderSpeechFeature.Action)
         case ai(ReaderAIFeature.Action)
@@ -178,6 +189,23 @@ public struct ReaderFeature {
         case readingProgressSave
         case progressPoll
         case articleRefresh
+        case offloadRestore
+    }
+
+    /// True when the item's heavy local files were offloaded (or lost) and
+    /// must be restored before it can render properly.
+    static func needsOffloadRestore(_ item: SavedItem) -> Bool {
+        switch item.renderFormat {
+        case .pdf:
+            return !PDFArchiver.pdfExists(for: item.id)
+        case .webView:
+            if item.captureVersion > 0 {
+                return ArticleCapturePackage.archiveURL(for: item.id, original: true) == nil
+            }
+            return !AssetArchiver.archiveExists(for: item.id)
+        default:
+            return false
+        }
     }
 
     @Dependency(\.stowerRepository)
@@ -258,8 +286,37 @@ public struct ReaderFeature {
                     archiveIfNeeded(item: state.item, sourceHTML: sourceHTML),
                     startProgressPollingEffect(),
                     .send(.ai(.appeared(itemID: state.itemID))),
-                    .send(.loadDisplayPreference)
+                    .send(.loadDisplayPreference),
+                    .send(.restoreOffloadedContent)
                 )
+
+            case .restoreOffloadedContent:
+                guard let item = state.item,
+                      state.offloadRestore != .restoring,
+                      Self.needsOffloadRestore(item)
+                else { return .none }
+                state.offloadRestore = .restoring
+                let repository = self.repository
+                return .run { [itemID = item.id] send in
+                    do {
+                        try await CloudAssetService.restore(itemID: itemID, repository: repository)
+                        await send(.offloadRestoreFinished(nil))
+                    } catch {
+                        await send(.offloadRestoreFinished(error.localizedDescription))
+                    }
+                }
+                .cancellable(id: CancelID.offloadRestore, cancelInFlight: true)
+
+            case .offloadRestoreFinished(let message):
+                if let message {
+                    state.offloadRestore = .failed(message)
+                    return .none
+                }
+                state.offloadRestore = .idle
+                // Force a clean reload so the restored files are picked up.
+                state.document = nil
+                state.sourceHTML = nil
+                return .send(.load)
 
             case .failed(let error):
                 state.isLoading = false

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Reader/ReaderScreen.swift
@@ -387,7 +387,29 @@ public struct ReaderScreen: View {
     // MARK: - Content
 
     @ViewBuilder private var content: some View {
-        if let item = store.item, hasRenderableContent(for: item) {
+        if store.offloadRestore == .restoring {
+            VStack(spacing: 12) {
+                ProgressView()
+                Text("Downloading from iCloud…")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if case .failed(let message) = store.offloadRestore {
+            VStack(spacing: 12) {
+                Image(systemName: "icloud.slash")
+                    .font(.largeTitle)
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+                CopyableText(text: message, font: .callout)
+                Button("Try Again") {
+                    store.send(.restoreOffloadedContent)
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let item = store.item, hasRenderableContent(for: item) {
             VStack(spacing: 0) {
                 if item.processingState == .partial {
                     partialCaptureBanner(for: item)

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Settings/StorageFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Settings/StorageFeature.swift
@@ -24,6 +24,10 @@ public struct StorageFeature {
         public var isComputing = false
         public var maintenance: MaintenanceState = .idle
         public var errorMessage: String?
+        /// Automatic-offload budget; nil disables the eviction pass.
+        public var budgetBytes: Int?
+        public var isOffloading = false
+        public var lastOffloadReport: StorageOffloadService.EvictionReport?
 
         public init() {}
     }
@@ -36,10 +40,19 @@ public struct StorageFeature {
         case reclaimTapped
         case maintenanceFinished(MaintenanceReport)
         case maintenanceFailed(String)
+        case budgetLoaded(Int?)
+        case budgetChanged(Int?)
+        case offloadNowTapped
+        case offloadFinished(StorageOffloadService.EvictionReport)
+        case offloadFailed(String)
     }
 
     @Dependency(\.storageUsageClient)
     var storageUsageClient
+    @Dependency(\.itemStorageClient)
+    var itemStorageClient
+    @Dependency(\.stowerRepository)
+    var repository
 
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -47,7 +60,72 @@ public struct StorageFeature {
             case .task:
                 guard !state.isComputing else { return .none }
                 state.isComputing = true
-                return loadSnapshot(force: false)
+                let storageUsageClient = self.storageUsageClient
+                let itemStorageClient = self.itemStorageClient
+                return .run { send in
+                    var budget: Int?
+                    if let loaded = try? await itemStorageClient.budgetBytes() {
+                        budget = loaded
+                    }
+                    await send(.budgetLoaded(budget))
+                    do {
+                        let snapshot = try await storageUsageClient.computeSnapshot(false)
+                        await send(.snapshotLoaded(snapshot))
+                    } catch {
+                        await send(.snapshotFailed(error.localizedDescription))
+                    }
+                }
+                .cancellable(id: CancelID.snapshot, cancelInFlight: true)
+
+            case .budgetLoaded(let budget):
+                state.budgetBytes = budget
+                return .none
+
+            case .budgetChanged(let budget):
+                state.budgetBytes = budget
+                let itemStorageClient = self.itemStorageClient
+                let repository = self.repository
+                return .run { send in
+                    try? await itemStorageClient.setBudgetBytes(budget)
+                    guard budget != nil else { return }
+                    do {
+                        let report = try await StorageOffloadService.runEviction(repository: repository)
+                        if report.evictedCount > 0 {
+                            await send(.offloadFinished(report))
+                        }
+                    } catch {
+                        await send(.offloadFailed(error.localizedDescription))
+                    }
+                }
+
+            case .offloadNowTapped:
+                guard !state.isOffloading else { return .none }
+                state.isOffloading = true
+                state.errorMessage = nil
+                let repository = self.repository
+                return .run { send in
+                    do {
+                        // Budget 0 evicts every eligible read item.
+                        let report = try await StorageOffloadService.runEviction(
+                            repository: repository,
+                            budgetOverride: 0
+                        )
+                        await send(.offloadFinished(report))
+                    } catch {
+                        await send(.offloadFailed(error.localizedDescription))
+                    }
+                }
+
+            case .offloadFinished(let report):
+                state.isOffloading = false
+                state.lastOffloadReport = report
+                state.isComputing = true
+                return loadSnapshot(force: true)
+
+            case .offloadFailed(let message):
+                state.isOffloading = false
+                state.errorMessage = message
+                return .none
 
             case .refresh:
                 guard !state.isComputing else { return .none }

--- a/StowerPackage/Sources/StowerFeatureV2/Features/Settings/StorageSectionView.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Features/Settings/StorageSectionView.swift
@@ -39,6 +39,8 @@ struct StorageSectionView: View {
 
             reclaimRows
 
+            offloadRows
+
             if let error = store.errorMessage {
                 CopyableText(text: error, font: .caption, textColor: palette.error)
             }
@@ -132,6 +134,47 @@ struct StorageSectionView: View {
             Button("Try Again") {
                 store.send(.reclaimTapped)
             }
+        }
+    }
+
+    /// Budget choices for automatic offload. `nil` disables it.
+    private static let budgetChoices: [(label: String, bytes: Int?)] = [
+        ("Off", nil),
+        ("1 GB", 1 << 30),
+        ("5 GB", 5 << 30),
+        ("10 GB", 10 << 30),
+        ("20 GB", 20 << 30),
+    ]
+
+    @ViewBuilder private var offloadRows: some View {
+        Picker("Storage Limit", selection: Binding(
+            get: { store.budgetBytes },
+            set: { store.send(.budgetChanged($0)) }
+        )) {
+            ForEach(Self.budgetChoices, id: \.bytes) { choice in
+                Text(choice.label).tag(choice.bytes)
+            }
+        }
+
+        if store.isOffloading {
+            ProgressView {
+                Text("Offloading read items…")
+                    .font(.callout)
+            }
+        } else {
+            Button("Offload Read Items") {
+                store.send(.offloadNowTapped)
+            }
+        }
+
+        if let report = store.lastOffloadReport {
+            Text(
+                report.evictedCount == 0
+                    ? "Nothing eligible to offload."
+                    : "Offloaded \(report.evictedCount) item\(report.evictedCount == 1 ? "" : "s"), freeing \(Self.format(report.freedBytes))."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
         }
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Support/CloudAssetService.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/CloudAssetService.swift
@@ -1,0 +1,320 @@
+import Dependencies
+import Foundation
+import OSLog
+import PDFKit
+import StowerData
+
+private let kAssetServiceLogger = Logger(subsystem: "com.ryanleewilliams.stower", category: "CloudAssetService")
+
+public enum CloudAssetServiceError: Error, Equatable, LocalizedError {
+    case missingLocalFile
+    case missingManifest
+    case integrityFailure
+    case unreadablePDF
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingLocalFile:
+            "The file to upload no longer exists on this device."
+        case .missingManifest:
+            "This item has no copy stored in iCloud yet."
+        case .integrityFailure:
+            "The downloaded file was incomplete. It will be retried."
+        case .unreadablePDF:
+            "The downloaded PDF could not be opened."
+        }
+    }
+}
+
+/// Upload, download, and migration flows for the app-managed CloudKit asset
+/// store. This is the only place that composes `CloudAssetClient` (CloudKit),
+/// `ItemStorageClient` (SQLite state), and the on-disk archivers.
+public enum CloudAssetService {
+    /// Where a freshly imported website zip waits for its upload job. Deleted
+    /// once the upload is confirmed; offload is blocked until then.
+    static func pendingUploadZipURL(for itemID: UUID) -> URL {
+        AssetArchiver.archiveDirectory(for: itemID)
+            .appendingPathComponent("pending-upload.zip")
+    }
+
+    // MARK: Upload
+
+    /// Uploads an item's heavy payload and records the synced manifest.
+    /// Idempotent: record names are content-addressed and re-upserting the
+    /// manifest replaces the previous row for (item, kind).
+    public static func upload(payload: AssetJobPayload) async throws {
+        @Dependency(\.cloudAssetClient)
+        var cloudAssetClient
+        @Dependency(\.itemStorageClient)
+        var itemStorageClient
+        @Dependency(\.cloudSyncClient)
+        var cloudSyncClient
+        @Dependency(\.uuid)
+        var uuid
+
+        let fileURL: URL
+        var cleanupAfterUpload: URL?
+        switch payload.kind {
+        case .pdf:
+            fileURL = PDFArchiver.pdfURL(for: payload.itemID)
+        case .websiteZip:
+            fileURL = pendingUploadZipURL(for: payload.itemID)
+            cleanupAfterUpload = fileURL
+        }
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            // The local source is gone (e.g. re-installed device). Mark the
+            // state so eviction stays blocked, then surface the failure.
+            try? await itemStorageClient.setUploadState(payload.itemID, "failed")
+            throw CloudAssetServiceError.missingLocalFile
+        }
+
+        let data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
+        let sha256 = ArticleCapturePackage.sha256(data)
+        let manifest = AssetManifest(
+            id: uuid(),
+            itemID: payload.itemID,
+            kind: payload.kind,
+            recordName: AssetManifest.makeRecordName(
+                kind: payload.kind,
+                itemID: payload.itemID,
+                sha256: sha256
+            ),
+            sha256: sha256,
+            byteCount: data.count,
+            originalFilename: payload.originalFilename
+                ?? fileURL.lastPathComponent
+        )
+
+        do {
+            try await cloudAssetClient.upload(manifest, fileURL)
+            guard try await cloudAssetClient.exists(manifest.recordName) else {
+                throw CloudAssetError.transient("Upload not visible after save")
+            }
+        } catch {
+            if case CloudAssetError.quotaExceeded = error {
+                try? await itemStorageClient.setUploadState(payload.itemID, "failed")
+            }
+            throw error
+        }
+
+        try await itemStorageClient.upsertManifest(manifest)
+        try await itemStorageClient.setUploadState(payload.itemID, "uploaded")
+        if let cleanupAfterUpload {
+            try? FileManager.default.removeItem(at: cleanupAfterUpload)
+        }
+        await cloudSyncClient.scheduleSendChanges()
+        kAssetServiceLogger.info("Uploaded \(manifest.recordName, privacy: .public) (\(manifest.byteCount) bytes)")
+    }
+
+    // MARK: Migration
+
+    /// Moves one legacy website zip out of the SyncEngine BLOB table into the
+    /// asset store. Strictly upload → verify → replace: the `zipData` row is
+    /// only deleted (which propagates to CloudKit) after the asset record is
+    /// confirmed to exist.
+    public static func migrateWebsiteZip(itemID: UUID, repository: StowerRepository) async throws {
+        @Dependency(\.cloudAssetClient)
+        var cloudAssetClient
+        @Dependency(\.itemStorageClient)
+        var itemStorageClient
+        @Dependency(\.cloudSyncClient)
+        var cloudSyncClient
+        @Dependency(\.uuid)
+        var uuid
+
+        guard let archive = try await repository.loadWebsiteArchive(itemID) else {
+            // Nothing to migrate (already migrated, or the row never finished
+            // syncing to this device). Not an error.
+            return
+        }
+
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("StowerAssetMigration-\(uuid().uuidString).zip")
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        try archive.zipData.write(to: scratch, options: .atomic)
+
+        let sha256 = archive.sha256.isEmpty
+            ? ArticleCapturePackage.sha256(archive.zipData)
+            : archive.sha256
+        let manifest = AssetManifest(
+            id: uuid(),
+            itemID: itemID,
+            kind: .websiteZip,
+            recordName: AssetManifest.makeRecordName(
+                kind: .websiteZip,
+                itemID: itemID,
+                sha256: sha256
+            ),
+            sha256: sha256,
+            byteCount: archive.zipData.count,
+            originalFilename: archive.originalFilename
+        )
+
+        try await cloudAssetClient.upload(manifest, scratch)
+        guard try await cloudAssetClient.exists(manifest.recordName) else {
+            throw CloudAssetError.transient("Upload not visible after save")
+        }
+        try await itemStorageClient.replaceWebsiteArchiveWithManifest(manifest)
+        await cloudSyncClient.scheduleSendChanges()
+        kAssetServiceLogger.info("Migrated website zip for \(itemID, privacy: .public) to asset store")
+    }
+
+    // MARK: Download / restore
+
+    /// Downloads an offloaded item's payload and reinstalls it locally.
+    /// Sources, in order: asset store (PDF, website zip), the legacy zip sync
+    /// row, and — for interactive captures — the chunk rows already in the
+    /// local database (which needs no network at all).
+    public static func restore(itemID: UUID, repository: StowerRepository) async throws {
+        @Dependency(\.itemStorageClient)
+        var itemStorageClient
+        @Dependency(\.articleSaveClient)
+        var articleSaveClient
+
+        try await repository.updateLocalContentStatus(itemID, "downloading", nil)
+        do {
+            if let manifest = try await itemStorageClient.manifest(itemID, .pdf) {
+                try await restorePDF(manifest: manifest, repository: repository)
+            } else if let manifest = try await itemStorageClient.manifest(itemID, .websiteZip) {
+                try await restoreWebsiteZip(manifest: manifest, repository: repository)
+            } else if let archive = try await repository.loadWebsiteArchive(itemID) {
+                // Legacy path: the zip still lives in the sync table.
+                try await WebsiteImportService.hydrateWebsite(
+                    itemID: itemID,
+                    archive: archive,
+                    repository: repository
+                )
+            } else if let info = try await itemStorageClient.storageInfo(itemID),
+                      info.hasCaptureManifest,
+                      let sourceURL = try await repository.loadItem(itemID)?.sourceURL,
+                      let url = URL(string: sourceURL) {
+                // Interactive capture: reinstall from local chunk rows.
+                _ = try await articleSaveClient.hydrate(itemID, url)
+                try await repository.updateLocalContentStatus(itemID, "available", nil)
+            } else {
+                throw CloudAssetServiceError.missingManifest
+            }
+            try await itemStorageClient.setOffloaded(itemID, false)
+        } catch {
+            try? await repository.updateLocalContentStatus(itemID, "failed", restoreFailureMessage(error))
+            throw error
+        }
+    }
+
+    private static func restorePDF(manifest: AssetManifest, repository: StowerRepository) async throws {
+        @Dependency(\.cloudAssetClient)
+        var cloudAssetClient
+        @Dependency(\.uuid)
+        var uuid
+
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("StowerAssetDownload-\(uuid().uuidString).pdf")
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        try await cloudAssetClient.download(manifest.recordName, scratch)
+        let data = try Data(contentsOf: scratch, options: .mappedIfSafe)
+        guard ArticleCapturePackage.sha256(data) == manifest.sha256 else {
+            throw CloudAssetServiceError.integrityFailure
+        }
+
+        try PDFArchiver.archivePDF(from: scratch, itemID: manifest.itemID)
+        try rerasterizePages(itemID: manifest.itemID, pdfURL: scratch)
+        try await repository.updateLocalContentStatus(manifest.itemID, "available", nil)
+    }
+
+    private static func restoreWebsiteZip(manifest: AssetManifest, repository: StowerRepository) async throws {
+        @Dependency(\.cloudAssetClient)
+        var cloudAssetClient
+        @Dependency(\.uuid)
+        var uuid
+
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("StowerAssetDownload-\(uuid().uuidString).zip")
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        try await cloudAssetClient.download(manifest.recordName, scratch)
+        let data = try Data(contentsOf: scratch, options: .mappedIfSafe)
+        guard ArticleCapturePackage.sha256(data) == manifest.sha256 else {
+            throw CloudAssetServiceError.integrityFailure
+        }
+
+        // Reuse the exact hydration path the legacy sync-table zips take:
+        // sha-verify, unpack to staging, atomic install, local row update.
+        try await WebsiteImportService.hydrateWebsite(
+            itemID: manifest.itemID,
+            archive: WebsiteArchiveBytes(
+                zipData: data,
+                originalFilename: manifest.originalFilename,
+                sha256: manifest.sha256
+            ),
+            repository: repository
+        )
+    }
+
+    /// Rebuilds the reader's per-page JPEGs from freshly downloaded PDF
+    /// bytes. The reader document (block structure, text) was never deleted —
+    /// its figure blocks reference `pdf-page-N.jpg` by position, so pages
+    /// rasterized from the identical PDF line up exactly.
+    static func rerasterizePages(itemID: UUID, pdfURL: URL) throws {
+        guard let pdf = PDFDocument(url: pdfURL) else {
+            throw CloudAssetServiceError.unreadablePDF
+        }
+        PDFArchiver.deletePageImages(for: itemID)
+        for pageIndex in 0..<pdf.pageCount {
+            guard let page = pdf.page(at: pageIndex),
+                  let image = rasterizePage(page, scale: 2.0)
+            else { continue }
+            try PDFArchiver.archivePageImage(image, for: itemID, pageIndex: pageIndex)
+        }
+    }
+
+    private static func restoreFailureMessage(_ error: Error) -> String {
+        switch error {
+        case CloudAssetError.notAuthenticated:
+            return "Sign in to iCloud to download this item."
+        case CloudAssetError.transient, CloudAssetServiceError.integrityFailure:
+            return "This item is stored in iCloud. Connect to the internet and try again."
+        case CloudAssetError.assetMissing, CloudAssetServiceError.missingManifest:
+            return "This item's iCloud copy could not be found. Re-import it to restore it."
+        default:
+            return error.localizedDescription
+        }
+    }
+
+    // MARK: Backfill
+
+    /// The date existing website zips start migrating out of the SyncEngine
+    /// table. Gives older app versions a window to update before re-hydration
+    /// stops working for migrated items. PDF uploads are net-new (nothing is
+    /// deleted) and are not gated.
+    ///
+    /// Set roughly two weeks after the release that ships this feature.
+    static let websiteMigrationEligibleAfter = Date(timeIntervalSince1970: 1_790_812_800)  // 2026-10-01T00:00:00Z
+
+    /// Enqueues upload jobs for PDFs that have never been uploaded and, once
+    /// the gate date passes, migration jobs for legacy website zips.
+    /// Returns the number of jobs enqueued.
+    @discardableResult
+    public static func enqueueBackfillJobs(repository: StowerRepository) async throws -> Int {
+        @Dependency(\.itemStorageClient)
+        var itemStorageClient
+        @Dependency(\.date.now)
+        var now
+
+        var enqueued = 0
+        for itemID in try await itemStorageClient.pdfItemIDsWithoutManifest() {
+            guard PDFArchiver.pdfExists(for: itemID) else { continue }
+            let payload = try AssetJobPayload(itemID: itemID, kind: .pdf).encoded()
+            try await repository.enqueueIngestionJob(.uploadAsset, payload)
+            enqueued += 1
+        }
+        if now >= websiteMigrationEligibleAfter {
+            for itemID in try await itemStorageClient.websiteZipItemIDsWithoutManifest() {
+                let payload = try AssetJobPayload(itemID: itemID, kind: .websiteZip).encoded()
+                try await repository.enqueueIngestionJob(.migrateWebsiteAsset, payload)
+                enqueued += 1
+            }
+        }
+        return enqueued
+    }
+}

--- a/StowerPackage/Sources/StowerFeatureV2/Support/FailedImport.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/FailedImport.swift
@@ -70,6 +70,10 @@ public struct FailedImport: Equatable, Identifiable, Sendable {
             // Payloads are JSON envelopes; the raw text is more confusing than
             // helpful, so name the kind instead.
             return job.kind == .markdown ? "Imported Markdown" : "Imported text"
+        case .uploadAsset, .migrateWebsiteAsset:
+            return "iCloud upload"
+        case .downloadAsset:
+            return "iCloud download"
         }
     }
 

--- a/StowerPackage/Sources/StowerFeatureV2/Support/PDFIngestionClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/PDFIngestionClient.swift
@@ -252,7 +252,10 @@ private func pdfIngest(url: URL) async throws -> IngestionResult {
 /// Renders a PDF page to a CGImage at `scale`x the page's point size.
 /// Uses CoreGraphics directly so the function works on both iOS and
 /// macOS with no UIKit/AppKit dependency.
-private func rasterizePage(_ page: PDFPage, scale: CGFloat) -> CGImage? {
+///
+/// Internal (not private): `CloudAssetService` re-rasterizes pages with the
+/// exact same pipeline when an offloaded PDF is downloaded again.
+func rasterizePage(_ page: PDFPage, scale: CGFloat) -> CGImage? {
     let bounds = page.bounds(for: .mediaBox)
     let width = Int(bounds.width * scale)
     let height = Int(bounds.height * scale)

--- a/StowerPackage/Sources/StowerFeatureV2/Support/StorageOffloadService.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/StorageOffloadService.swift
@@ -1,0 +1,148 @@
+import Dependencies
+import Foundation
+import OSLog
+import StowerData
+
+private let kOffloadLogger = Logger(subsystem: "com.ryanleewilliams.stower", category: "StorageOffload")
+
+public enum StorageOffloadError: Error, Equatable, LocalizedError {
+    case notOffloadable
+
+    public var errorDescription: String? {
+        "This item can't be removed from the device until its iCloud copy is confirmed."
+    }
+}
+
+/// Local eviction ("offload") of heavy per-item content whose bytes are
+/// safely stored elsewhere, and the automatic budget-based pass over read
+/// items. Regular articles are never offloaded — per the product policy their
+/// reader content always stays local.
+public enum StorageOffloadService {
+    /// Whether the item's heavy local files can be deleted without losing the
+    /// only copy. This is the safety gate shared by manual and automatic
+    /// offload:
+    /// - PDFs and website imports need a confirmed (`uploaded`) asset
+    ///   manifest.
+    /// - Interactive web captures need their capture manifest — the chunk
+    ///   rows in the local database rebuild the archive, even offline.
+    public static func canOffload(_ info: ItemStorageInfo) -> Bool {
+        guard info.offloadedAt == nil else { return false }
+        switch info.renderFormat {
+        case "pdf":
+            return info.uploadState == "uploaded"
+                && info.assetManifests.contains { $0.kind == .pdf }
+        case "webView":
+            if info.assetManifests.contains(where: { $0.kind == .websiteZip }) {
+                return info.uploadState == "uploaded"
+            }
+            // Interactive URL articles reinstall from local capture chunks.
+            return info.hasCaptureManifest
+        default:
+            return false
+        }
+    }
+
+    /// Automatic eviction additionally requires the item to be read and not
+    /// pinned. Manual offload only requires safety.
+    public static func isAutoEvictable(_ info: ItemStorageInfo) -> Bool {
+        info.isRead && !info.isPinned && canOffload(info)
+    }
+
+    /// Deletes the item's local heavy files and marks it offloaded. The
+    /// caller is responsible for the eligibility check (`canOffload`).
+    public static func offload(itemID: UUID, repository: StowerRepository) async throws {
+        @Dependency(\.itemStorageClient)
+        var itemStorageClient
+
+        guard let info = try await itemStorageClient.storageInfo(itemID), canOffload(info) else {
+            throw StorageOffloadError.notOffloadable
+        }
+        AssetArchiver.deleteArchive(for: itemID)
+        try await repository.updateLocalContentStatus(itemID, "notDownloaded", nil)
+        try await itemStorageClient.setOffloaded(itemID, true)
+        kOffloadLogger.info("Offloaded \(itemID, privacy: .public)")
+    }
+
+    /// Result of an automatic or bulk eviction pass.
+    public struct EvictionReport: Equatable, Sendable {
+        public var evictedCount = 0
+        public var freedBytes = 0
+
+        public init(evictedCount: Int = 0, freedBytes: Int = 0) {
+            self.evictedCount = evictedCount
+            self.freedBytes = freedBytes
+        }
+    }
+
+    /// Evicts read, unpinned, safely-offloadable items — least recently
+    /// opened first — until the archive directory fits the configured budget.
+    /// No budget (nil) disables the pass; `budgetOverride` of 0 evicts every
+    /// eligible item ("Offload Read Items Now").
+    @discardableResult
+    public static func runEviction(
+        repository: StowerRepository,
+        excluding excludedItemIDs: Set<UUID> = [],
+        budgetOverride: Int? = nil
+    ) async throws -> EvictionReport {
+        @Dependency(\.itemStorageClient)
+        var itemStorageClient
+        @Dependency(\.cloudAssetClient)
+        var cloudAssetClient
+
+        let configuredBudget = try await itemStorageClient.budgetBytes()
+        guard let budget = budgetOverride ?? configuredBudget else {
+            return EvictionReport()
+        }
+
+        let candidates = try await itemStorageClient.evictionCandidates()
+            .filter { isAutoEvictable($0) && !excludedItemIDs.contains($0.itemID) }
+
+        var sized: [(info: ItemStorageInfo, bytes: Int)] = candidates.map { info in
+            (info, archiveDirectorySize(for: info.itemID))
+        }
+        .filter { $0.bytes > 0 }
+        // Least recently opened first; never-opened items lead the line.
+        sized.sort { lhs, rhs in
+            (lhs.info.lastOpenedAt ?? .distantPast) < (rhs.info.lastOpenedAt ?? .distantPast)
+        }
+
+        var occupiedBytes = totalArchiveBytes()
+        var report = EvictionReport()
+        for (info, bytes) in sized {
+            guard occupiedBytes > budget else { break }
+            // Belt and suspenders for asset-backed items: confirm the iCloud
+            // record is actually there before deleting the local copy. An
+            // interactive capture restores from local chunks, so it needs no
+            // network check.
+            if let manifest = info.assetManifests.first {
+                guard (try? await cloudAssetClient.exists(manifest.recordName)) == true else {
+                    continue
+                }
+            }
+            do {
+                try await offload(itemID: info.itemID, repository: repository)
+            } catch {
+                continue
+            }
+            occupiedBytes -= bytes
+            report.evictedCount += 1
+            report.freedBytes += bytes
+        }
+        if report.evictedCount > 0 {
+            kOffloadLogger.info(
+                "Eviction pass freed \(report.freedBytes) bytes across \(report.evictedCount) items"
+            )
+        }
+        return report
+    }
+
+    private static func totalArchiveBytes() -> Int {
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let root = documents.appendingPathComponent("StowerArchive", isDirectory: true)
+        return StorageScanActor.directorySize(root)
+    }
+
+    private static func archiveDirectorySize(for itemID: UUID) -> Int {
+        StorageScanActor.directorySize(AssetArchiver.archiveDirectory(for: itemID))
+    }
+}

--- a/StowerPackage/Sources/StowerFeatureV2/Support/WebsiteImportService.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/WebsiteImportService.swift
@@ -57,10 +57,6 @@ enum WebsiteImportService {
             throw ImportError.sizeCapExceeded(maxCompressedBytes)
         }
 
-        let zipData = try Data(contentsOf: zipURL)
-        let digest = SHA256.hash(data: zipData)
-        let sha256 = digest.map { String(format: "%02x", $0) }.joined()
-
         let filename = zipURL.lastPathComponent
         let fallbackTitle = zipURL.deletingPathExtension().lastPathComponent
             .replacingOccurrences(of: "_", with: " ")
@@ -124,9 +120,22 @@ enum WebsiteImportService {
         )
         try FileManager.default.moveItem(at: staging, to: archiveDir)
 
-        try await repository.saveWebsiteArchive(item.id, zipData, sha256, filename)
+        // The original zip goes to the app-managed CloudKit asset store, not
+        // the SyncEngine BLOB table — asset-store payloads can be offloaded
+        // from a device without deleting the iCloud copy. The zip waits next
+        // to the unpacked archive until the upload job confirms; eviction is
+        // blocked until `uploadState == "uploaded"`.
+        let pendingZip = CloudAssetService.pendingUploadZipURL(for: item.id)
+        try? FileManager.default.removeItem(at: pendingZip)
+        try FileManager.default.copyItem(at: zipURL, to: pendingZip)
+        let uploadPayload = try AssetJobPayload(
+            itemID: item.id,
+            kind: .websiteZip,
+            originalFilename: filename
+        ).encoded()
+        try await repository.enqueueIngestionJob(.uploadAsset, uploadPayload)
         kWebsiteImportLog.info(
-            "Import complete \(item.id.uuidString, privacy: .public)"
+            "Import complete \(item.id.uuidString, privacy: .public); upload queued"
         )
         return item
     }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/CloudAssetServiceTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/CloudAssetServiceTests.swift
@@ -1,0 +1,325 @@
+import Dependencies
+import Foundation
+import SQLiteData
+@testable import StowerData
+@testable import StowerFeature
+import Testing
+import ZIPFoundation
+
+/// In-memory stand-in for the CloudKit asset zone. SQLiteData's
+/// MockCloudDatabase covers SyncEngine traffic, not our direct CKDatabase
+/// use, so the asset store gets its own double with injectable failures.
+actor InMemoryCloudAssetStore {
+    enum Failure {
+        case uploadQuotaExceeded
+        case downloadNetworkUnavailable
+        case existsAlwaysFalse
+        case truncateDownloads
+    }
+
+    private(set) var records = [String: Data]()
+    private(set) var deletedRecordNames = [String]()
+    var failures = Set<Failure>()
+
+    func setFailures(_ failures: Set<Failure>) {
+        self.failures = failures
+    }
+
+    func put(_ recordName: String, data: Data) throws {
+        if failures.contains(.uploadQuotaExceeded) {
+            throw CloudAssetError.quotaExceeded
+        }
+        records[recordName] = data
+    }
+
+    func get(_ recordName: String) throws -> Data {
+        if failures.contains(.downloadNetworkUnavailable) {
+            throw CloudAssetError.transient("network unavailable")
+        }
+        guard var data = records[recordName] else {
+            throw CloudAssetError.assetMissing
+        }
+        if failures.contains(.truncateDownloads) {
+            data = data.dropLast(1)
+        }
+        return data
+    }
+
+    func exists(_ recordName: String) -> Bool {
+        if failures.contains(.existsAlwaysFalse) {
+            return false
+        }
+        return records[recordName] != nil
+    }
+
+    func delete(_ recordName: String) {
+        records[recordName] = nil
+        deletedRecordNames.append(recordName)
+    }
+
+    nonisolated var client: CloudAssetClient {
+        CloudAssetClient(
+            upload: { manifest, fileURL in
+                try await self.put(manifest.recordName, data: Data(contentsOf: fileURL))
+            },
+            download: { recordName, destination in
+                let data = try await self.get(recordName)
+                try FileManager.default.createDirectory(
+                    at: destination.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try data.write(to: destination, options: .atomic)
+            },
+            exists: { recordName in
+                await self.exists(recordName)
+            },
+            delete: { recordName in
+                await self.delete(recordName)
+            }
+        )
+    }
+}
+
+@Suite
+struct CloudAssetServiceTests {
+    struct Fixture {
+        var database: any DatabaseWriter
+        var repository: StowerRepository
+        var store: InMemoryCloudAssetStore
+        var itemStorage: ItemStorageClient
+    }
+
+    private func makeFixture() throws -> Fixture {
+        let database = try StowerDatabase.makeDatabase()
+        return Fixture(
+            database: database,
+            repository: .live(database: database, cloudSyncClient: .noop),
+            store: InMemoryCloudAssetStore(),
+            itemStorage: .live(database: database)
+        )
+    }
+
+    private func withFixtureDependencies<T>(
+        _ fixture: Fixture,
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        try await withDependencies {
+            $0.cloudAssetClient = fixture.store.client
+            $0.itemStorageClient = fixture.itemStorage
+            $0.cloudSyncClient = .noop
+            $0.stowerRepository = fixture.repository
+            $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+            $0.uuid = .incrementing
+        } operation: {
+            try await operation()
+        }
+    }
+
+    private func makeWebsiteZip(index: String = "<html><title>Site</title></html>") throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("asset-service-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let zipURL = dir.appendingPathComponent("site.zip")
+        let archive = try Archive(url: zipURL, accessMode: .create)
+        let indexData = Data(index.utf8)
+        try archive.addEntry(
+            with: "index.html",
+            type: .file,
+            uncompressedSize: Int64(indexData.count)
+        ) { position, size in
+            indexData.subdata(in: Int(position)..<(Int(position) + size))
+        }
+        return zipURL
+    }
+
+    // MARK: Upload
+
+    @Test
+    func uploadPDF_recordsManifestAndMarksUploaded() async throws {
+        let fixture = try makeFixture()
+        let item = try await fixture.repository.createItemFromIngestion(.sharedText("PDF host"))
+        defer { AssetArchiver.deleteArchive(for: item.id) }
+        let pdfBytes = Data("fake pdf bytes".utf8)
+        let scratch = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID()).pdf")
+        try pdfBytes.write(to: scratch)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        try PDFArchiver.archivePDF(from: scratch, itemID: item.id)
+
+        try await withFixtureDependencies(fixture) {
+            try await CloudAssetService.upload(
+                payload: AssetJobPayload(itemID: item.id, kind: .pdf, originalFilename: "report.pdf")
+            )
+        }
+
+        let manifest = try await fixture.itemStorage.manifest(item.id, .pdf)
+        let stored = try #require(manifest)
+        #expect(stored.sha256 == ArticleCapturePackage.sha256(pdfBytes))
+        #expect(stored.byteCount == pdfBytes.count)
+        #expect(stored.originalFilename == "report.pdf")
+        let uploaded = await fixture.store.exists(stored.recordName)
+        #expect(uploaded)
+        let info = try await fixture.itemStorage.storageInfo(item.id)
+        #expect(info?.uploadState == "uploaded")
+    }
+
+    @Test
+    func uploadQuotaExceeded_marksUploadFailed() async throws {
+        let fixture = try makeFixture()
+        await fixture.store.setFailures([.uploadQuotaExceeded])
+        let item = try await fixture.repository.createItemFromIngestion(.sharedText("Quota"))
+        defer { AssetArchiver.deleteArchive(for: item.id) }
+        let scratch = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID()).pdf")
+        try Data("bytes".utf8).write(to: scratch)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        try PDFArchiver.archivePDF(from: scratch, itemID: item.id)
+
+        await #expect(throws: CloudAssetError.quotaExceeded) {
+            try await withFixtureDependencies(fixture) {
+                try await CloudAssetService.upload(
+                    payload: AssetJobPayload(itemID: item.id, kind: .pdf)
+                )
+            }
+        }
+        let info = try await fixture.itemStorage.storageInfo(item.id)
+        #expect(info?.uploadState == "failed")
+        let manifest = try await fixture.itemStorage.manifest(item.id, .pdf)
+        #expect(manifest == nil)
+    }
+
+    // MARK: Website zip migration
+
+    @Test
+    func migrateWebsiteZip_uploadsThenReplacesRow() async throws {
+        let fixture = try makeFixture()
+        let item = try await fixture.repository.createItemFromIngestion(.sharedText("Site"))
+        let zipData = Data("legacy zip bytes".utf8)
+        try await withFixtureDependencies(fixture) {
+            try await fixture.repository.saveWebsiteArchive(
+                item.id, zipData, ArticleCapturePackage.sha256(zipData), "site.zip"
+            )
+        }
+
+        try await withFixtureDependencies(fixture) {
+            try await CloudAssetService.migrateWebsiteZip(
+                itemID: item.id,
+                repository: fixture.repository
+            )
+        }
+
+        // Manifest recorded, legacy row gone, bytes in the asset store.
+        let manifest = try #require(try await fixture.itemStorage.manifest(item.id, .websiteZip))
+        #expect(manifest.sha256 == ArticleCapturePackage.sha256(zipData))
+        let legacy = try await fixture.repository.loadWebsiteArchive(item.id)
+        #expect(legacy == nil)
+        let cloudCopy = try await fixture.store.get(manifest.recordName)
+        #expect(cloudCopy == zipData)
+    }
+
+    @Test
+    func migrateWebsiteZip_keepsRowWhenUploadCannotBeVerified() async throws {
+        let fixture = try makeFixture()
+        await fixture.store.setFailures([.existsAlwaysFalse])
+        let item = try await fixture.repository.createItemFromIngestion(.sharedText("Site"))
+        let zipData = Data("precious only copy".utf8)
+        try await withFixtureDependencies(fixture) {
+            try await fixture.repository.saveWebsiteArchive(
+                item.id, zipData, ArticleCapturePackage.sha256(zipData), "site.zip"
+            )
+        }
+
+        await #expect(throws: (any Error).self) {
+            try await withFixtureDependencies(fixture) {
+                try await CloudAssetService.migrateWebsiteZip(
+                    itemID: item.id,
+                    repository: fixture.repository
+                )
+            }
+        }
+
+        // The upload-verify-then-delete invariant: with verification failing,
+        // the legacy sync row must survive untouched.
+        let legacy = try await fixture.repository.loadWebsiteArchive(item.id)
+        #expect(legacy?.zipData == zipData)
+        let manifest = try await fixture.itemStorage.manifest(item.id, .websiteZip)
+        #expect(manifest == nil)
+    }
+
+    // MARK: Restore
+
+    @Test
+    func restoreWebsiteZip_downloadsVerifiesAndUnpacks() async throws {
+        let fixture = try makeFixture()
+        let item = try await fixture.repository.createItemFromIngestion(.sharedText("Site"))
+        defer { AssetArchiver.deleteArchive(for: item.id) }
+        let zipURL = try makeWebsiteZip()
+        defer { try? FileManager.default.removeItem(at: zipURL.deletingLastPathComponent()) }
+        let zipData = try Data(contentsOf: zipURL)
+        let sha256 = ArticleCapturePackage.sha256(zipData)
+        let manifest = AssetManifest(
+            id: UUID(),
+            itemID: item.id,
+            kind: .websiteZip,
+            recordName: AssetManifest.makeRecordName(kind: .websiteZip, itemID: item.id, sha256: sha256),
+            sha256: sha256,
+            byteCount: zipData.count,
+            originalFilename: "site.zip"
+        )
+        try await fixture.store.put(manifest.recordName, data: zipData)
+        try await withFixtureDependencies(fixture) {
+            try await fixture.itemStorage.upsertManifest(manifest)
+        }
+
+        try await withFixtureDependencies(fixture) {
+            try await CloudAssetService.restore(itemID: item.id, repository: fixture.repository)
+        }
+
+        #expect(AssetArchiver.archiveExists(for: item.id))
+        let restored = try await fixture.repository.loadItem(item.id)
+        #expect(restored?.processingState == .ready)
+        let info = try await fixture.itemStorage.storageInfo(item.id)
+        #expect(info?.offloadedAt == nil)
+    }
+
+    @Test
+    func restore_integrityFailureMarksFailedAndThrows() async throws {
+        let fixture = try makeFixture()
+        await fixture.store.setFailures([.truncateDownloads])
+        let item = try await fixture.repository.createItemFromIngestion(.sharedText("Site"))
+        defer { AssetArchiver.deleteArchive(for: item.id) }
+        let zipData = Data("some zip".utf8)
+        let sha256 = ArticleCapturePackage.sha256(zipData)
+        let manifest = AssetManifest(
+            id: UUID(),
+            itemID: item.id,
+            kind: .websiteZip,
+            recordName: AssetManifest.makeRecordName(kind: .websiteZip, itemID: item.id, sha256: sha256),
+            sha256: sha256,
+            byteCount: zipData.count,
+            originalFilename: "site.zip"
+        )
+        try await fixture.store.put(manifest.recordName, data: zipData)
+        try await withFixtureDependencies(fixture) {
+            try await fixture.itemStorage.upsertManifest(manifest)
+        }
+
+        await #expect(throws: CloudAssetServiceError.integrityFailure) {
+            try await withFixtureDependencies(fixture) {
+                try await CloudAssetService.restore(itemID: item.id, repository: fixture.repository)
+            }
+        }
+        let restored = try await fixture.repository.loadItem(item.id)
+        #expect(restored?.processingState == .failed)
+    }
+
+    @Test
+    func restore_withoutAnySourceThrowsMissingManifest() async throws {
+        let fixture = try makeFixture()
+        let item = try await fixture.repository.createItemFromIngestion(.sharedText("Empty"))
+
+        await #expect(throws: CloudAssetServiceError.missingManifest) {
+            try await withFixtureDependencies(fixture) {
+                try await CloudAssetService.restore(itemID: item.id, repository: fixture.repository)
+            }
+        }
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/LibraryFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/LibraryFeatureTests.swift
@@ -64,6 +64,7 @@ struct LibraryFeatureTests {
             $0.isLoading = false
             $0.items = expected
         }
+        await store.receive(LibraryFeature.Action.storageInfoLoaded([:]))
     }
 
     @Test
@@ -107,6 +108,7 @@ struct LibraryFeatureTests {
             $0.isLoading = false
             $0.items = [readItem]
         }
+        await store.receive(.storageInfoLoaded([:]))
     }
 
     @Test

--- a/StowerPackage/Tests/StowerFeatureV2Tests/OffloadRestoreFlowTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/OffloadRestoreFlowTests.swift
@@ -1,0 +1,80 @@
+import ComposableArchitecture
+import Dependencies
+import Foundation
+@testable import StowerData
+@testable import StowerFeature
+import Testing
+
+/// Reader-side behavior for offloaded items: opening one triggers a restore,
+/// success reloads, failure surfaces a retryable message.
+@MainActor
+@Suite
+struct OffloadRestoreFlowTests {
+    private static func makePDFItem(id: UUID = UUID()) -> SavedItem {
+        SavedItem(title: "Offloaded PDF", content: "extracted text", id: id, renderFormat: .pdf)
+    }
+
+    @Test
+    func needsOffloadRestore_detectsMissingFiles() {
+        // A random-ID PDF item has no document.pdf on disk.
+        #expect(ReaderFeature.needsOffloadRestore(Self.makePDFItem()))
+        let article = SavedItem(title: "Article", content: "text", renderFormat: .structuredV1)
+        #expect(!ReaderFeature.needsOffloadRestore(article))
+    }
+
+    @Test
+    func openingOffloadedItemWithNoSourcesFailsWithRetryableMessage() async {
+        let item = Self.makePDFItem()
+        let store = TestStore(
+            initialState: ReaderFeature.State(item: item)
+        ) {
+            ReaderFeature()
+        } withDependencies: {
+            $0.itemStorageClient = .noop
+            $0.cloudAssetClient = .noop
+            $0.cloudSyncClient = .noop
+            $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+            $0.uuid = .incrementing
+        }
+        store.exhaustivity = .off
+
+        await store.send(.restoreOffloadedContent) {
+            $0.offloadRestore = .restoring
+        }
+        await store.receive(\.offloadRestoreFinished) {
+            guard case .failed = $0.offloadRestore else {
+                Issue.record("Expected failed restore state")
+                return
+            }
+        }
+    }
+
+    @Test
+    func restoreFinishedWithoutErrorReloads() async {
+        let item = Self.makePDFItem()
+        let store = TestStore(
+            initialState: {
+                var state = ReaderFeature.State(item: item)
+                state.offloadRestore = .restoring
+                state.document = ReaderDocument(title: "Old", blocks: [])
+                return state
+            }()
+        ) {
+            ReaderFeature()
+        } withDependencies: {
+            $0.itemStorageClient = .noop
+            $0.cloudSyncClient = .noop
+            $0.continuousClock = ImmediateClock()
+            $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+        }
+        store.exhaustivity = .off
+
+        await store.send(.offloadRestoreFinished(nil)) {
+            $0.offloadRestore = .idle
+            $0.document = nil
+            $0.sourceHTML = nil
+        }
+        await store.receive(\.load)
+        await store.skipInFlightEffects()
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/StorageFeatureTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/StorageFeatureTests.swift
@@ -28,6 +28,7 @@ struct StorageFeatureTests {
         await store.send(.task) {
             $0.isComputing = true
         }
+        await store.receive(.budgetLoaded(nil))
         await store.receive(.snapshotLoaded(snapshot)) {
             $0.isComputing = false
             $0.snapshot = snapshot

--- a/StowerPackage/Tests/StowerFeatureV2Tests/StorageLeakFixTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/StorageLeakFixTests.swift
@@ -37,15 +37,39 @@ struct StorageLeakFixTests {
                 SavedTextContentSyncTable.Draft(id: id, plainText: "text", rawSourceText: "raw")
             }
             .execute(db)
+            try SavedAssetManifestSyncTable.insert {
+                SavedAssetManifestSyncTable(
+                    id: UUID(),
+                    itemID: id,
+                    kind: "pdf",
+                    recordName: "asset-record",
+                    sha256: "abc"
+                )
+            }
+            .execute(db)
+            try ItemStorageLocalTable.insert {
+                ItemStorageLocalTable(itemID: id)
+            }
+            .execute(db)
         }
     }
 
-    private func contentRowCounts(for id: UUID, in database: any DatabaseWriter) async throws -> (website: Int, pdf: Int, text: Int) {
+    private struct RowCounts {
+        var website = 0
+        var pdf = 0
+        var text = 0
+        var manifests = 0
+        var storage = 0
+    }
+
+    private func contentRowCounts(for id: UUID, in database: any DatabaseWriter) async throws -> RowCounts {
         try await database.read { db in
-            (
+            RowCounts(
                 website: try SavedWebsiteArchiveSyncTable.where { $0.id.eq(id) }.fetchCount(db),
                 pdf: try SavedPDFContentSyncTable.where { $0.id.eq(id) }.fetchCount(db),
-                text: try SavedTextContentSyncTable.where { $0.id.eq(id) }.fetchCount(db)
+                text: try SavedTextContentSyncTable.where { $0.id.eq(id) }.fetchCount(db),
+                manifests: try SavedAssetManifestSyncTable.where { $0.itemID.eq(id) }.fetchCount(db),
+                storage: try ItemStorageLocalTable.where { $0.itemID.eq(id) }.fetchCount(db)
             )
         }
     }
@@ -63,6 +87,8 @@ struct StorageLeakFixTests {
         #expect(counts.website == 0)
         #expect(counts.pdf == 0)
         #expect(counts.text == 0)
+        #expect(counts.manifests == 0)
+        #expect(counts.storage == 0)
     }
 
     @Test
@@ -90,11 +116,15 @@ struct StorageLeakFixTests {
         #expect(expiredCounts.website == 0)
         #expect(expiredCounts.pdf == 0)
         #expect(expiredCounts.text == 0)
+        #expect(expiredCounts.manifests == 0)
+        #expect(expiredCounts.storage == 0)
 
         // The still-retained trash item keeps its content rows.
         let freshCounts = try await contentRowCounts(for: fresh.id, in: database)
         #expect(freshCounts.website == 1)
         #expect(freshCounts.pdf == 1)
         #expect(freshCounts.text == 1)
+        #expect(freshCounts.manifests == 1)
+        #expect(freshCounts.storage == 1)
     }
 }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/StorageOffloadServiceTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/StorageOffloadServiceTests.swift
@@ -1,0 +1,253 @@
+import Dependencies
+import Foundation
+import SQLiteData
+@testable import StowerData
+@testable import StowerFeature
+import Testing
+
+@Suite
+struct StorageOffloadServiceTests {
+    // MARK: Eligibility (pure)
+
+    private func makeInfo(
+        renderFormat: String,
+        isRead: Bool = true,
+        isPinned: Bool = false,
+        uploadState: String = "uploaded",
+        offloadedAt: Date? = nil,
+        hasCaptureManifest: Bool = false,
+        manifestKinds: [CloudAssetKind] = []
+    ) -> ItemStorageInfo {
+        let itemID = UUID()
+        return ItemStorageInfo(
+            itemID: itemID,
+            renderFormat: renderFormat,
+            isRead: isRead,
+            isPinned: isPinned,
+            uploadState: uploadState,
+            offloadedAt: offloadedAt,
+            hasCaptureManifest: hasCaptureManifest,
+            assetManifests: manifestKinds.map {
+                AssetManifest(
+                    id: UUID(),
+                    itemID: itemID,
+                    kind: $0,
+                    recordName: "record",
+                    sha256: "abc",
+                    byteCount: 1,
+                    originalFilename: "f"
+                )
+            }
+        )
+    }
+
+    @Test
+    func canOffload_requiresConfirmedRemoteCopy() {
+        // PDFs need an uploaded manifest.
+        #expect(StorageOffloadService.canOffload(makeInfo(renderFormat: "pdf", manifestKinds: [.pdf])))
+        #expect(!StorageOffloadService.canOffload(
+            makeInfo(renderFormat: "pdf", uploadState: "pending", manifestKinds: [.pdf])
+        ))
+        #expect(!StorageOffloadService.canOffload(makeInfo(renderFormat: "pdf")))
+
+        // Website imports need an uploaded zip manifest.
+        #expect(StorageOffloadService.canOffload(
+            makeInfo(renderFormat: "webView", manifestKinds: [.websiteZip])
+        ))
+        // Interactive captures restore from local chunks — no manifest needed.
+        #expect(StorageOffloadService.canOffload(
+            makeInfo(renderFormat: "webView", uploadState: "pending", hasCaptureManifest: true)
+        ))
+        // Legacy website imports with neither are NOT offloadable yet.
+        #expect(!StorageOffloadService.canOffload(
+            makeInfo(renderFormat: "webView", uploadState: "pending")
+        ))
+
+        // Regular articles never offload.
+        #expect(!StorageOffloadService.canOffload(
+            makeInfo(renderFormat: "structuredV1", manifestKinds: [.pdf])
+        ))
+        // Already offloaded items are done.
+        #expect(!StorageOffloadService.canOffload(
+            makeInfo(renderFormat: "pdf", offloadedAt: .now, manifestKinds: [.pdf])
+        ))
+    }
+
+    @Test
+    func isAutoEvictable_requiresReadAndUnpinned() {
+        #expect(StorageOffloadService.isAutoEvictable(makeInfo(renderFormat: "pdf", manifestKinds: [.pdf])))
+        #expect(!StorageOffloadService.isAutoEvictable(
+            makeInfo(renderFormat: "pdf", isRead: false, manifestKinds: [.pdf])
+        ))
+        #expect(!StorageOffloadService.isAutoEvictable(
+            makeInfo(renderFormat: "pdf", isPinned: true, manifestKinds: [.pdf])
+        ))
+    }
+
+    // MARK: Offload + eviction against a live database
+
+    struct Fixture {
+        var database: any DatabaseWriter
+        var repository: StowerRepository
+        var itemStorage: ItemStorageClient
+        var store: InMemoryCloudAssetStore
+        // Shared across every dependency scope in a test so UUIDs never
+        // collide between successive fixture operations.
+        var uuid: UUIDGenerator = .incrementing
+    }
+
+    private func makeFixture() throws -> Fixture {
+        let database = try StowerDatabase.makeDatabase()
+        return Fixture(
+            database: database,
+            repository: .live(database: database, cloudSyncClient: .noop),
+            itemStorage: .live(database: database),
+            store: InMemoryCloudAssetStore()
+        )
+    }
+
+    private func withFixtureDependencies<T>(
+        _ fixture: Fixture,
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        try await withDependencies {
+            $0.itemStorageClient = fixture.itemStorage
+            $0.cloudAssetClient = fixture.store.client
+            $0.cloudSyncClient = .noop
+            $0.stowerRepository = fixture.repository
+            $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+            $0.uuid = fixture.uuid
+        } operation: {
+            try await operation()
+        }
+    }
+
+    /// Creates a read PDF item with an on-disk archive, an uploaded manifest,
+    /// and a local content row marked `pdf`.
+    private func makeUploadedPDFItem(
+        _ fixture: Fixture,
+        pinned: Bool = false
+    ) async throws -> SavedItem {
+        try await withFixtureDependencies(fixture) {
+            let item = try await fixture.repository.createItemFromIngestion(.sharedText("PDF"))
+            try await fixture.repository.setReadStatus(item.id, true)
+            try await fixture.database.write { db in
+                try SavedItemContentLocalTable
+                    .find(item.id)
+                    .update { $0.renderFormat = "pdf" }
+                    .execute(db)
+            }
+            let bytes = Data("pdf-bytes-\(item.id)".utf8)
+            let scratch = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID()).pdf")
+            try bytes.write(to: scratch)
+            defer { try? FileManager.default.removeItem(at: scratch) }
+            try PDFArchiver.archivePDF(from: scratch, itemID: item.id)
+            try await CloudAssetService.upload(payload: AssetJobPayload(itemID: item.id, kind: .pdf))
+            if pinned {
+                try await fixture.itemStorage.setPinned(item.id, true)
+            }
+            return item
+        }
+    }
+
+    @Test
+    func offload_deletesFilesAndMarksState() async throws {
+        let fixture = try makeFixture()
+        let item = try await makeUploadedPDFItem(fixture)
+        defer { AssetArchiver.deleteArchive(for: item.id) }
+        #expect(PDFArchiver.pdfExists(for: item.id))
+
+        try await withFixtureDependencies(fixture) {
+            try await StorageOffloadService.offload(itemID: item.id, repository: fixture.repository)
+        }
+
+        #expect(!PDFArchiver.pdfExists(for: item.id))
+        let info = try await fixture.itemStorage.storageInfo(item.id)
+        #expect(info?.offloadedAt != nil)
+        let reloaded = try await withFixtureDependencies(fixture) {
+            try await fixture.repository.loadItem(item.id)
+        }
+        #expect(reloaded?.processingState == .queued)
+    }
+
+    @Test
+    func offload_refusesWithoutConfirmedUpload() async throws {
+        let fixture = try makeFixture()
+        let item = try await withFixtureDependencies(fixture) {
+            let item = try await fixture.repository.createItemFromIngestion(.sharedText("Local-only"))
+            try await fixture.database.write { db in
+                try SavedItemContentLocalTable
+                    .find(item.id)
+                    .update { $0.renderFormat = "pdf" }
+                    .execute(db)
+            }
+            return item
+        }
+
+        await #expect(throws: StorageOffloadError.notOffloadable) {
+            try await withFixtureDependencies(fixture) {
+                try await StorageOffloadService.offload(itemID: item.id, repository: fixture.repository)
+            }
+        }
+    }
+
+    @Test
+    func runEviction_skipsPinnedAndExcludedItems() async throws {
+        let fixture = try makeFixture()
+        let evictable = try await makeUploadedPDFItem(fixture)
+        let pinned = try await makeUploadedPDFItem(fixture, pinned: true)
+        let excluded = try await makeUploadedPDFItem(fixture)
+        defer {
+            AssetArchiver.deleteArchive(for: evictable.id)
+            AssetArchiver.deleteArchive(for: pinned.id)
+            AssetArchiver.deleteArchive(for: excluded.id)
+        }
+
+        let report = try await withFixtureDependencies(fixture) {
+            try await StorageOffloadService.runEviction(
+                repository: fixture.repository,
+                excluding: [excluded.id],
+                budgetOverride: 0
+            )
+        }
+
+        #expect(report.evictedCount == 1)
+        #expect(!PDFArchiver.pdfExists(for: evictable.id))
+        #expect(PDFArchiver.pdfExists(for: pinned.id))
+        #expect(PDFArchiver.pdfExists(for: excluded.id))
+    }
+
+    @Test
+    func runEviction_withoutBudgetIsANoop() async throws {
+        let fixture = try makeFixture()
+        let item = try await makeUploadedPDFItem(fixture)
+        defer { AssetArchiver.deleteArchive(for: item.id) }
+
+        let report = try await withFixtureDependencies(fixture) {
+            try await StorageOffloadService.runEviction(repository: fixture.repository)
+        }
+
+        #expect(report.evictedCount == 0)
+        #expect(PDFArchiver.pdfExists(for: item.id))
+    }
+
+    @Test
+    func runEviction_skipsItemsWhoseCloudRecordDisappeared() async throws {
+        let fixture = try makeFixture()
+        let item = try await makeUploadedPDFItem(fixture)
+        defer { AssetArchiver.deleteArchive(for: item.id) }
+        // Simulate the belt-and-suspenders case: state says uploaded but the
+        // record is not actually in CloudKit.
+        await fixture.store.setFailures([.existsAlwaysFalse])
+
+        let report = try await withFixtureDependencies(fixture) {
+            try await StorageOffloadService.runEviction(
+                repository: fixture.repository,
+                budgetOverride: 0
+            )
+        }
+
+        #expect(report.evictedCount == 0)
+        #expect(PDFArchiver.pdfExists(for: item.id))
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/StorageUsageClientTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/StorageUsageClientTests.swift
@@ -55,8 +55,10 @@ struct StorageUsageClientTests {
         defer { try? FileManager.default.removeItem(at: fixture.scratch) }
         let bigItem = UUID()
         let smallItem = UUID()
-        try write(4096, to: fixture.roots.archiveRoot.appendingPathComponent("\(bigItem.uuidString)/index.html"))
-        try write(1024, to: fixture.roots.archiveRoot.appendingPathComponent("\(smallItem.uuidString)/index.html"))
+        // Sizes far enough apart that filesystem block-size rounding of
+        // allocated sizes can never make them tie.
+        try write(64 * 1024, to: fixture.roots.archiveRoot.appendingPathComponent("\(bigItem.uuidString)/index.html"))
+        try write(8 * 1024, to: fixture.roots.archiveRoot.appendingPathComponent("\(smallItem.uuidString)/index.html"))
         try write(512, to: fixture.roots.imagesRoot.appendingPathComponent("hero.jpg"))
         try write(256, to: fixture.roots.pendingRoots[0].appendingPathComponent("stranded.pdf"))
         try write(128, to: fixture.roots.legacyDatabaseURL!)


### PR DESCRIPTION
PDFs and website imports no longer have to occupy the device forever.
Their bytes move to an app-managed CloudKit asset store — immutable,
content-addressed StowerAsset records in a dedicated StowerAssetZone,
separate from the SQLiteData SyncEngine zone — because SyncEngine is
full replication: every BLOB in a synced table is mirrored into the
local database on every device, and deleting a row locally deletes it
from CloudKit. Only a small synced manifest row now replicates; the
payload is fetched when the user actually opens the item.

Per the content-tier policy: regular articles always stay local;
interactive captures are offloadable and restore from their local chunk
rows (works offline); PDFs and website imports are iCloud-resident.
PDF originals never synced at all before this — new and existing PDFs
are uploaded via backfill, and page images are re-rasterized from the
downloaded PDF rather than stored twice in the cloud.

Website zips migrate out of the SyncEngine BLOB table with a strict
upload → verify → replace sequence — the legacy row is only deleted
after the asset record is confirmed to exist — and the migration is
date-gated so older app versions get a window to update. New website
imports upload straight to the asset store and never write the legacy
row.

Offload itself deletes the item's archive directory, marks the local
content row notDownloaded, and stamps the per-device storage row (new
local-only tables track pin state, last-opened recency, and upload
confirmation; pinning is deliberately per-device). Opening an offloaded
item in the reader shows a download state, fetches, sha256-verifies,
and reinstalls before rendering. The library gains a cloud badge and
Download Now / Remove Download / Keep Downloaded controls, and Settings
gains a storage limit picker with an LRU eviction pass over read,
unpinned items plus an "Offload Read Items" action. Eviction only ever
runs against items whose remote copy is confirmed, re-checked against
CloudKit at eviction time.

Deleting an item now also removes its manifest rows and best-effort
deletes the CloudKit asset records, and the orphan quarantine sweep
covers the manifest table.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>