### PR TITLE
Retry staged asset uploads whose first attempt failed

### DIFF
--- a/StowerPackage/Sources/StowerFeatureV2/Support/CloudAssetService.swift
+++ b/StowerPackage/Sources/StowerFeatureV2/Support/CloudAssetService.swift
@@ -403,6 +403,34 @@ public enum CloudAssetService {
             try await repository.enqueueIngestionJob(.uploadAsset, payload)
             enqueued += 1
         }
+        // Staged payloads still waiting on disk are uploads whose earlier
+        // attempts failed — e.g. the CloudKit schema wasn't deployed to the
+        // container yet. Failed jobs never suppress a re-enqueue, so retrying
+        // every startup is safe and cheap (upload jobs are deduplicated while
+        // queued or running).
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let archiveRoot = documents.appendingPathComponent("StowerArchive", isDirectory: true)
+        let itemDirs = (try? FileManager.default.contentsOfDirectory(
+            at: archiveRoot,
+            includingPropertiesForKeys: nil
+        )) ?? []
+        for entry in itemDirs {
+            guard let itemID = UUID(uuidString: entry.lastPathComponent) else { continue }
+            if FileManager.default.fileExists(atPath: pendingUploadCaptureURL(for: itemID).path) {
+                let payload = try AssetJobPayload(
+                    itemID: itemID,
+                    kind: .capture,
+                    originalFilename: ArticleCapturePackage.installedPackageFilename
+                ).encoded()
+                try await repository.enqueueIngestionJob(.uploadAsset, payload)
+                enqueued += 1
+            }
+            if FileManager.default.fileExists(atPath: pendingUploadZipURL(for: itemID).path) {
+                let payload = try AssetJobPayload(itemID: itemID, kind: .websiteZip).encoded()
+                try await repository.enqueueIngestionJob(.uploadAsset, payload)
+                enqueued += 1
+            }
+        }
         if now >= websiteMigrationEligibleAfter {
             for itemID in try await itemStorageClient.websiteZipItemIDsWithoutManifest() {
                 let payload = try AssetJobPayload(itemID: itemID, kind: .websiteZip).encoded()

--- a/StowerPackage/Tests/StowerFeatureV2Tests/CaptureAssetStoreTests.swift
+++ b/StowerPackage/Tests/StowerFeatureV2Tests/CaptureAssetStoreTests.swift
@@ -248,6 +248,50 @@ struct CaptureAssetStoreTests {
     }
 
     @Test
+    func backfill_retriesUploadsWithStagedPayloadsOnDisk() async throws {
+        let fixture = try makeFixture()
+        let (captureItem, websiteItem) = try await withFixtureDependencies(fixture) {
+            (
+                try await fixture.repository.createItemFromIngestion(.sharedText("Capture")),
+                try await fixture.repository.createItemFromIngestion(.sharedText("Website"))
+            )
+        }
+        defer {
+            AssetArchiver.deleteArchive(for: captureItem.id)
+            AssetArchiver.deleteArchive(for: websiteItem.id)
+        }
+        // A first upload attempt failed (e.g. CloudKit schema not deployed),
+        // leaving the staged payloads on disk.
+        let pendingCapture = CloudAssetService.pendingUploadCaptureURL(for: captureItem.id)
+        try FileManager.default.createDirectory(
+            at: pendingCapture.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("capture".utf8).write(to: pendingCapture)
+        let pendingZip = CloudAssetService.pendingUploadZipURL(for: websiteItem.id)
+        try FileManager.default.createDirectory(
+            at: pendingZip.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("zip".utf8).write(to: pendingZip)
+
+        let enqueued = try await withFixtureDependencies(fixture) {
+            try await CloudAssetService.enqueueBackfillJobs(repository: fixture.repository)
+        }
+
+        #expect(enqueued >= 2)
+        let uploadJobs = try await fixture.database.read { db in
+            try IngestionJobLocalTable
+                .where { $0.kind.eq(IngestionJob.Kind.uploadAsset.rawValue) }
+                .select(\.payload)
+                .fetchAll(db)
+        }
+        let payloads = try uploadJobs.map { try AssetJobPayload.decoded(from: $0) }
+        #expect(payloads.contains { $0.itemID == captureItem.id && $0.kind == .capture })
+        #expect(payloads.contains { $0.itemID == websiteItem.id && $0.kind == .websiteZip })
+    }
+
+    @Test
     func uploadCapture_fallsBackToChunkRowsWhenPendingZipMissing() async throws {
         let fixture = try makeFixture()
         let item = try await withFixtureDependencies(fixture) {


### PR DESCRIPTION
A capture or website upload that fails permanently — seen in the wild when the CloudKit container's production schema didn't have the `StowerAsset` record type deployed yet — left its staged zip on disk with nothing ever re-enqueuing the job. PDFs already recovered through the manifest-less backfill query; captures and website zips did not.

The startup backfill now scans the archive directories for staged pending-upload payloads and re-enqueues an upload job for each. Failed jobs never suppress a re-enqueue and queued upload jobs are deduplicated, so the retry is idempotent and free when there is nothing to do.

Follow-up to #45. Note the failed upload itself also needs the one-time CloudKit schema deployment (run a Debug build to create the types in Development, then Deploy Schema Changes to Production in the CloudKit Console) — after that, this change makes stranded uploads recover automatically on next launch.