### PR TITLE
Move article capture packages into the CloudKit asset store

### DIFF
--- a/StowerPackage/Sources/StowerData/Data/ItemStorageClient.swift
+++ b/StowerPackage/Sources/StowerData/Data/ItemStorageClient.swift
@@ -13,6 +13,9 @@ public struct ItemStorageInfo: Equatable, Sendable, Identifiable {
     public var uploadState: String
     public var offloadedAt: Date?
     public var hasCaptureManifest: Bool
+    /// Whether the capture's bytes still exist as legacy chunk rows in the
+    /// local database (pre-asset-store captures restore from these offline).
+    public var hasCaptureChunks = false
     public var assetManifests = [AssetManifest]()
 
     public var id: UUID { itemID }
@@ -26,6 +29,7 @@ public struct ItemStorageInfo: Equatable, Sendable, Identifiable {
         uploadState: String = "pending",
         offloadedAt: Date? = nil,
         hasCaptureManifest: Bool = false,
+        hasCaptureChunks: Bool = false,
         assetManifests: [AssetManifest] = []
     ) {
         self.itemID = itemID
@@ -36,6 +40,7 @@ public struct ItemStorageInfo: Equatable, Sendable, Identifiable {
         self.uploadState = uploadState
         self.offloadedAt = offloadedAt
         self.hasCaptureManifest = hasCaptureManifest
+        self.hasCaptureChunks = hasCaptureChunks
         self.assetManifests = assetManifests
     }
 }
@@ -67,6 +72,13 @@ public struct ItemStorageClient: Sendable {
     public var pdfItemIDsWithoutManifest: @Sendable () async throws -> [UUID]
     /// Items still carrying a legacy `zipData` sync row — migration targets.
     public var websiteZipItemIDsWithoutManifest: @Sendable () async throws -> [UUID]
+    /// Live items whose capture still stores its bytes as chunk rows —
+    /// capture-migration targets.
+    public var captureItemIDsWithChunks: @Sendable () async throws -> [UUID]
+    /// Deletes an item's chunk rows and stamps its capture manifest with
+    /// `chunkCount = 0`. Callers MUST have confirmed the asset upload first —
+    /// the chunk deletion propagates to every device.
+    public var markCaptureMigrated: @Sendable (_ itemID: UUID) async throws -> Void
 
     public static let noop = Self(
         upsertManifest: { _ in },
@@ -83,7 +95,9 @@ public struct ItemStorageClient: Sendable {
         setBudgetBytes: { _ in },
         replaceWebsiteArchiveWithManifest: { _ in },
         pdfItemIDsWithoutManifest: { [] },
-        websiteZipItemIDsWithoutManifest: { [] }
+        websiteZipItemIDsWithoutManifest: { [] },
+        captureItemIDsWithChunks: { [] },
+        markCaptureMigrated: { _ in }
     )
 
     public init(
@@ -101,7 +115,9 @@ public struct ItemStorageClient: Sendable {
         setBudgetBytes: @escaping @Sendable (Int?) async throws -> Void,
         replaceWebsiteArchiveWithManifest: @escaping @Sendable (AssetManifest) async throws -> Void,
         pdfItemIDsWithoutManifest: @escaping @Sendable () async throws -> [UUID],
-        websiteZipItemIDsWithoutManifest: @escaping @Sendable () async throws -> [UUID]
+        websiteZipItemIDsWithoutManifest: @escaping @Sendable () async throws -> [UUID],
+        captureItemIDsWithChunks: @escaping @Sendable () async throws -> [UUID],
+        markCaptureMigrated: @escaping @Sendable (UUID) async throws -> Void
     ) {
         self.upsertManifest = upsertManifest
         self.manifest = manifest
@@ -118,6 +134,8 @@ public struct ItemStorageClient: Sendable {
         self.replaceWebsiteArchiveWithManifest = replaceWebsiteArchiveWithManifest
         self.pdfItemIDsWithoutManifest = pdfItemIDsWithoutManifest
         self.websiteZipItemIDsWithoutManifest = websiteZipItemIDsWithoutManifest
+        self.captureItemIDsWithChunks = captureItemIDsWithChunks
+        self.markCaptureMigrated = markCaptureMigrated
     }
 }
 
@@ -323,6 +341,38 @@ extension ItemStorageClient {
                     )
                     return zipItemIDs.filter { liveIDs.contains($0) && !manifested.contains($0) }
                 }
+            },
+            captureItemIDsWithChunks: {
+                try await database.read { db in
+                    let chunkedItemIDs = Set(
+                        try SavedArticleCaptureChunkSyncTable
+                            .select(\.itemID)
+                            .fetchAll(db)
+                    )
+                    guard !chunkedItemIDs.isEmpty else { return [] }
+                    return try SavedItemSyncTable
+                        .where { $0.id.in(Array(chunkedItemIDs)) }
+                        .where { $0.deletedAt.is(nil) }
+                        .select(\.id)
+                        .fetchAll(db)
+                }
+            },
+            markCaptureMigrated: { itemID in
+                @Dependency(\.date.now)
+                var now
+                try await database.write { db in
+                    try SavedArticleCaptureChunkSyncTable
+                        .where { $0.itemID.eq(itemID) }
+                        .delete()
+                        .execute(db)
+                    try SavedArticleCaptureSyncTable
+                        .where { $0.itemID.eq(itemID) }
+                        .update {
+                            $0.chunkCount = 0
+                            $0.updatedAt = now
+                        }
+                        .execute(db)
+                }
             }
         )
     }
@@ -369,6 +419,12 @@ extension ItemStorageClient {
                 .select(\.itemID)
                 .fetchAll(db)
         )
+        let chunkedItemIDs = Set(
+            try SavedArticleCaptureChunkSyncTable
+                .where { $0.itemID.in(itemIDs) }
+                .select(\.itemID)
+                .fetchAll(db)
+        )
 
         let contentByID = Dictionary(uniqueKeysWithValues: contents.map { ($0.itemID, $0) })
         let storageByID = Dictionary(uniqueKeysWithValues: storageRows.map { ($0.itemID, $0) })
@@ -385,6 +441,7 @@ extension ItemStorageClient {
                 uploadState: storage?.uploadState ?? "pending",
                 offloadedAt: storage?.offloadedAt,
                 hasCaptureManifest: captureItemIDs.contains(item.id),
+                hasCaptureChunks: chunkedItemIDs.contains(item.id),
                 assetManifests: manifestsByID[item.id] ?? []
             )
         }

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+ArticleCapture.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+ArticleCapture.swift
@@ -7,8 +7,15 @@ extension StowerRepository {
         scheduleSync: @escaping @Sendable () -> Void
     ) -> @Sendable (WebCaptureManifest, [WebCaptureChunk]) async throws -> Void {
         { manifest, chunks in
-            guard chunks.count == manifest.chunkCount,
-                  chunks.reduce(0, { $0 + $1.data.count }) == manifest.byteCount
+            // `chunkCount == 0` marks an asset-store capture: the manifest
+            // still syncs (it carries the sha/byteCount the receiving device
+            // verifies against), but the bytes live in the CloudKit asset
+            // zone rather than chunk rows, so `byteCount` intentionally
+            // exceeds the (empty) chunk total.
+            let isAssetStoreCapture = manifest.chunkCount == 0 && chunks.isEmpty
+            guard isAssetStoreCapture
+                || (chunks.count == manifest.chunkCount
+                    && chunks.reduce(0, { $0 + $1.data.count }) == manifest.byteCount)
             else {
                 throw ArticleCaptureRepositoryError.incompleteChunkSet
             }

--- a/StowerPackage/Sources/StowerData/Data/StowerRepository+Jobs.swift
+++ b/StowerPackage/Sources/StowerData/Data/StowerRepository+Jobs.swift
@@ -590,7 +590,7 @@ private extension IngestionJob.Kind {
     var isDeduplicated: Bool {
         switch self {
         case .hydrate, .hydrateText, .hydrateWebsite, .url,
-             .uploadAsset, .downloadAsset, .migrateWebsiteAsset:
+             .uploadAsset, .downloadAsset, .migrateWebsiteAsset, .migrateCaptureAsset:
             true
         case .pdf, .website, .text, .markdown:
             false

--- a/StowerPackage/Sources/StowerData/Domain/Models.swift
+++ b/StowerPackage/Sources/StowerData/Domain/Models.swift
@@ -397,6 +397,7 @@ public struct IngestionJob: Equatable, Identifiable, Sendable {
         case uploadAsset = "uploadAsset"
         case downloadAsset = "downloadAsset"
         case migrateWebsiteAsset = "migrateWebsiteAsset"
+        case migrateCaptureAsset = "migrateCaptureAsset"
     }
 
     public let id: UUID
@@ -467,6 +468,10 @@ public enum CloudAssetKind: String, Codable, CaseIterable, Sendable {
     case pdf = "pdf"
     /// The original imported `.zip` of a user-imported website.
     case websiteZip = "websiteZip"
+    /// A web article's `capture.zip` package. Capture manifests with
+    /// `chunkCount == 0` store their bytes here instead of in the chunk
+    /// sync table.
+    case capture = "capture"
 }
 
 /// Payload for `uploadAsset` / `downloadAsset` / `migrateWebsiteAsset` jobs.

--- a/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/App/AppFeature.swift
@@ -801,6 +801,12 @@ private func processIngestionJob(
                 itemID: payload.itemID,
                 repository: repository
             )
+        case .migrateCaptureAsset:
+            let payload = try AssetJobPayload.decoded(from: job.payload)
+            try await CloudAssetService.migrateCapture(
+                itemID: payload.itemID,
+                repository: repository
+            )
         case .hydrateWebsite:
             // Receive-side: the website archive arrived via CloudKit sync but
             // the site isn't unpacked locally yet. Pull the zip bytes out of

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ArticleCapturePackage.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ArticleCapturePackage.swift
@@ -182,6 +182,23 @@ enum ArticleCapturePackage {
         )
     }
 
+    /// A `chunkCount == 0` manifest for a capture whose bytes live in the
+    /// CloudKit asset store rather than the chunk sync table.
+    static func makeManifest(from artifact: WebCaptureArtifact, itemID: UUID) throws -> WebCaptureManifest {
+        let packageData = try Data(contentsOf: artifact.stagedPackageURL, options: .mappedIfSafe)
+        guard packageData.count == artifact.byteCount, sha256(packageData) == artifact.sha256 else {
+            throw ArticleCapturePackageError.aggregateHashMismatch
+        }
+        return WebCaptureManifest(
+            itemID: itemID,
+            captureID: artifact.captureID,
+            sha256: artifact.sha256,
+            byteCount: artifact.byteCount,
+            chunkCount: 0,
+            version: artifact.version
+        )
+    }
+
     static func reconstruct(_ capture: SyncedWebCapture) throws -> Data {
         let ordered = capture.chunks.sorted { $0.sequence < $1.sequence }
         guard ordered.count == capture.manifest.chunkCount,

--- a/StowerPackage/Sources/StowerFeatureV2/Support/ArticleSaveClient.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/ArticleSaveClient.swift
@@ -68,7 +68,16 @@ public struct ArticleSaveClient: Sendable {
             // Exact synced bytes always win. A source refetch is reserved for
             // legacy rows with no capture manifest.
             if let synced = try await repository.loadArticleCapture(itemID) {
-                let packageData = try ArticleCapturePackage.reconstruct(synced)
+                let packageData: Data
+                if synced.manifest.chunkCount > 0 {
+                    packageData = try ArticleCapturePackage.reconstruct(synced)
+                } else {
+                    // `chunkCount == 0`: the package lives in the CloudKit
+                    // asset store. Download failures throw rather than fall
+                    // through to a live refetch — a refetch would silently
+                    // replace the exact capture with a new one.
+                    packageData = try await downloadCapturePackage(manifest: synced.manifest)
+                }
                 try ArticleCapturePackage.install(
                     packageData: packageData,
                     expectedHash: synced.manifest.sha256,
@@ -103,6 +112,35 @@ public struct ArticleSaveClient: Sendable {
         }
     )
 
+    /// Fetches an asset-store capture package and verifies it against the
+    /// synced capture manifest. The asset-manifest row usually names the
+    /// record, but the name is also derivable from the capture manifest —
+    /// so hydration works even when the asset-manifest row hasn't synced yet.
+    private static func downloadCapturePackage(manifest: WebCaptureManifest) async throws -> Data {
+        @Dependency(\.cloudAssetClient)
+        var cloudAssetClient
+        @Dependency(\.itemStorageClient)
+        var itemStorageClient
+        @Dependency(\.uuid)
+        var uuid
+
+        let recordName = (try? await itemStorageClient.manifest(manifest.itemID, .capture))?.recordName
+            ?? AssetManifest.makeRecordName(
+                kind: .capture,
+                itemID: manifest.itemID,
+                sha256: manifest.sha256
+            )
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("StowerCaptureDownload-\(uuid().uuidString).zip")
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        try await cloudAssetClient.download(recordName, scratch)
+        let data = try Data(contentsOf: scratch, options: .mappedIfSafe)
+        guard ArticleCapturePackage.sha256(data) == manifest.sha256 else {
+            throw ArticleCapturePackageError.aggregateHashMismatch
+        }
+        return data
+    }
+
     private static func finish(
         result: IngestionResult,
         item: SavedItem,
@@ -110,11 +148,26 @@ public struct ArticleSaveClient: Sendable {
     ) async throws -> ArticleSaveResult {
         if let artifact = result.webCapture {
             defer { try? FileManager.default.removeItem(at: artifact.stagedPackageURL.deletingLastPathComponent()) }
-            let (manifest, chunks) = try ArticleCapturePackage.makeChunks(from: artifact, itemID: item.id)
+            // The package bytes go to the CloudKit asset store, not chunk
+            // rows — only the (small) capture manifest syncs through the
+            // SyncEngine. Other devices verify downloads against its sha.
+            let manifest = try ArticleCapturePackage.makeManifest(from: artifact, itemID: item.id)
             try Task.checkCancellation()
-            try await repository.saveArticleCapture(manifest, chunks)
+            try await repository.saveArticleCapture(manifest, [])
             try Task.checkCancellation()
             try ArticleCapturePackage.install(artifact, for: item.id)
+            // Stage the package beside the installed archive until the upload
+            // job confirms it reached CloudKit.
+            let pendingZip = CloudAssetService.pendingUploadCaptureURL(for: item.id)
+            try? FileManager.default.removeItem(at: pendingZip)
+            try FileManager.default.copyItem(at: artifact.stagedPackageURL, to: pendingZip)
+            if let payload = try? AssetJobPayload(
+                itemID: item.id,
+                kind: .capture,
+                originalFilename: ArticleCapturePackage.installedPackageFilename
+            ).encoded() {
+                try? await repository.enqueueIngestionJob(.uploadAsset, payload)
+            }
             try await repository.markArticleCaptureInstalled(item.id, artifact.captureID, artifact.version)
             let installedItem = try await repository.loadItem(item.id) ?? item
             return ArticleSaveResult(

--- a/StowerPackage/Sources/StowerFeatureV2/Support/CloudAssetService.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/CloudAssetService.swift
@@ -37,12 +37,86 @@ public enum CloudAssetService {
             .appendingPathComponent("pending-upload.zip")
     }
 
+    /// Where a freshly captured article package waits for its upload job.
+    static func pendingUploadCaptureURL(for itemID: UUID) -> URL {
+        AssetArchiver.archiveDirectory(for: itemID)
+            .appendingPathComponent("pending-upload-capture.zip")
+    }
+
     // MARK: Upload
 
     /// Uploads an item's heavy payload and records the synced manifest.
     /// Idempotent: record names are content-addressed and re-upserting the
     /// manifest replaces the previous row for (item, kind).
     public static func upload(payload: AssetJobPayload) async throws {
+        @Dependency(\.itemStorageClient)
+        var itemStorageClient
+        @Dependency(\.stowerRepository)
+        var repository
+        @Dependency(\.uuid)
+        var uuid
+
+        let fileURL: URL
+        var cleanupAfterUpload: URL?
+        var scratchToRemove: URL?
+        defer {
+            if let scratchToRemove {
+                try? FileManager.default.removeItem(at: scratchToRemove)
+            }
+        }
+        switch payload.kind {
+        case .pdf:
+            fileURL = PDFArchiver.pdfURL(for: payload.itemID)
+        case .websiteZip:
+            fileURL = pendingUploadZipURL(for: payload.itemID)
+            cleanupAfterUpload = fileURL
+        case .capture:
+            let pending = pendingUploadCaptureURL(for: payload.itemID)
+            if FileManager.default.fileExists(atPath: pending.path) {
+                fileURL = pending
+                cleanupAfterUpload = pending
+            } else if let synced = try await repository.loadArticleCapture(payload.itemID),
+                      synced.manifest.chunkCount > 0 {
+                // The staged copy is gone but the legacy chunk rows still
+                // hold the package — reconstruct and upload from those.
+                let packageData = try ArticleCapturePackage.reconstruct(synced)
+                let scratch = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("StowerCaptureUpload-\(uuid().uuidString).zip")
+                try packageData.write(to: scratch, options: .atomic)
+                fileURL = scratch
+                scratchToRemove = scratch
+            } else {
+                try? await itemStorageClient.setUploadState(payload.itemID, "failed")
+                throw CloudAssetServiceError.missingLocalFile
+            }
+        }
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            // The local source is gone (e.g. re-installed device). Mark the
+            // state so eviction stays blocked, then surface the failure.
+            try? await itemStorageClient.setUploadState(payload.itemID, "failed")
+            throw CloudAssetServiceError.missingLocalFile
+        }
+
+        try await uploadFile(
+            at: fileURL,
+            itemID: payload.itemID,
+            kind: payload.kind,
+            originalFilename: payload.originalFilename ?? fileURL.lastPathComponent
+        )
+        if let cleanupAfterUpload {
+            try? FileManager.default.removeItem(at: cleanupAfterUpload)
+        }
+    }
+
+    /// Shared upload core: content-address, upload, verify, record the
+    /// manifest, mark the item uploaded, and best-effort delete the record a
+    /// re-capture supersedes.
+    private static func uploadFile(
+        at fileURL: URL,
+        itemID: UUID,
+        kind: CloudAssetKind,
+        originalFilename: String
+    ) async throws {
         @Dependency(\.cloudAssetClient)
         var cloudAssetClient
         @Dependency(\.itemStorageClient)
@@ -52,38 +126,18 @@ public enum CloudAssetService {
         @Dependency(\.uuid)
         var uuid
 
-        let fileURL: URL
-        var cleanupAfterUpload: URL?
-        switch payload.kind {
-        case .pdf:
-            fileURL = PDFArchiver.pdfURL(for: payload.itemID)
-        case .websiteZip:
-            fileURL = pendingUploadZipURL(for: payload.itemID)
-            cleanupAfterUpload = fileURL
-        }
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            // The local source is gone (e.g. re-installed device). Mark the
-            // state so eviction stays blocked, then surface the failure.
-            try? await itemStorageClient.setUploadState(payload.itemID, "failed")
-            throw CloudAssetServiceError.missingLocalFile
-        }
-
         let data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
         let sha256 = ArticleCapturePackage.sha256(data)
         let manifest = AssetManifest(
             id: uuid(),
-            itemID: payload.itemID,
-            kind: payload.kind,
-            recordName: AssetManifest.makeRecordName(
-                kind: payload.kind,
-                itemID: payload.itemID,
-                sha256: sha256
-            ),
+            itemID: itemID,
+            kind: kind,
+            recordName: AssetManifest.makeRecordName(kind: kind, itemID: itemID, sha256: sha256),
             sha256: sha256,
             byteCount: data.count,
-            originalFilename: payload.originalFilename
-                ?? fileURL.lastPathComponent
+            originalFilename: originalFilename
         )
+        let superseded = try? await itemStorageClient.manifest(itemID, kind)
 
         do {
             try await cloudAssetClient.upload(manifest, fileURL)
@@ -92,15 +146,15 @@ public enum CloudAssetService {
             }
         } catch {
             if case CloudAssetError.quotaExceeded = error {
-                try? await itemStorageClient.setUploadState(payload.itemID, "failed")
+                try? await itemStorageClient.setUploadState(itemID, "failed")
             }
             throw error
         }
 
         try await itemStorageClient.upsertManifest(manifest)
-        try await itemStorageClient.setUploadState(payload.itemID, "uploaded")
-        if let cleanupAfterUpload {
-            try? FileManager.default.removeItem(at: cleanupAfterUpload)
+        try await itemStorageClient.setUploadState(itemID, "uploaded")
+        if let superseded, superseded.recordName != manifest.recordName {
+            try? await cloudAssetClient.delete(superseded.recordName)
         }
         await cloudSyncClient.scheduleSendChanges()
         kAssetServiceLogger.info("Uploaded \(manifest.recordName, privacy: .public) (\(manifest.byteCount) bytes)")
@@ -157,6 +211,47 @@ public enum CloudAssetService {
         try await itemStorageClient.replaceWebsiteArchiveWithManifest(manifest)
         await cloudSyncClient.scheduleSendChanges()
         kAssetServiceLogger.info("Migrated website zip for \(itemID, privacy: .public) to asset store")
+    }
+
+    /// Moves one legacy capture out of the chunk sync table into the asset
+    /// store. Upload → verify → replace: the chunk rows are only deleted
+    /// (propagating to CloudKit) after the asset record is confirmed. The
+    /// capture manifest row survives with `chunkCount = 0`, which is how
+    /// other devices know the bytes now live in the asset zone.
+    public static func migrateCapture(itemID: UUID, repository: StowerRepository) async throws {
+        @Dependency(\.cloudAssetClient)
+        var cloudAssetClient
+        @Dependency(\.itemStorageClient)
+        var itemStorageClient
+        @Dependency(\.cloudSyncClient)
+        var cloudSyncClient
+        @Dependency(\.uuid)
+        var uuid
+
+        guard let synced = try await repository.loadArticleCapture(itemID),
+              synced.manifest.chunkCount > 0
+        else {
+            // Already migrated or never chunked. Not an error.
+            return
+        }
+
+        let packageData = try ArticleCapturePackage.reconstruct(synced)
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("StowerCaptureMigration-\(uuid().uuidString).zip")
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        try packageData.write(to: scratch, options: .atomic)
+
+        try await uploadFile(
+            at: scratch,
+            itemID: itemID,
+            kind: .capture,
+            originalFilename: ArticleCapturePackage.installedPackageFilename
+        )
+        // uploadFile verified the record exists; only now do the chunk rows
+        // go away.
+        try await itemStorageClient.markCaptureMigrated(itemID)
+        await cloudSyncClient.scheduleSendChanges()
+        kAssetServiceLogger.info("Migrated capture for \(itemID, privacy: .public) to asset store")
     }
 
     // MARK: Download / restore
@@ -292,8 +387,8 @@ public enum CloudAssetService {
     static let websiteMigrationEligibleAfter = Date(timeIntervalSince1970: 1_790_812_800)  // 2026-10-01T00:00:00Z
 
     /// Enqueues upload jobs for PDFs that have never been uploaded and, once
-    /// the gate date passes, migration jobs for legacy website zips.
-    /// Returns the number of jobs enqueued.
+    /// the gate date passes, migration jobs for legacy website zips and
+    /// chunked captures. Returns the number of jobs enqueued.
     @discardableResult
     public static func enqueueBackfillJobs(repository: StowerRepository) async throws -> Int {
         @Dependency(\.itemStorageClient)
@@ -312,6 +407,11 @@ public enum CloudAssetService {
             for itemID in try await itemStorageClient.websiteZipItemIDsWithoutManifest() {
                 let payload = try AssetJobPayload(itemID: itemID, kind: .websiteZip).encoded()
                 try await repository.enqueueIngestionJob(.migrateWebsiteAsset, payload)
+                enqueued += 1
+            }
+            for itemID in try await itemStorageClient.captureItemIDsWithChunks() {
+                let payload = try AssetJobPayload(itemID: itemID, kind: .capture).encoded()
+                try await repository.enqueueIngestionJob(.migrateCaptureAsset, payload)
                 enqueued += 1
             }
         }

--- a/StowerPackage/Sources/StowerFeatureV2/Support/FailedImport.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/FailedImport.swift
@@ -70,7 +70,7 @@ public struct FailedImport: Equatable, Identifiable, Sendable {
             // Payloads are JSON envelopes; the raw text is more confusing than
             // helpful, so name the kind instead.
             return job.kind == .markdown ? "Imported Markdown" : "Imported text"
-        case .uploadAsset, .migrateWebsiteAsset:
+        case .uploadAsset, .migrateWebsiteAsset, .migrateCaptureAsset:
             return "iCloud upload"
         case .downloadAsset:
             return "iCloud download"

--- a/StowerPackage/Sources/StowerFeatureV2/Support/StorageOffloadService.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/StorageOffloadService.swift
@@ -35,8 +35,15 @@ public enum StorageOffloadService {
             if info.assetManifests.contains(where: { $0.kind == .websiteZip }) {
                 return info.uploadState == "uploaded"
             }
-            // Interactive URL articles reinstall from local capture chunks.
-            return info.hasCaptureManifest
+            // Interactive URL articles restore from local chunk rows when the
+            // capture predates the asset store, or from the confirmed asset
+            // record after it.
+            guard info.hasCaptureManifest else { return false }
+            if info.hasCaptureChunks {
+                return true
+            }
+            return info.assetManifests.contains { $0.kind == .capture }
+                && info.uploadState == "uploaded"
         default:
             return false
         }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/CaptureAssetStoreTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/CaptureAssetStoreTests.swift
@@ -1,0 +1,279 @@
+import Dependencies
+import Foundation
+import SQLiteData
+@testable import StowerData
+@testable import StowerFeature
+import Testing
+
+/// Phase 3: web article capture packages live in the CloudKit asset store.
+/// Capture manifests with `chunkCount == 0` mark asset-store captures; chunk
+/// rows are the legacy representation and get migrated upload-first.
+@Suite
+struct CaptureAssetStoreTests {
+    struct Fixture {
+        var database: any DatabaseWriter
+        var repository: StowerRepository
+        var itemStorage: ItemStorageClient
+        var store: InMemoryCloudAssetStore
+        var uuid = UUIDGenerator { UUID() }
+    }
+
+    private func makeFixture() throws -> Fixture {
+        let database = try StowerDatabase.makeDatabase()
+        return Fixture(
+            database: database,
+            repository: .live(database: database, cloudSyncClient: .noop),
+            itemStorage: .live(database: database),
+            store: InMemoryCloudAssetStore()
+        )
+    }
+
+    private func withFixtureDependencies<T>(
+        _ fixture: Fixture,
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        try await withDependencies {
+            $0.cloudAssetClient = fixture.store.client
+            $0.itemStorageClient = fixture.itemStorage
+            $0.cloudSyncClient = .noop
+            $0.stowerRepository = fixture.repository
+            $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+            $0.uuid = fixture.uuid
+        } operation: {
+            try await operation()
+        }
+    }
+
+    /// Seeds a legacy chunked capture the way pre-Phase-3 builds wrote them.
+    private func seedChunkedCapture(
+        _ fixture: Fixture,
+        itemID: UUID,
+        package: Data
+    ) async throws -> WebCaptureManifest {
+        let chunkSize = 8
+        let chunks = stride(from: 0, to: package.count, by: chunkSize).enumerated().map { sequence, offset in
+            let data = package.subdata(in: offset..<min(offset + chunkSize, package.count))
+            return WebCaptureChunk(sequence: sequence, data: data, sha256: ArticleCapturePackage.sha256(data))
+        }
+        let manifest = WebCaptureManifest(
+            itemID: itemID,
+            captureID: UUID(),
+            sha256: ArticleCapturePackage.sha256(package),
+            byteCount: package.count,
+            chunkCount: chunks.count
+        )
+        try await fixture.repository.saveArticleCapture(manifest, chunks)
+        return manifest
+    }
+
+    @Test
+    func saveArticleCapture_acceptsChunklessAssetStoreManifest() async throws {
+        let fixture = try makeFixture()
+        let item = try await withFixtureDependencies(fixture) {
+            try await fixture.repository.createItemFromIngestion(.sharedText("Article"))
+        }
+        let package = Data("capture package bytes".utf8)
+        let manifest = WebCaptureManifest(
+            itemID: item.id,
+            captureID: UUID(),
+            sha256: ArticleCapturePackage.sha256(package),
+            byteCount: package.count,
+            chunkCount: 0
+        )
+
+        try await withFixtureDependencies(fixture) {
+            try await fixture.repository.saveArticleCapture(manifest, [])
+        }
+
+        let synced = try await fixture.repository.loadArticleCapture(item.id)
+        #expect(synced?.manifest.chunkCount == 0)
+        #expect(synced?.manifest.byteCount == package.count)
+        #expect(synced?.chunks.isEmpty == true)
+        // A mismatched chunk set is still rejected.
+        await #expect(throws: ArticleCaptureRepositoryError.incompleteChunkSet) {
+            let bad = WebCaptureManifest(
+                itemID: item.id,
+                captureID: UUID(),
+                sha256: "x",
+                byteCount: 10,
+                chunkCount: 2
+            )
+            try await fixture.repository.saveArticleCapture(bad, [])
+        }
+    }
+
+    @Test
+    func hydrate_downloadsChunklessCaptureFromAssetStore() async throws {
+        let fixture = try makeFixture()
+        let item = try await withFixtureDependencies(fixture) {
+            try await fixture.repository.createItemFromIngestion(.sharedText("Article"))
+        }
+        defer { AssetArchiver.deleteArchive(for: item.id) }
+
+        // Build a real capture package zip so install() accepts it.
+        let captureID = UUID()
+        let artifact = try ArticleCapturePackage.stage(
+            captureID: captureID,
+            sourceURL: URL(string: "https://example.com/story")!,
+            content: ArticleCapturePackage.Content(
+                readerArchive: Data("reader".utf8),
+                originalArchive: Data("original".utf8),
+                document: ReaderDocument(title: "Story", blocks: [.paragraph([.text("Body")])]),
+                plainText: "Body"
+            ),
+            completeness: .complete,
+            warnings: []
+        )
+        defer { try? FileManager.default.removeItem(at: artifact.stagedPackageURL.deletingLastPathComponent()) }
+        let package = try Data(contentsOf: artifact.stagedPackageURL)
+
+        // Chunkless manifest synced; bytes only in the asset store.
+        let manifest = WebCaptureManifest(
+            itemID: item.id,
+            captureID: captureID,
+            sha256: artifact.sha256,
+            byteCount: artifact.byteCount,
+            chunkCount: 0
+        )
+        try await withFixtureDependencies(fixture) {
+            try await fixture.repository.saveArticleCapture(manifest, [])
+        }
+        let recordName = AssetManifest.makeRecordName(
+            kind: .capture,
+            itemID: item.id,
+            sha256: artifact.sha256
+        )
+        try await fixture.store.put(recordName, data: package)
+
+        let result = try await withFixtureDependencies(fixture) {
+            try await ArticleSaveClient.live.hydrate(
+                item.id,
+                URL(string: "https://example.com/story")!
+            )
+        }
+
+        #expect(result.state == .ready)
+        #expect(ArticleCapturePackage.archiveURL(for: item.id, original: true) != nil)
+        #expect(ArticleCapturePackage.archiveURL(for: item.id, original: false) != nil)
+    }
+
+    @Test
+    func hydrate_throwsWhenAssetUnavailableInsteadOfRefetching() async throws {
+        let fixture = try makeFixture()
+        let item = try await withFixtureDependencies(fixture) {
+            try await fixture.repository.createItemFromIngestion(.sharedText("Article"))
+        }
+        let manifest = WebCaptureManifest(
+            itemID: item.id,
+            captureID: UUID(),
+            sha256: "deadbeef",
+            byteCount: 42,
+            chunkCount: 0
+        )
+        try await withFixtureDependencies(fixture) {
+            try await fixture.repository.saveArticleCapture(manifest, [])
+        }
+
+        // Empty asset store: hydration must fail loudly, not fall back to a
+        // live refetch that would replace the exact capture.
+        await #expect(throws: (any Error).self) {
+            try await withFixtureDependencies(fixture) {
+                _ = try await ArticleSaveClient.live.hydrate(
+                    item.id,
+                    URL(string: "https://example.com/story")!
+                )
+            }
+        }
+    }
+
+    @Test
+    func migrateCapture_uploadsThenDeletesChunks() async throws {
+        let fixture = try makeFixture()
+        let item = try await withFixtureDependencies(fixture) {
+            try await fixture.repository.createItemFromIngestion(.sharedText("Chunked"))
+        }
+        let package = Data("legacy chunked capture package".utf8)
+        let manifest = try await withFixtureDependencies(fixture) {
+            try await seedChunkedCapture(fixture, itemID: item.id, package: package)
+        }
+
+        try await withFixtureDependencies(fixture) {
+            try await CloudAssetService.migrateCapture(itemID: item.id, repository: fixture.repository)
+        }
+
+        // Asset holds the exact package, chunk rows are gone, and the synced
+        // capture manifest now says chunkCount == 0.
+        let recordName = AssetManifest.makeRecordName(
+            kind: .capture,
+            itemID: item.id,
+            sha256: manifest.sha256
+        )
+        let cloudCopy = try await fixture.store.get(recordName)
+        #expect(cloudCopy == package)
+        let synced = try await fixture.repository.loadArticleCapture(item.id)
+        #expect(synced?.manifest.chunkCount == 0)
+        #expect(synced?.chunks.isEmpty == true)
+        let chunkRows = try await fixture.database.read { db in
+            try SavedArticleCaptureChunkSyncTable.where { $0.itemID.eq(item.id) }.fetchCount(db)
+        }
+        #expect(chunkRows == 0)
+        let info = try await fixture.itemStorage.storageInfo(item.id)
+        #expect(info?.uploadState == "uploaded")
+        #expect(info?.assetManifests.contains { $0.kind == .capture } == true)
+    }
+
+    @Test
+    func migrateCapture_keepsChunksWhenUploadCannotBeVerified() async throws {
+        let fixture = try makeFixture()
+        await fixture.store.setFailures([.existsAlwaysFalse])
+        let item = try await withFixtureDependencies(fixture) {
+            try await fixture.repository.createItemFromIngestion(.sharedText("Chunked"))
+        }
+        let package = Data("only copy of this capture".utf8)
+        _ = try await withFixtureDependencies(fixture) {
+            try await seedChunkedCapture(fixture, itemID: item.id, package: package)
+        }
+
+        await #expect(throws: (any Error).self) {
+            try await withFixtureDependencies(fixture) {
+                try await CloudAssetService.migrateCapture(itemID: item.id, repository: fixture.repository)
+            }
+        }
+
+        // Upload-verify-then-delete invariant: chunks must survive.
+        let synced = try await fixture.repository.loadArticleCapture(item.id)
+        #expect(synced?.manifest.chunkCount ?? 0 > 0)
+        let reconstructed = try ArticleCapturePackage.reconstruct(try #require(synced))
+        #expect(reconstructed == package)
+    }
+
+    @Test
+    func uploadCapture_fallsBackToChunkRowsWhenPendingZipMissing() async throws {
+        let fixture = try makeFixture()
+        let item = try await withFixtureDependencies(fixture) {
+            try await fixture.repository.createItemFromIngestion(.sharedText("Chunked"))
+        }
+        let package = Data("chunked but never staged".utf8)
+        let manifest = try await withFixtureDependencies(fixture) {
+            try await seedChunkedCapture(fixture, itemID: item.id, package: package)
+        }
+
+        try await withFixtureDependencies(fixture) {
+            try await CloudAssetService.upload(
+                payload: AssetJobPayload(itemID: item.id, kind: .capture)
+            )
+        }
+
+        let recordName = AssetManifest.makeRecordName(
+            kind: .capture,
+            itemID: item.id,
+            sha256: manifest.sha256
+        )
+        let cloudCopy = try await fixture.store.get(recordName)
+        #expect(cloudCopy == package)
+        // Upload alone does NOT delete the chunk rows — that is the
+        // migration job's explicit responsibility.
+        let synced = try await fixture.repository.loadArticleCapture(item.id)
+        #expect(synced?.manifest.chunkCount ?? 0 > 0)
+    }
+}

--- a/StowerPackage/Tests/StowerFeatureV2Tests/CloudAssetServiceTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/CloudAssetServiceTests.swift
@@ -109,7 +109,7 @@ struct CloudAssetServiceTests {
             $0.cloudSyncClient = .noop
             $0.stowerRepository = fixture.repository
             $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
-            $0.uuid = .incrementing
+            $0.uuid = UUIDGenerator { UUID() }
         } operation: {
             try await operation()
         }

--- a/StowerPackage/Tests/StowerFeatureV2Tests/StorageOffloadServiceTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/StorageOffloadServiceTests.swift
@@ -16,6 +16,7 @@ struct StorageOffloadServiceTests {
         uploadState: String = "uploaded",
         offloadedAt: Date? = nil,
         hasCaptureManifest: Bool = false,
+        hasCaptureChunks: Bool = false,
         manifestKinds: [CloudAssetKind] = []
     ) -> ItemStorageInfo {
         let itemID = UUID()
@@ -27,6 +28,7 @@ struct StorageOffloadServiceTests {
             uploadState: uploadState,
             offloadedAt: offloadedAt,
             hasCaptureManifest: hasCaptureManifest,
+            hasCaptureChunks: hasCaptureChunks,
             assetManifests: manifestKinds.map {
                 AssetManifest(
                     id: UUID(),
@@ -54,8 +56,30 @@ struct StorageOffloadServiceTests {
         #expect(StorageOffloadService.canOffload(
             makeInfo(renderFormat: "webView", manifestKinds: [.websiteZip])
         ))
-        // Interactive captures restore from local chunks — no manifest needed.
+        // Legacy interactive captures restore from local chunk rows — no
+        // asset needed.
         #expect(StorageOffloadService.canOffload(
+            makeInfo(
+                renderFormat: "webView",
+                uploadState: "pending",
+                hasCaptureManifest: true,
+                hasCaptureChunks: true
+            )
+        ))
+        // Asset-store captures need the confirmed upload.
+        #expect(StorageOffloadService.canOffload(
+            makeInfo(renderFormat: "webView", hasCaptureManifest: true, manifestKinds: [.capture])
+        ))
+        #expect(!StorageOffloadService.canOffload(
+            makeInfo(
+                renderFormat: "webView",
+                uploadState: "pending",
+                hasCaptureManifest: true,
+                manifestKinds: [.capture]
+            )
+        ))
+        // A chunkless capture whose upload never happened is stuck local.
+        #expect(!StorageOffloadService.canOffload(
             makeInfo(renderFormat: "webView", uploadState: "pending", hasCaptureManifest: true)
         ))
         // Legacy website imports with neither are NOT offloadable yet.
@@ -93,7 +117,7 @@ struct StorageOffloadServiceTests {
         var store: InMemoryCloudAssetStore
         // Shared across every dependency scope in a test so UUIDs never
         // collide between successive fixture operations.
-        var uuid: UUIDGenerator = .incrementing
+        var uuid = UUIDGenerator { UUID() }
     }
 
     private func makeFixture() throws -> Fixture {


### PR DESCRIPTION
The capture chunk table was the last big weight in the local database:
SyncEngine replication mirrored every article's full capture.zip onto
every device as 20 MiB BLOB rows, so the database grew with the whole
library whether or not an article was ever opened on that device.

Capture packages now live in the asset zone alongside PDFs and website
zips. A capture manifest with chunkCount == 0 marks the new
representation — the manifest still syncs (it carries the sha256 and
byte count the receiving device verifies downloads against, and its
record name is derivable from those fields, so hydration works even
before the asset-manifest row arrives). New saves write the manifest
only, stage the package beside the installed archive, and enqueue an
upload job; the staged copy doubles as the upload source and is removed
once CloudKit confirms.

Hydration prefers legacy chunk rows when they exist and otherwise
downloads from the asset store, failing loudly rather than falling back
to a live refetch that would silently replace the exact capture with a
new one. The upload job can also reconstruct from chunk rows when the
staged copy is gone.

Existing chunked captures migrate with the same upload → verify →
replace sequence as website zips, behind the same gate date: the chunk
rows are only deleted (propagating to CloudKit) after the asset record
is confirmed, and the capture manifest survives with chunkCount = 0.
Re-captures best-effort delete the record they supersede so re-saved
articles don't accumulate stale packages in the zone.

Offload eligibility for interactive articles now distinguishes the two
representations: chunk-backed captures restore offline and stay
offloadable as before, while asset-store captures require the confirmed
upload.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>